### PR TITLE
import the classic mtr plugin and update it to keep working with newer munin

### DIFF
--- a/plugins/network/mtr100_
+++ b/plugins/network/mtr100_
@@ -7,6 +7,9 @@
 # Author: tobias.geiger@vido.info
 # Please email me bugs/suggestions 
 #
+# Version: 1.1
+# Author: charlie@evilforbeginners.com
+# changed: munin eats 1 character ds-names. prefix with "hop_"
 #
 #
 # HINT: Needs a bigger TIMEOUT-Value than the default (10) in /etc/munin/plugin-conf.d/munin-node ,
@@ -62,7 +65,7 @@ total+=$6
 END {
 	for (x=1; x<=count; x++) { 
 		value=(val[x]/total)*100
-		if ( C != "config" ) { printf "%s.value %2.2f\n",lab[x],value }
+		if ( C != "config" ) { printf "%s.value %2.2f\n","hop_" lab[x],value }
 		if ( C == "config" ) { print "hop_" lab[x] ".label " name[x] }
 		if ( C == "config" ) { if ( x == 1 ) { print "hop_" lab[x]".draw AREA" } else { print "hop_" lab[x]".draw STACK" } }
         }


### PR DESCRIPTION
Plugin.pm now eats the first character of a ds-name and turns it into _

fix this by adding a hop_ prefix to each ds-name.
