### PR TITLE
New Plugin: HugePages usage

### DIFF
--- a/plugins/system/hugepages
+++ b/plugins/system/hugepages
@@ -1,4 +1,37 @@
 #!/usr/bin/gawk --exec
+#
+# HugePages monitoring plugin for munin
+#
+# This plugin monitors the usage of the Linux kernel HugePages, on some
+# architectures also called  Large Pages. It will show both pre-reserved
+# pages (via /prc/sys/vm/nr_hugepages), their usage and reserved size, as
+# well as HugePages allocated by the khugepaged (activated by the
+# transparent_hugepages kernel command line parameter). All values are
+# shown in (KiBi/MeBi/GiBi)Bytes.
+#
+# This plugin is used like many other munin plugins: put it in 
+# /usr/share/munin/plugins (or another appropriate location)
+# and create a symlink in /etc/munin/plugins:
+# > ln -s /usr/share/munin/plugins/hugepages /etc/munin/plugins
+# Then restart munin-node.
+#
+#
+# --
+#  Copyright 2012 Stefan Seidel <munin@stefanseidel.info>
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# --
+#
 BEGIN {
   if (ARGC > 1 && ARGV[1] == "config") {
     print "graph_args --base 1024 -l 0"


### PR DESCRIPTION
This plugin monitors the usage of both pre-allocated and anonymously (through the khugepaged, kernel parameter transparent_hugepages) used Huge Pages, also called Large Pages depending on who you ask.
