### PR TITLE
Fixing a warning in the ping plugin

### DIFF
--- a/plugins/network/ping/ping
+++ b/plugins/network/ping/ping
@@ -171,8 +171,10 @@ for (my $host_i = 0; $host_i < @host_addrs; ++$host_i) {
 				my @ping = `$h_ping $ping_args $h_addr $ping_args2`;
 				chomp @ping;
 				my $ping = join(" ", @ping);
-				my $ping_time = ($1 / 1000) if ($ping =~ m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@);
-				my $packet_loss = $1 if ($ping =~ /(\d+)% packet loss/);
+				my $ping_time = "U";
+				my $packet_loss = "U";
+				$ping_time = ($1 / 1000) if ($ping =~ m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@);
+				$packet_loss = $1 if ($ping =~ /(\d+)% packet loss/);
 				print "$h_norm_name.value ". ($packetloss_mode ? $packet_loss : $ping_time) . "\n";
 				if ($pid == 0) {
 					# this is a child process, don't forget to exit


### PR DESCRIPTION
Error message:
Use of uninitialized value $ping_time in concatenation (.) or string at /etc/munin/plugins/ping line 176.

Fix is to declare a variable prior to using it in postfix-if assignment
