### PR TITLE
Proper shebang for flexibility

### DIFF
--- a/plugins/weather/weather_press_
+++ b/plugins/weather/weather_press_
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 """
 munin US NOAA weather plugin (http://weather.noaa.gov)
 

--- a/plugins/weather/weather_temp_
+++ b/plugins/weather/weather_temp_
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 """
 munin US NOAA weather plugin (http://weather.noaa.gov)
 


### PR DESCRIPTION
I've replaced '/usr/local/bin/python' with '/usr/bin/env python' for automatic interpreter search.
