### PR TITLE
simple plugins to monitor a hosts ARP cache

### DIFF
--- a/plugins/arp/arp
+++ b/plugins/arp/arp
@@ -38,6 +38,5 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo -n "entries.value "
-arp -an | grep -v "incomplete" | awk '{ print $4; }' | sort -u | wc -l 
+arp -an | awk 'BEGIN { regex="<incomplete>";} { if (!match($4,regex)) { a[$4] }} END{for(i in a){n++};print "entries.value " n}'
 

--- a/plugins/arp/arp_
+++ b/plugins/arp/arp_
@@ -51,6 +51,5 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo -n "entries.value "
-arp -an -i $INTERFACE | grep -v "incomplete" | awk '{ print $4; }' | sort -u | wc -l 
+arp -an -i $INTERFACE | awk 'BEGIN { regex="<incomplete>";} { if (!match($4,regex)) { a[$4] }} END{for(i in a){n++};print "entries.value " n}'
 


### PR DESCRIPTION
Contained are two simple plugins to monitor a hosts ARP cache

arp: monitor the complete ARP cache for all interfaces. Usefull for hosts with only a single interface

arp_: monitor the ARP cache for a specified interface, usefull for routers and multi-homed hosts.
