### PR TITLE
Changed interpreter to bash, cause on some systems sh does not properly ...

### DIFF
--- a/plugins/ftp/pureftpd_count
+++ b/plugins/ftp/pureftpd_count
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #
 # Script to show pureftp counts.


### PR DESCRIPTION
...parses echo with -en parameters, thus producing garbage lines.
