### PR TITLE
Adding "netatalk" plugin: monitors number of files held open by the Netatalk/AFP clients

### DIFF
--- a/plugins/network/netatalk
+++ b/plugins/network/netatalk
@@ -69,7 +69,7 @@ if [ "$1" = "config" ]; then
 	echo 'graph_title Netatalk status'
 	echo 'graph_args --logarithmic --lower-limit 0.1'
 	echo 'graph_vlabel Number'
-	echo 'graph_category netatalk'
+	echo 'graph_category network'
 	echo 'proc.label Running processes'
 	echo 'proc.info Number of running afpd processes'
 	echo 'proc.min 0'


### PR DESCRIPTION
Simple plugin that gives the same informations about Netatalk/AFP sharing service than "samba" plugin is giving for samba shares:
- Running processes
- Connected users
- Locked files
- Open shares
