### PR TITLE
nvidia_smi: Get memory usage even if nvmlDeviceGetUtilizationRates is not available

### DIFF
--- a/plugins/gpu/nvidia_smi_
+++ b/plugins/gpu/nvidia_smi_
@@ -110,7 +110,16 @@ for (my $i = 0; $i < $gpuCount; $i++)
         else
         {
             $gpuUtil = "N/A";
-            $memUtil = "N/A";
+
+            ($ret, my $memory) = nvmlDeviceGetMemoryInfo($handle);
+            if ($ret == $NVML_SUCCESS)
+            {
+                $memUtil = $memory->{"used"} / $memory->{"total"} * 100;
+            }
+            else
+            {
+                $memUtil = "N/A";
+            }
         }
 
         print "GPU_TEMP_$i.value $gpuTemp\n";


### PR DESCRIPTION
Memory usage can be retrieved by two different ways. Use both for fallback.
