### PR TITLE
Correct plugins/samba/samba_locked on Debian Squeeze

### DIFF
--- a/plugins/samba/samba_locked
+++ b/plugins/samba/samba_locked
@@ -34,7 +34,4 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo -n "samba_locked.value "
-smbstatus -L 2> /dev/null | grep -c DENY_
-
-
+echo "samba_locked.value `smbstatus -L 2> /dev/null | grep -c DENY_`"


### PR DESCRIPTION
Two-lines syntax for last "echo" not working on Debian Squeeze
Error : 2012/05/09-14:55:05 [15253] Service 'samba_locked' exited with status 1/0.
