### PR TITLE
Mail/Dovecot: Debain Stable Squeeze compatibility

### DIFF
--- a/plugins/mail/dovecot
+++ b/plugins/mail/dovecot
@@ -68,7 +68,7 @@ fi
 # Total Logins
 ######################
 echo -en "login_total.value "
-NEW_TOTAL=$(egrep 'dovecot.*Login' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
+NEW_TOTAL=$(egrep '[dovecot]?.*Login' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
 OLD_TOTAL=$(grep TOTAL $STAT_FILE | cut -f2 -d '=')
 TOTAL=$($EXPR_BIN $NEW_TOTAL - $OLD_TOTAL)
 if [ $TOTAL -gt 0 ]; then
@@ -80,8 +80,8 @@ echo -n
 ######################
 # Connected Users
 ######################
-DISCONNECTS=$(egrep 'dovecot.*Disconnected' $LOGFILE | sort | wc -l)
-CONNECTS=$(egrep 'dovecot.*Login' $LOGFILE | sort | wc -l)
+DISCONNECTS=$(egrep '[dovecot]?.*Disconnected' $LOGFILE | sort | wc -l)
+CONNECTS=$(egrep '[dovecot]?.*Login' $LOGFILE | sort | wc -l)
 DISCON=$($EXPR_BIN $CONNECTS - $DISCONNECTS)
 if [ $DISCON -lt 0 ]; then
 	DISCON=0
@@ -93,7 +93,7 @@ echo -n
 # TLS Logins
 ######################
 echo -en "login_tls.value "
-NEW_TLS=$(egrep 'dovecot.*Login.*TLS' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
+NEW_TLS=$(egrep '[dovecot]?.*Login.*TLS' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
 OLD_TLS=$(grep TLS $STAT_FILE | cut -f2 -d '=')
 TLS=$($EXPR_BIN $NEW_TLS - $OLD_TLS)
 if [ $TLS -gt 0 ]; then
@@ -106,7 +106,7 @@ echo -n
 # SSL Logins
 ######################
 echo -en "login_ssl.value "
-NEW_SSL=$(egrep 'dovecot.*Login.*SSL' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
+NEW_SSL=$(egrep '[dovecot]?.*Login.*SSL' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
 OLD_SSL=$(grep SSL $STAT_FILE | cut -f2 -d '=')
 SSL=$($EXPR_BIN $NEW_SSL - $OLD_SSL)
 if [ $SSL -gt 0 ]; then
@@ -119,7 +119,7 @@ echo -n
 # IMAP Logins
 ######################
 echo -en "login_imap.value "
-NEW_IMAP=$(egrep 'dovecot.*imap.*Login' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
+NEW_IMAP=$(egrep '[dovecot]?.*imap.*Login' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
 OLD_IMAP=$(grep IMAP $STAT_FILE | cut -f2 -d '=')
 IMAP=$($EXPR_BIN $NEW_IMAP - $OLD_IMAP)
 if [ $IMAP -gt 0 ]; then
@@ -132,7 +132,7 @@ echo -n
 # POP3 Logins
 ######################
 echo -en "login_pop3.value "
-NEW_POP3=$(egrep 'dovecot.*pop3.*Login' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
+NEW_POP3=$(egrep '[dovecot]?.*pop3.*Login' $LOGFILE | grep "`date '+%b %e'`" | sort | wc -l)
 OLD_POP3=$(grep POP3 $STAT_FILE | cut -f2 -d '=')
 POP3=$($EXPR_BIN $NEW_POP3 - $OLD_POP3)
 if [ $POP3 -gt 0 ]; then


### PR DESCRIPTION
Hi all,
I've seen that with dovecot by Debian Stable repos the new dovecot plugin is broken; in fact the log format, particularly the prepended log tag, does not correspond, so that the updated plugin lost backwards compatibility. I think that a stable OS needs backwards compatibility, so I've just modified the egrep's regex to match strings in both log format.

If you'd like to take a look over it...

Unfortunately I've done some mistakes by pushing wrong commits, so I'm here with 5 commits instead of ... 1! OMG what a mess! Anyway, the idea still remains. :)

Thanks for the attention.

Bye,
Alessandro
