### PR TITLE
Bugfix: missing perl argument in memory_by_proccess

### DIFF
--- a/plugins/system/memory_by_process
+++ b/plugins/system/memory_by_process
@@ -24,7 +24,7 @@ if [ "$1" = "config" ]; then
 	echo 'graph_category system'
 	echo "graph_info Shows contribution of each process to VM size"
 
-	ps auxww | perl '
+	ps auxww | perl -e '
 		$junk = <>;
 		while (<>)
 		{


### PR DESCRIPTION
This was keeping this pluggin from configuring correctly on my arch box
