### PR TITLE
Fixed a typo in tor-connections

### DIFF
--- a/plugins/other/tor-connections
+++ b/plugins/other/tor-connections
@@ -41,7 +41,7 @@ if ($cmd == "config") {
         print "failed.max 50000\n";
         print "failed.min 0\n";
 
-        print "close.label closed\n";
+        print "closed.label closed\n";
         print "closed.type GAUGE\n";
         print "closed.max 50000\n";
         print "closed.min 0\n";


### PR DESCRIPTION
A typo in tor-connections' config was preventing Munin from generating the graphs.
