### PR TITLE
postgres_queries2: Simple fix for database name containing underscore(s).

### DIFF
--- a/plugins/other/postgres_queries2_
+++ b/plugins/other/postgres_queries2_
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-db="${0/*_/}"
+db=$(basename $0 | sed 's/^postgres_queries2_//g')
 if [ "$db" == "" ];then
 	echo	"error/no db" >&2
 	exit 1


### PR DESCRIPTION
The postgres_queries2_ plugin doesn't work correctly with database names that contain underscores, this oneliner fixes it.
