### PR TITLE
php5-fpm typo fix

### DIFF
--- a/plugins/nginx/php5-fpm_status
+++ b/plugins/nginx/php5-fpm_status
@@ -41,8 +41,8 @@ if [ "$1" = "config" ]; then
   exit 0
 else
   awk '
-		/^idle/	{print "active.value " $3}
-		/^active/{print "idle.value "   $3}
+		/^idle/	{print "idle.value " $3}
+		/^active/{print "active.value "   $3}
 		/^total/ {print "total.value "  $3}
 	' < $statusfile
 fi


### PR DESCRIPTION
php5-fpm plugin has small typo that produces big error in values. This commit fixes it
