### PR TITLE
apache_vhosts updates

### DIFF
--- a/plugins/apache/apache_vhosts/apache_logparser
+++ b/plugins/apache/apache_vhosts/apache_logparser
@@ -150,7 +150,7 @@ while (1) {
         $share->lock(LOCK_EX);
         
         # get data (may be updated by other loggers too)
-        my %old=%{thaw $share->fetch};
+        my %old=eval{%{thaw($share->fetch)}};              # using eval to suppress thaw error on empty string at the first run
 
         foreach my $vpm (keys %temp){
                 # merge values

--- a/plugins/apache/apache_vhosts/apache_pipelogger
+++ b/plugins/apache/apache_vhosts/apache_pipelogger
@@ -39,7 +39,7 @@ while (<STDIN>) {
  	my ($vhost,$port,$method,$bytes,$time,$status)=split(/\s/,$_);
 
 	# sanity check
-	next unless m/^([\d\w.-_]+\s){5}([\d\w.-_]+$)/;
+	next unless m/^([\d\w\.\-_]+\s){5}([\d\w\.\-_]+$)/;       # escaped "." and "-"
 	$time=sprintf("%d",$time/1000); # microsec to millisec	
 	
 	# sitename to munin fieldname
@@ -85,7 +85,7 @@ sub periodic_write {
         $share->lock(LOCK_EX);
         
         # get data (may be updated by other loggers too)
-        my %old=%{thaw $share->fetch};
+        my %old=eval{%{thaw($share->fetch)}};             # using eval to suppress thaw error on empty string at the first run
 
         foreach my $vpm (keys %temp){
                 # merge values

--- a/plugins/apache/apache_vhosts/apache_vhosts
+++ b/plugins/apache/apache_vhosts/apache_vhosts
@@ -80,7 +80,7 @@ my $share = IPC::ShareLite->new(
 ) or die $!;
 
 
-my %data=%{thaw $share->fetch};
+my %data=eval{%{thaw($share->fetch)}};  # using eval to suppress thaw error on empty string at the first run
 
 if ( defined $ARGV[0] and $ARGV[0] eq "autoconf" ) {
   if (scalar(keys %data)>0) {


### PR DESCRIPTION
apache_vhosts didn't work for me (debian squeeze), so I added these fixes: Surrounded thaw by eval{} to suppress error at the very first run and escaped "." and "-" at the sanitizing regex in apache_pipelogger
