### PR TITLE
measure IMAP bandwidth based on mbsync/isync file transfers

### DIFF
--- a/plugins/mail/imap_bandwidth
+++ b/plugins/mail/imap_bandwidth
@@ -1,4 +1,11 @@
 #!/bin/sh
+#
+# Revision 1.1  2012/02/26 03:43:27
+# Improved labels
+#
+# Revision 1.0  2012/02/25 21:31:16
+# Initial release
+#
 
 : <<=cut
 =head1 NAME
@@ -107,13 +114,14 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 if [ "$1" = "config" ]; then
-	echo 'graph_title IMAP speed'
-	echo 'graph_vlabel upload/download speed [bit/s]'
+	echo 'graph_title IMAP bandwidth'
+	echo 'graph_vlabel to (+) / from (-) server [bit/s]'
 	echo 'graph_category network'
 	for item in $SERVERS; do
 		key="$(echo "$item" | cut -f 1 -d =)"
 		clean_name="$(clean_fieldname "$key")"
 		echo "download_${clean_name}.graph no"
+		echo "download_${clean_name}.label download"
 		echo "upload_${clean_name}.label $key"
 		echo "upload_${clean_name}.negative download_${clean_name}"
 	 done


### PR DESCRIPTION
The plugin "imap_bandwidth" runs the following steps in order to measure the bandwidth of one or more IMAP servers:
- generate a file with random content of configured size
- upload the file to the remote IMAP server via mbsync
- download the file from the remote IMAP server via mbsync
- upload and download bandwidth is calculated based on the file size and the duration of the upload/download operations
