### PR TITLE
MongoDB Replication Lag

### DIFF
--- a/plugins/mongodb/mongo_lag
+++ b/plugins/mongodb/mongo_lag
@@ -41,17 +41,8 @@ def run():
             primary_optime = members[member]['optimeDate']
 
     for member in members:
-        members[member]['lag'] = (primary_optime - members[member]['optimeDate']).seconds
-
-    print "multigraph mongodb_replication_lag"
-    for member in members:
-        print "{}_lag.value {}".format(member, members[member]['lag'])
-    print
-
-    for member in members:
-        print "multigraph mongodb_replication_lag.{}".format(member)
-        print "lag.value {}".format(members[member]['lag'])
-        print
+        lag = (primary_optime - members[member]['optimeDate']).seconds
+        print "{}.value {}".format(member, lag)
 
 def config():
     print """graph_title MongoDB replication lag
@@ -59,14 +50,9 @@ graph_args --base 1000
 graph_vlabel Replication lag (seconds)
 graph_category MongoDB
 """
-
+   
     for member in _get_members():
-        print "{0}_lag.label {0}".format(member)
-        print "{}_lag.type GAUGE".format(member)
-        print "{}_lag.info Replication lag behind master".format(member)
-        print "{}_lag.min 0".format(member)
-        print "{}_lag.draw LINE1".format(member)
-        print 
+        print "{0}.label {0}".format(member)
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "config":


### PR DESCRIPTION
Connects to a single mongo instance and retrieve replication lag for all connected members.
