### PR TITLE
Correct wildcard name handling on plugin net/vnstat_

### DIFF
--- a/plugins/network/vnstat_
+++ b/plugins/network/vnstat_
@@ -16,7 +16,7 @@
 
 
 
-IFACE=`echo $0 | awk -F_ '{print $1}'`
+IFACE=${0##*vnstat_}
 
 
 # Config section


### PR DESCRIPTION
The previous awk function did not work for my system, always returned the script name instead. Replaced with the same clean and sanitary bash variable logic that if_ uses to extract the interface name from $0.
