### PR TITLE
New plugin for ARIS

### DIFF
--- a/plugins/aris/aris_players
+++ b/plugins/aris/aris_players
@@ -1,6 +1,19 @@
 #!/usr/bin/php
-# Author David Gagnon <djgagnon@wisc.edu>
+# Copyright (C) 2012 David Gagnon <djgagnon@wisc.edu>
 # Plugin to monitor ARIS users
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Library General Public License as published by
+# the Free Software Foundation; version 2 only
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 #
 # Parameters:
 #
@@ -8,7 +21,6 @@
 # 	
 #
 #%# family=manual
-
 
 <?php
 $aris_db_host='localhost';


### PR DESCRIPTION
This plugin allows munin users to monitor server instances of the ARIS
locative game engine. See http://arisgames.org
