### PR TITLE
Memcached_multi_ update

### DIFF
--- a/plugins/memcached/memcached_multi_
+++ b/plugins/memcached/memcached_multi_
@@ -810,6 +810,9 @@ sub fetch_stats {
     while (my $line = <$s>) {
         if ($line =~ /STAT\s(.+?)\s(.*)/) {
             my ($skey,$svalue) = ($1,$2);
+            if ($skey eq 'evictions') {
+                $skey = 'evictions_active';
+            }
             $stats{$skey} = $svalue;
         }
         last if $line =~ /^END/;


### PR DESCRIPTION
Fixing a collision on a stats key for evictions. I've double checked the stats and stats settings commands in v1.4.5 and not found any other duplicate keys that could collide.

This is a minor bug, but it did mask the true value. I'm not quite sure when this got into Memcached I'll have to speak with the maintainer, I may suggest he doesn't dupe stats key names moving forward, but it will only be a suggestion. ;)
