### PR TITLE
Fixing a visibility issue with the utilization function in zfs_stats_.

### DIFF
--- a/plugins/zfs/zfs_stats_
+++ b/plugins/zfs/zfs_stats_
@@ -213,25 +213,25 @@ utilization() {
 
                 echo 'max_size.label Maximum Size'
 		echo 'max_size.draw AREA'
-		echo 'target_size.label Target Size'
-		echo 'target_size.draw AREA'
                 echo 'size.label Size'
                 echo 'size.draw AREA'
-		echo 'recently_size.label Recently Used Cache Size'
-		echo 'recently_size.draw AREA'
-		echo 'frequently_size.label Frequently Used Cache Size'
-		echo 'frequently_size.draw AREA'
                 echo 'min_size.label Minimum Size'
-		echo 'min_size.draw AREA'
+                echo 'min_size.draw AREA'
+                echo 'target_size.label Target Size'
+                echo 'target_size.draw LINE1'
+		echo 'recently_size.label Recently Used Cache Size'
+		echo 'recently_size.draw LINE1'
+		echo 'frequently_size.label Frequently Used Cache Size'
+		echo 'frequently_size.draw LINE1'
 
 		exit 0
 	else
                 echo 'max_size.value ' $MAX_SIZE
-		echo 'target_size.value ' $TARGET_SIZE
 		echo 'size.value ' $SIZE
+                echo 'min_size.value ' $MIN_SIZE
+                echo 'target_size.value ' $TARGET_SIZE
 		echo 'recently_size.value ' $MRU_SIZE
 		echo 'frequently_size.value ' $MFU_SIZE
-		echo 'min_size.value ' $MIN_SIZE
 	fi
 }
 


### PR DESCRIPTION
'Frequently Used Cache Size' got obscured on low IO systems.
