### PR TITLE
support for 'adaX' and 'daX' devices

### DIFF
--- a/plugins/other/hddtemp_smartctl
+++ b/plugins/other/hddtemp_smartctl
@@ -139,7 +139,7 @@ if ($^O eq 'linux') {
   # without probing them.
 } elsif ($^O eq 'freebsd') {
   opendir(DEV, '/dev');
-  @drives = grep /^ad[0-9]+$/, readdir DEV;
+  @drives = grep /^(a?da|ad)[0-9]+$/, readdir DEV;
   closedir(DEV);
 } elsif ($^O eq 'solaris') {
   @drives = map { s@.*/@@ ; $_ } glob '/dev/rdsk/c*t*d*s2';


### PR DESCRIPTION
Hi,

When loading the ahci module or having some certain sas-controllers, the device-names aren't adX any longer.
Maybe you want to put this patch upstream.

Yours,
Manuel
