### PR TITLE
Changed mysql command for mysql_slave from mysqladmin to mysql

### DIFF
--- a/plugins/mysql/mysql_slave
+++ b/plugins/mysql/mysql_slave
@@ -43,7 +43,7 @@
 
 use strict;
 
-my $MYSQLADMIN = $ENV{mysqladmin} || "mysql";
+my $MYSQL = $ENV{mysql} || "mysql";
 my $MYSQLOPTS = $ENV{mysqlopts} || "";
 
 my %WANTED = ( "Seconds"  => "seconds", 
@@ -66,7 +66,7 @@ if ($arg eq 'config') {
 my $seconds = 0;
 my (@infos,$info,$i_seconds);
 
-my $COMMAND = "$MYSQLADMIN $MYSQLOPTS -e 'show slave status;' | grep 'Slave'";
+my $COMMAND = "$MYSQL $MYSQLOPTS -e 'show slave status;' | grep 'Slave'";
 
 open(SERVICE, "$COMMAND |")
   or die("Coult not execute '$COMMAND': $!");
@@ -85,7 +85,7 @@ foreach $info (@infos) {
     }
 }
 
-$COMMAND = "$MYSQLADMIN $MYSQLOPTS -e 'show slave status;' | cut -f $i_seconds | grep -v leng";
+$COMMAND = "$MYSQL $MYSQLOPTS -e 'show slave status;' | cut -f $i_seconds | grep -v leng";
 
 open(SERVICE, "$COMMAND |")
   or die("Coult not execute '$COMMAND': $!");
@@ -117,7 +117,7 @@ sub test_service {
 
     my $return = 1;
 
-    system ("$MYSQLADMIN --version >/dev/null 2>/dev/null");
+    system ("$MYSQL --version >/dev/null 2>/dev/null");
     if ($? == 0)
     {
 	system ("$COMMAND >/dev/null 2>/dev/null");


### PR DESCRIPTION
Recent versions of mysqladmin do not seem to have the -e(execute a query) flag, as this is a standard flag for the mysql utility and the script uses no other mysqladmin only flags, I modified the script to use mysql, which also brings it into line with many of the other scripts, including mysql_slave_threads which issues similar queries.
