### PR TITLE
Update plugins/system/debsecan

### DIFF
--- a/plugins/system/debsecan
+++ b/plugins/system/debsecan
@@ -60,10 +60,10 @@ EOF_
 fi
 
 debsecan 2> /dev/null > /tmp/debsecan.munin.$$
-high=`grep -c '(high urgency)' /tmp/debsecan.munin.$$`
-medium=`grep -c '(medium urgency)' /tmp/debsecan.munin.$$`
-low=`grep -c '(low urgency)' /tmp/debsecan.munin.$$`
-other=`grep -c -v -e '(low urgency)' -e '(medium urgency)' -e '(high urgency)' /tmp/debsecan.munin.$$`
+high=`grep -c 'high urgency' /tmp/debsecan.munin.$$`
+medium=`grep -c 'medium urgency' /tmp/debsecan.munin.$$`
+low=`grep -c 'low urgency)' /tmp/debsecan.munin.$$`
+other=`grep -c -v -e 'low urgency' -e 'medium urgency' -e 'high urgency' /tmp/debsecan.munin.$$`
 cat <<EOF_
 high.value $high
 medium.value $medium


### PR DESCRIPTION
adjusted patterns to grep

the latest version of debsecan has a output like this:

`CVE-2011-1092 php5-cli (remotely exploitable, high urgency)`
