### PR TITLE
Traffic plugin. Monitor total throughput by IP protocol.

### DIFF
--- a/plugins/network/traffic
+++ b/plugins/network/traffic
@@ -62,7 +62,7 @@ fi
 
 if [ -r /proc/net/dev ]
 then
-	ipv4=$(( `egrep -v bond\|lo /proc/net/dev | awk -F' ' '{print $2+$10}' | paste -sd+ | bc` * 8 ))
+	ipv4=$( echo "`egrep -v bond\|lo /proc/net/dev | awk -F' ' '{print $2+$10}' | paste -sd+ | bc` * 8" | bc )
 	echo "IPv4.value $ipv4"
 else
 	echo "IPv4.value 0"
@@ -71,7 +71,7 @@ fi
 
 if [ -r /proc/net/snmp6 ]
 then
-	ipv6=$(( `egrep Ip6InOctets\|Ip6OutOctets /proc/net/snmp6 | awk -F' ' '{print $2}' | paste -sd+ | bc` * 8 ))
+	ipv6=$( echo "`egrep Ip6InOctets\|Ip6OutOctets /proc/net/snmp6 | awk -F' ' '{print $2}' | paste -sd+ | bc` * 8"  | bc )
 	echo "IPv6.value $ipv6"
 else
 	echo "IPv6.value 0"


### PR DESCRIPTION
Hi there!

I created and have been using for a while this `traffic` plugin for `munin`.

It's simple as hell: print total network usage by IPv4 and IPv6 in bps (or Mbps, Gbps, Tbps, you know...)

This, for example, gives you hints about how many traffic from IPv6 to IPv4 you have.

We use it ( the `traffic` plugin) in some network nodes to definitively know what is going on with IPv6 implementation.
Other plugins like `ip_*` or `if_*` don't fit in some environments to do this monitor operations. 
