### PR TITLE
Make the php_apc.php script's URL configurable

### DIFF
--- a/plugins/php/php_apc_
+++ b/plugins/php/php_apc_
@@ -10,12 +10,14 @@
 #################################################################
 #
 # Configuration section
+# 
+# Configuration example
+# 
+# [php_apc_*]
+# user root
+# env.URL http://localhost/php_apc.php # URL to fetch APC status
 #
-# URL to the script to check apc status
-URL=""
-#URL="http://localhost/php_apc.php";
-#
-#  php file included in package
+# (php_apc.php file included in package)
 #
 #################################################################
 #
@@ -27,6 +29,10 @@ URL=""
 # Settigs required for autoconf
 #%# family=auto
 #%# capabilities=autoconf suggest
+
+# URL to the script to check APC status (defaults to 
+# 'http://localhost/php_apc.php' if not configured)
+URL=${URL:-'http://localhost/php_apc.php'}
 
 WGET=`which wget`;
 WGET_FLAGS="-Yoff"; # refer to wget manual, you may set extra parameters like disable proxy


### PR DESCRIPTION
I've made the "URL" parameter look up if not already defined (in munin-node configuration file) before defaulting to http://localhost/php_apc.php.
