### PR TITLE
If no friendly name, will automatically use IP/FQDN

### DIFF
--- a/plugins/network/multiping
+++ b/plugins/network/multiping
@@ -26,7 +26,8 @@
 # 	ping_args2     - Arguments after the host name (required for Solaris)
 # 	ping           - Ping program to use
 # 	hosts          - List of comma-separated hosts to ping (IP address or FQDN)
-# 	names          - Friendly display name of each host given in the "hosts" parameter (comma-separated list)
+# 	names          - Friendly display name of each host given in the "hosts" parameter (comma-separated list).
+# 	                 If not set, "hosts" elements will be used
 #
 # Arguments for Solaris:
 #      ping_args      -s
@@ -51,7 +52,7 @@
 use strict;
 
 my @hosts = exists $ENV{hosts} ? split(/,/, $ENV{hosts}) : 'www.google.com.au';
-my @names = exists $ENV{names} ? split(/,/, $ENV{names}) : 'Google Australia';
+my @names = exists $ENV{names} ? split(/,/, $ENV{names}) : @hosts;
 my $ping_cmd = exists $ENV{ping} ? $ENV{ping} : 'ping';
 my $ping_args = exists $ENV{ping_args} ? $ENV{ping_args} : '-c 2 -w 1';
 my $ping_args2 = exists $ENV{ping_args2} ? $ENV{ping_args2} : '';


### PR DESCRIPTION
Minor improvement to ease the configuration by removing the need to specify friendly display names for each hosts: if such names aren't set, IPs/FQDNs will be used instead.
