### PR TITLE
(Generic) Game query module

### DIFF
--- a/plugins/game/game
+++ b/plugins/game/game
@@ -1,0 +1,216 @@
+#!/usr/bin/php
+<?php
+
+/*
+ * README
+ * This plugin makes use of the GameQ library to be able to query many different
+ * types of game servers and display the results in munin. You can see a list of
+ * supported games at http://gameq.sourceforge.net/#games
+ *
+ * This plugin has 2 environment variables:
+ * game_config_file - Defaults to /etc/munin/munin-game.ini. The location of the config file
+ * game_state_file - Defaults to /var/lib/munin/plugin-state/game. The location of the munin state directory
+ *
+ * (Probably) FAQ
+ * Q: Why PHP?
+ * A: The GameQ library is written in PHP, so it was either that or rewrite the entire library.
+ *
+ * Q: Why have you used a config file instead of environment variables?
+ * A: Way too much to fit data inside an environment variable unfortunately. Imagine
+ *    trying to fit information about 50 servers all inside one variable.
+ *
+ * Q: I want to ask you a question!
+ * A: I'm on most IRC networks under the nick Azelphur, or email me. support@azelphur.com
+ *
+ * Q: It's not working!
+ * A: Try running ./game autoconf, it'll probably tell you what's up.
+ */
+
+// Check environment variables
+$var = getenv('game_config_file');
+$config = ($var) ? $var : "/etc/munin/munin-game.ini";
+$var = getenv('game_state_file');
+$state = ($var) ? $var : "/var/lib/munin/plugin-state/game";
+
+function p($str) {
+    // Quick function to print a string with an EOL on the end
+    echo $str . PHP_EOL;
+}
+
+function printMultigraph($ini_array, $machine_name, $title, $info, $max) {
+    // Print out a standard graph config.
+    p("multigraph $machine_name");
+    p("graph_title $title");
+    p("graph_vlabel players");
+    p("graph_category gameserver");
+    p("graph_info $info");
+    p("graph_printf %6.0lf");
+    
+    if (isset($ini_array['settings'][$machine_name . '_colour']))
+        p("players.colour " . $ini_array['settings'][$machine_name . '_colour']);
+
+    if (isset($ini_array['settings'][$machine_name . '_draw']))
+        p("players.draw " . $ini_array['settings'][$machine_name . '_draw']);
+
+    p("players.label players");
+    p("players.info Number of players");
+    p("players.min 0");
+    p("players.max $max");
+}
+
+function printValue($machine_name, $value) {
+    // Print a value
+    p("multigraph $machine_name");
+    p("players.value " . $value);
+}
+
+function queryServers($ini_array) {
+    // Query all game servers and return the results
+
+    require "gameq/GameQ.php";
+
+    // Populate the $servers array from the ini file, ready to pass to GameQ
+    $servers = array();
+    foreach ($ini_array as $section => $value) {
+        if ($section != 'settings')
+            $servers[$section] = array($value['game'], $value['address'], $value['port']);
+    }
+
+    // Create a new GameQ object and pass it a list of servers
+    $gq = new GameQ();
+    $gq->addServers($servers);
+
+    // Set timeout from the config file
+    $gq->setOption('timeout', $ini_array['settings']['timeout']);
+    $gq->setOption('sock_count', $ini_array['settings']['sock_count']);
+    $gq->setOption('sock_start', $ini_array['settings']['sock_start']);
+
+    // This filter makes sure a subset of data is always available, next to the normal data
+    $gq->setFilter('normalise');
+
+    // Send request(s)
+    $results = $gq->requestData();
+
+    return $results;
+}
+
+// Parse command line arguments if required.
+if (isset($_SERVER['argv'][1])) {
+    if ($_SERVER['argv'][1] == 'config') {
+        // Load our config.ini
+        $ini_array = parse_ini_file($config, true);
+
+        // Load games.ini so we can show pretty game names
+        $games = parse_ini_file('gameq/GameQ/games.ini', true);
+
+        // Query the game servers
+        $results = queryServers($ini_array);
+        // Cache the query in the state file
+        $fp = fopen($state, 'w+') or die("I could not open state file."); 
+        fwrite($fp, serialize($results)); 
+        fclose($fp);
+
+
+        // Loop through each server, printing graphs.
+        foreach ($results as $name => $server) {
+            // If sub graphs and the game total graphs are enabled, make this be a sub-graph.
+            if ($ini_array['settings']['show_game_total'] && $ini_array['settings']['enable_sub_graphs'])
+                $machine_name = "gameserver_" . $ini_array[$name]['game'] . ".$name";
+            else
+                $machine_name = "gameserver_" . $ini_array[$name]['game'] . "_$name";
+            $title = $ini_array[$name]['name'] . " players";
+            $info = "The number of players connected to the " . $games[$ini_array[$name]['game']]['name'] . " server";
+            printMultigraph($ini_array, $machine_name, $title, $info, $server['gq_maxplayers']);
+        }
+
+        // Game total graphs.
+        if ($ini_array['settings']['show_game_total']) {
+            $game_total_max = array();
+
+            // Count players connected to each game
+            foreach ($results as $name => $server) {
+                if (!isset($game_total_max[$ini_array[$name]['game']]))
+                    $game_total_max[$ini_array[$name]['game']] = $server['gq_maxplayers'];
+                else
+                    $game_total_max[$ini_array[$name]['game']] += $server['gq_maxplayers'];
+            }
+
+            // Print all the game total graphs.
+            foreach ($game_total_max as $game => $total)
+            {
+                $machine_name = "gameserver_" . $game;
+                $title = "Total " . $games[$game]['name'] . " players";
+                $info = "Total players connected to all " . $games[$game]['name'] . " servers";
+                printMultigraph($ini_array, $machine_name, $title, $info, $total);
+            }
+        }
+
+        // Global total graph
+        if ($ini_array['settings']['show_global_total']) {
+            $total_max = 0;
+            // Add up all the players connected to all the servers
+            foreach ($results as $name => $server) {
+                $total_max += $server['gq_maxplayers'];
+            }
+
+            printMultigraph($ini_array, "gameserver", "Total Players", "Total players connected to all servers", $total_max);
+        }
+    }
+    if ($_SERVER['argv'][1] == 'autoconf') {
+        if (!@include("gameq/GameQ.php"))
+            p("no (GameQ Library not found)");
+        elseif (!file_exists($config))
+            p("no ($config not found)");
+        else
+            p("yes");
+    }
+    die();
+}
+
+// No command line arguments, print values.
+
+// Load our config.ini
+$ini_array = parse_ini_file($config, true);
+
+// Load games.ini so we can show pretty game names
+$games = parse_ini_file('gameq/GameQ/games.ini', true);
+
+$results = unserialize(file_get_contents($state)); 
+
+// Print individual game values
+foreach ($results as $name => $server){
+    if ($ini_array['settings']['show_game_total'] && $ini_array['settings']['enable_sub_graphs'])
+        $machine_name = "gameserver_" . $ini_array[$name]['game'] . ".$name";
+    else
+        $machine_name = "gameserver_" . $ini_array[$name]['game'] . "_$name";
+    printValue($machine_name, $server['gq_numplayers']);
+}
+
+// Print game total values
+if ($ini_array['settings']['show_game_total']) {
+    $game_total = array();
+    foreach ($results as $name => $server) {
+        // Add up counts for the total graph
+        if (!isset($game_total_max[$ini_array[$name]['game']]))
+            $game_total[$ini_array[$name]['game']] = $server['gq_numplayers'];
+        else
+            $game_total[$ini_array[$name]['game']] += $server['gq_numplayers'];
+    }
+    foreach ($game_total as $game => $total)
+    {
+        $machine_name = "gameserver_" . $game;
+        printValue($machine_name, $total);
+    }
+}
+
+// Are global totals enabled?
+if ($ini_array['settings']['show_global_total']) {
+    $total = 0;
+    foreach ($results as $name => $server) {
+        $total += $server['gq_numplayers'];
+    }
+    printValue("gameserver", $total);
+}
+
+
+?>

