### PR TITLE
Determine used cmd tools dynamically and add memory usage to graph

### DIFF
--- a/plugins/php/php-cgi
+++ b/plugins/php/php-cgi
@@ -34,35 +34,35 @@ fi
 
 CMD_GREP=`which grep`
 if [ ! -e ${CMD_GREP} ]; then
-  echo "Command grep (${CMD_GREP}) not found!"
+  echo "Command grep not found!"
   exit 1
 fi
 CMD_SED=`which sed`
 if [ ! -e ${CMD_SED} ]; then
-  echo "Command sed (${CMD_SED}) not found!"
+  echo "Command sed not found!"
   exit 1
 fi
 CMD_WC=`which wc`
 if [ ! -e ${CMD_WC} ]; then
-  echo "Command wc (${CMD_WC}) not found!"
+  echo "Command wc not found!"
   exit 1
 fi
 CMD_AWK=`which awk`
 if [ ! -e ${CMD_AWK} ]; then
-  echo "Command awk (${CMD_AWK}) not found!"
+  echo "Command awk not found!"
   exit 1
 fi
 CMD_BC=`which bc`
 if [ ! -e ${CMD_BC} ]; then
-  echo "Command bc (${CMD_BC}) not found!"
+  echo "Command bc not found!"
   exit 1
 fi
 
 echo -n "php_cgi_processes.value "
-ps ax | ${CMD_GREP} -i php-cgi | ${CMD_GREP} -v grep | ${CMD_WC} -l | ${CMD_SED} 's/\t +//' | ${CMD_SED} 's/ *//'
+ps ax | grep -i php-cgi | grep -v grep | wc -l | sed 's/\t +//' | sed 's/ *//'
 
 MEMORY=0
-for mem in `ps avx | ${CMD_GREP} -i php-cgi | ${CMD_GREP} -v grep | ${CMD_GREP} "Ss" | ${CMD_AWK} '{ print $7 }'`; do
+for mem in `ps avx | grep -i php-cgi | grep -v grep | grep "Ss" | awk '{ print $7 }'`; do
   MEMORY=$(($MEMORY + $mem))
 done
 echo -n "php_cgi_ram.value "


### PR DESCRIPTION
The used command line tools are now avaluated via `which` because they can have different paths.

Also the memory usage in gb of all php-cgi processes (summed up) was added to the graph.
