### PR TITLE
Fixed bug which only displays the first 5 zones

### DIFF
--- a/plugins/system/zones_cpu
+++ b/plugins/system/zones_cpu
@@ -4,7 +4,7 @@
 #%# capabilities=autoconf
 
 PRSTAT=/usr/bin/prstat
-PRSTAT_OPTS="-Z 1 1"
+PRSTAT_OPTS="-Z -n 1,99 1 1"
 
 if [ "$1" = 'autoconf' ]; then
         if [ -f $PRSTAT ]; then


### PR DESCRIPTION
There is a bug which prevents prstat to display more than 5 zones. this can be fixed by setting -n 1,99 as prstat option