--- a/plugins/game/munin-game.ini
+++ b/plugins/game/munin-game.ini
@@ -1,0 +1,28 @@
+[settings]
+timeout = 1000                    ; Timeout in ms when attempting to connect to servers
+sock_count = 64                   ; Maximum number of sockets that are used simultaneously
+sock_start = 0                    ; Start of port range to use
+
+; Note that changing any of the below options may change your graph names, which may reset your statistics.
+show_global_total = True          ; Show a graph that shows the total players connected to all servers?
+show_game_total = True            ; Show a graph that shows the total players connected to all servers of the same type?
+enable_sub_graphs = True          ; Make each game be a sub-graph of it's game total graph.
+
+; The following variables allow you to override the style of graphs.
+; The server graphs are named gameserver_gamename.machinename, for example gameserver_tf2.myamazingserver
+; The game total graphs are named gameserver_gamename, for example gameserver_tf2
+; The global total graph is named gameserver.
+;graph_name_colour = 000000        ; Override the color of graph_name, for example gameserver_et.myetserver_color
+;graph_name_draw = LINE1          ; Override the draw method of graph_name, for example gameserver_
+
+[mytf2server]                     ; Machine name of the server
+name = "My TF2 Server"            ; Display name of the server
+game = tf2                        ; Game type, see GameQ/games.ini inside the GameQ library for a list of valid options.
+address = 1.2.3.4                 ; Server IP or hostname.
+port = 27015                      ; Server port
+
+[myetserver]
+name = "My Enemy Territory Server"
+game = et
+address = 1.2.3.4
+port = 27960


### PR DESCRIPTION
Hi, I've written a generic game query module powered by GameQ. It will query many different types of game and voice servers (Full list at http://gameq.sourceforge.net/#games) and show graphs for how many people are connected. Here's a screenshot: http://dl.dropbox.com/u/3832397/Static/2012/February/munin-game.png

I had to use PHP, because the GameQ library is written in PHP. I would have chosen a more sensible language, however to my knowledge there is nothing else like GameQ.

I also had to use a config file instead of the environment variable system, as this module will work for any amount of game servers, a space separated variable would be very tedious to administrate when you have a lot of servers. That said I do have environment variables for the location of the config file, and the location of the state file.

I've only been using Munin for a few days so there may be one or two things wrong with it, let me know and I'll do my best to get it fixed! :)
