### PR TITLE
Strip hidden characters from raid-mismatch script

### DIFF
--- a/plugins/disk/raid-mismatch-count
+++ b/plugins/disk/raid-mismatch-count
@@ -1,4 +1,4 @@
-﻿#!/bin/sh
+#!/bin/sh
 # Detect and display Linux sw-raid mismatch count
 # Copyright (C) 2011 Rory Jaffe <rsjaffe@gmail.com>
 # derived from md_sync_speed by Kristian Lyngstøl


### PR DESCRIPTION
Seems to have windows line-endings and a hidden unicode (U+FEFF) character on the first line which stops it running for me.
