### PR TITLE
Fix and strict mode

### DIFF
--- a/plugins/apache/apache_byprojects/README.md
+++ b/plugins/apache/apache_byprojects/README.md
@@ -1,36 +1,44 @@
 # The 'byprojects' family
-Those plugins are used to monitor different projects or vhost (i.e. either different log files or uing regular expression as filters) on the same web server.
+Those plugins are used to monitor different projects or vhost (i.e. either different log files or using regular expression as filters) on the same web server.
 
 ## munin_byprojects_access
 Count the number of hits per projects/vhost.  
 ![byproject_access](https://www.mantor.org/~northox/misc/munin-plugins/nginx_byprojects_access1-month.png "byproject_access")
 
 ## munin_byprojects_bandwidth
-Count the total bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.
+Count the total bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.  
 ![byproject_bandwidth](https://www.mantor.org/~northox/misc/munin-plugins/apache_byprojects_bandwidth-month.png "byproject_bandwidth")
 
 ## munin_byprojects_inout_bandwidth
-Counts the in/out bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.
+Counts the in/out bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.  
 ![byproject_inout_bandwidth](https://www.mantor.org/~northox/misc/munin-plugins/apache_byprojects_inout_bandwidth-month.png "byproject_inout_bandwidth")
 
 ## Installation
-Installation is pretty straight forward. First you need to configure the plugin:
+The setup is pretty straight forward. First you need to configure the plugin:
 
-Identify the file which will be used by logtail to identify it's position in the log and the path to logtail:
+Define the file which will be used by logtail to identify it's position in the log and the path to logtail:
 
       $statepath = '/usr/local/var/munin/plugin-state'; # directory where logtail will save the state
       $logtail = '/usr/local/bin/logtail';
 
 Multiple logs can be used for the same project/vhost and a regular expression (regex) can be used as a filter:
 
-      %logs = (
-      'prod' => ('/home/prod/log/access.log'),
-      'test' => (
-                  ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-                  '/home/test/log/access.log'
-                )
+      my %logs = (
+        'prod' => [
+                    {'path' => '/home/prod/log/access.log'}
+                  ],
+         'dev' => [
+                    {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                    {'path' => '/home/dev/log/access.log'}
+                  ],
+        'test' => [
+                    {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                    {'path' => '/home/test/log/access.log'}
+                  ],
       );
 
 In the previous example the prod project graph will be using everything in /home/prod/log/access.log. The test project will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in /var/log/httpd/access.log (e.g. "GET /test/).
 
 Then link the file just as any other plugins.
+
+      ln -s /usr/local/sbin/<plugin> /usr/local/etc/munin/plugins/<plugin>

--- a/plugins/apache/apache_byprojects/byprojects_access
+++ b/plugins/apache/apache_byprojects/byprojects_access
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 #
 # byprojects_access
 #
@@ -10,25 +11,32 @@
 #
 # You need logtail (https://www.fourmilab.ch/webtools/logtail/)
 #
-# Log can be gather from multiple sources by simply specifying multiple log filename and/or an array with two
-# elements: log filename and a regex.
-#   - 'prod' => array('/home/prod/log/access.log'),
+# Log can be gathered from multiple sources by simply specifying multiple log filename 
+# and/or a log filename and a regex.
+#   - 'prod' => [ {'path' => '/home/prod/log/access.log'} ],
 #     Prod graph will be using everything in /home/prod/log/access.log
-#   - 'test' => array(array('/var/log/httpd/access.log', '"[A-Z]+ /test/'), '/home/test/log/access.log')
-#     Test graph will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in 
-#     /var/log/httpd/access.log such as '"GET /test/'
+#   - 'test' => [ {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+#                 {'path' => '/home/test/log/access.log'} ],
+#     Test graph will be using everything in /home/test/log/access.log and stuff that match 
+#     '"[A-Z] /test/' in /var/log/access.log such as '"GET /test/'
 
-$server = 'Apache';
+my $server = 'Apache';
 
-$statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
-$logtail = '/usr/local/bin/logtail';
+my $statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
+my $logtail = '/usr/local/bin/logtail';
 
-%logs = (
-'prod' => ('/home/prod/log/access.log'),
-'test' => (
-            ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-            '/home/test/log/access.log'
-          )
+my %logs = (
+    'prod' => [
+                {'path' => '/home/prod/log/access.log'}
+              ],
+    'dev'  => [
+                {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                {'path' => '/home/dev/log/access.log'}
+              ],
+    'test' => [
+                {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                {'path' => '/home/test/log/access.log'}
+              ],
 );
 
 ###########
@@ -38,39 +46,38 @@ if(defined($ARGV[0])) {
     print "yes\n";
     exit(0);
   } elsif ($ARGV[0] eq 'config') {
-    $order = '';
-    while (($client, $files) = each(%logs)) { $order .= $client.' ' }
+    my $order = '';
+    while ((my $project, my @files) = each(%logs)) { $order .= $project.' ' }
     print "graph_order $order\n";
     print "graph_title $server access byprojects\n";
     print "graph_total Total\n";
     print "graph_vlabel Access by \${graph_period}\n";
     print "graph_category $server\n";
     print "graph_info This graph show $server access by various projects.\n";
-    while (($client, $files) = each(%logs)) {
-      print $client.".label $client\n";
-      print $client.".type DERIVE\n";
-      print $client.".min 0\n";
+    while ((my $project, my @files) = each(%logs)) {
+      print $project.".label $project";
+      print $project.".type DERIVE\n";
+      print $project.".min 0\n";
     }
     exit(0);
   }
 }
 
-while (($client, $files) = each(%logs)) {
-  $x = $i = 0;
-  foreach $file ($files) {
-    $regex = '';
-    $state = $statepath.'/'.$client.$x.'_access.state';
-    if(ref($file) eq 'ARRAY') { ($file, $regex) = @file }
-    open(my $lt, "$logtail -f $file -o $state |") or die "Can't open $logtail : $!";
-    while (<$lt>) {
-      $buf = $_;
+foreach my $project ( keys %logs )  {
+  my $i = 0;
+  my $x = 0;
+  foreach my $log ( @{$logs{$project}} ) {
+    my $state = $statepath.'/'.$project.$x.'_access.state';
+    open(LT, "$logtail -f ".$log->{'path'}." -o $state |") or die "Can't open $logtail : $!";
+    while (<LT>) {
+      my $buf = $_;
       if($buf eq '') { next }
-      if(!defined($regex) || $buf =~ m/$regex/) {
+      if(!defined($log->{'regex'}) || $buf =~ m/$log->{'regex'}/) {
         $i++;
       }
     }
-    close($lt);
+    close(LT);
     $x++;
   }
-  print $client.".value $i\n";
+  print $project.".value $i\n";
 }

--- a/plugins/apache/apache_byprojects/byprojects_bandwidth
+++ b/plugins/apache/apache_byprojects/byprojects_bandwidth
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 #
 # byprojects_bandwidth
 #
@@ -6,33 +7,42 @@
 #
 # Danny Fullerton <northox@mantor.org> 
 # Mantor Organization <www.mantor.org>
+# This work is licensed under a Creative Commons Attribution 3.0 Unported License.
 #
-# You need logtail (https://www.fourmilab.ch/webtools/logtail/) and
+# You need logtail (https://www.fourmilab.ch/webtools/logtail/)
 #
 # mod_logio apache module (https://httpd.apache.org/docs/2.0/mod/mod_logio.html).
 # Your logformat should look like this "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O"
 # where %I is input and %O is output.
 #
-# Log can be gather from multiple sources by simply specifying multiple log filename and/or an array with two
-# elements: log filename and a regex.
-#   - 'prod' => array('/home/prod/log/access.log'),
+# Log can be gathered from multiple sources by simply specifying multiple log filename 
+# and/or a log filename and a regex.
+#   - 'prod' => [ {'path' => '/home/prod/log/access.log'} ],
 #     Prod graph will be using everything in /home/prod/log/access.log
-#   - 'test' => array(array('/var/log/httpd/access.log', '"[A-Z]+ /test/'), '/home/test/log/access.log')
-#     Test graph will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in 
-#     /var/log/httpd/access.log such as '"GET /test/'
+#   - 'test' => [ {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+#                 {'path' => '/home/test/log/access.log'} ],
+#     Test graph will be using everything in /home/test/log/access.log and stuff that match 
+#     '"[A-Z] /test/' in /var/log/access.log such as '"GET /test/'
 
-$statepath = '/usr/local/var/munin/plugin-state'; # directory where logtail will save the state
-$logtail = '/usr/local/bin/logtail';
+my $server = 'Apache';
 
-$server = 'Apache';
+my $statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
+my $logtail = '/usr/local/bin/logtail';
 
-%logs = (
-'prod' => ('/home/prod/log/access.log'),
-'test' => (
-            ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-            '/home/test/log/access.log'
-          )
+my %logs = (
+    'prod' => [
+                {'path' => '/home/prod/log/access.log'}
+              ],
+    'dev'  => [
+                {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                {'path' => '/home/dev/log/access.log'}
+              ],
+    'test' => [
+                {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                {'path' => '/home/test/log/access.log'}
+              ],
 );
+
 
 ###########
 
@@ -41,43 +51,42 @@ if(defined($ARGV[0])) {
     print "yes\n";
     exit(0);
   } elsif ($ARGV[0] eq 'config') {
-    $order = '';
-    while (($client, $files) = each(%logs)) { $order .= $client.' ' }
+    my $order = '';
+    while ((my $project, my @files) = each(%logs)) { $order .= $project.' ' }
     print "graph_order $order\n";
     print "graph_title $server total bandwidth byprojects\n";
     print "graph_total Total\n";
     print "graph_vlabel Bits\n";
     print "graph_category $server\n";
     print "graph_info This graph show $server total bandwidth used by various projects.\n";
-    while (($client, $files) = each(%logs)) {
-      print $client.".label $client\n";
-      print $client.".type GAUGE\n";
+    while ((my $project, my @files) = each(%logs)) {
+      print $project.".label $project\n";
+      print $project.".type GAUGE\n";
     }
     exit(0);
   }
 }
 
-while (($client, $files) = each(%logs)) {
-  $i = $o = $x = 0;
-  foreach $file ($files) {
-    $regex = '';
-    $state = $statepath.'/'.$client.$x.'_totalbandwidth.state';
-    if(ref($file) eq 'ARRAY') { ($file, $regex) = @file }
-    open(my $lt, "$logtail -f $file -o $state |") or die "Can't open $logtail : $!";
-    while (<$lt>) {
-      $buf = $_;
+foreach my $project ( keys %logs )  {
+  my $i = 0;
+  my $o = 0;
+  my $x = 0;
+  foreach my $log ( @{$logs{$project}} ) {
+    my $state = $statepath.'/'.$project.$x.'_totalbandwidth.state';
+    open(LT, "$logtail -f ".$log->{'path'}." -o $state |") or die "Can't open $logtail : $!";
+    while (<LT>) {
+      my $buf = $_;
       if($buf eq '') { next }
-      if(!defined($regex) || $buf =~ m/$regex/) {
+      if(!defined($log->{'regex'}) || $buf =~ m/$log->{'regex'}/) {
         if($buf =~ m/(\d+) (\d+)$/) {
           $i += $1;
           $o += $2;
         }
       }
     }
-    close($lt);
+    close(LT);
     $x++;
   }
   $x = $i + $o;
-  print $client.".value $x\n";
+  print $project.".value $x\n";
 }
-

--- a/plugins/apache/apache_byprojects/byprojects_inout_bandwidth
+++ b/plugins/apache/apache_byprojects/byprojects_inout_bandwidth
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 #
 # byprojects_inout_bandwidth
 #
@@ -6,34 +7,42 @@
 #
 # Danny Fullerton <northox@mantor.org> 
 # Mantor Organization <www.mantor.org>
+# This work is licensed under a Creative Commons Attribution 3.0 Unported License.
 #
-# You need logtail (https://www.fourmilab.ch/webtools/logtail/) and 
+# You need logtail (https://www.fourmilab.ch/webtools/logtail/)
 #
-# Apache:
 # mod_logio apache module (https://httpd.apache.org/docs/2.0/mod/mod_logio.html).
 # Your logformat should look like this "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O"
 # where %I is input and %O is output.
 #
-# Log can be gather from multiple sources by simply specifying multiple log filename and/or an array with two
-# elements: log filename and a regex.
-#   - 'prod' => array('/home/prod/log/access.log'),
+# Log can be gathered from multiple sources by simply specifying multiple log filename 
+# and/or a log filename and a regex.
+#   - 'prod' => [ {'path' => '/home/prod/log/access.log'} ],
 #     Prod graph will be using everything in /home/prod/log/access.log
-#   - 'test' => array(array('/var/log/httpd/access.log', '"[A-Z]+ /test/'), '/home/test/log/access.log')
-#     Test graph will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in 
-#     /var/log/httpd/access.log such as '"GET /test/'
+#   - 'test' => [ {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+#                 {'path' => '/home/test/log/access.log'} ],
+#     Test graph will be using everything in /home/test/log/access.log and stuff that match 
+#     '"[A-Z] /test/' in /var/log/access.log such as '"GET /test/'
 
-$server = 'Apache';
+my $server = 'Apache';
 
-$statepath = '/usr/local/var/munin/plugin-state'; # directory where logtail will save the state
-$logtail = '/usr/local/bin/logtail';
+my $statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
+my $logtail = '/usr/local/bin/logtail';
 
-%logs = (
-'prod' => ('/home/prod/log/access.log'),
-'test' => (
-            ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-            '/home/test/log/access.log'
-          )
+my %logs = (
+    'prod' => [
+                {'path' => '/home/prod/log/access.log'}
+              ],
+    'dev'  => [
+                {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                {'path' => '/home/dev/log/access.log'}
+              ],
+    'test' => [
+                {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                {'path' => '/home/test/log/access.log'}
+              ],
 );
+
 
 ###########
 
@@ -47,40 +56,40 @@ if(defined($ARGV[0])) {
     print "graph_vlabel bits per \${graph_period} in (-) / out (+)\n";
     print "graph_category $server\n";
     print "graph_info This graph show $server in/out bandwidth used by various projects.\n";
-    while (($client, $files) = each(%logs)) {
-      print "i".$client.".label $client\n";
-      print "i".$client.".type GAUGE\n";
-      print "i".$client.".graph no\n";
-      print "i".$client.".cdef i".$client.",8,*\n";
-      print "o".$client.".label $client\n";
-      print "o".$client.".type GAUGE\n";
-      print "o".$client.".negative i".$client."\n";
-      print "o".$client.".cdef o".$client.",8,*\n";
+    while ((my $project, my @files) = each(%logs)) {
+      print "i".$project.".label $project\n";
+      print "i".$project.".type GAUGE\n";
+      print "i".$project.".graph no\n";
+      print "i".$project.".cdef i".$project.",8,*\n";
+      print "o".$project.".label $project\n";
+      print "o".$project.".type GAUGE\n";
+      print "o".$project.".negative i".$project."\n";
+      print "o".$project.".cdef o".$project.",8,*\n";
     }
     exit(0);
   }
 }
 
-while (($client, $files) = each(%logs)) {
-  $i = $o = $x = 0;
-  foreach $file ($files) {
-    $regex = '';
-    $state = $statepath.'/'.$client.$x.'_inoutbandwidth.state';
-    if(ref($file) eq 'ARRAY') { ($file, $regex) = @file }
-    open(my $lt, "$logtail -f $file -o $state |") or die "Can't open $logtail : $!";
-    while (<$lt>) {
-      $buf = $_;
+foreach my $project ( keys %logs )  {
+  my $i = 0;
+  my $o = 0;
+  my $x = 0;
+  foreach my $log ( @{$logs{$project}} ) {
+    my $state = $statepath.'/'.$project.$x.'_inoutbandwidth.state';
+    open(LT, "$logtail -f ".$log->{'path'}." -o $state |") or die "Can't open $logtail : $!";
+    while (<LT>) {
+      my $buf = $_;
       if($buf eq '') { next }
-      if(!defined($regex) || $buf =~ m/$regex/) {
+      if(!defined($log->{'regex'}) || $buf =~ m/$log->{'regex'}/) {
         if($buf =~ m/(\d+) (\d+)$/) {
           $i += $1;
           $o += $2;
         }
       }
     }
-    close($lt);
+    close(LT);
     $x++;
   }
-  print "i".$client.".value $i\n";
-  print "o".$client.".value $o\n";
+  print "i".$project.".value $i\n";
+  print "o".$project.".value $o\n";
 }

--- a/plugins/nginx/nginx_byprojects/README.md
+++ b/plugins/nginx/nginx_byprojects/README.md
@@ -1,36 +1,44 @@
 # The 'byprojects' family
-Those plugins are used to monitor different projects or vhost (i.e. either different log files or uing regular expression as filters) on the same web server.
+Those plugins are used to monitor different projects or vhost (i.e. either different log files or using regular expression as filters) on the same web server.
 
 ## munin_byprojects_access
 Count the number of hits per projects/vhost.  
 ![byproject_access](https://www.mantor.org/~northox/misc/munin-plugins/nginx_byprojects_access1-month.png "byproject_access")
 
 ## munin_byprojects_bandwidth
-Count the total bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.
+Count the total bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.  
 ![byproject_bandwidth](https://www.mantor.org/~northox/misc/munin-plugins/apache_byprojects_bandwidth-month.png "byproject_bandwidth")
 
 ## munin_byprojects_inout_bandwidth
-Counts the in/out bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.
+Counts the in/out bandwidth used by each projects/vhost. [Logtail] (https://www.fourmilab.ch/webtools/logtail/) is required.  
 ![byproject_inout_bandwidth](https://www.mantor.org/~northox/misc/munin-plugins/apache_byprojects_inout_bandwidth-month.png "byproject_inout_bandwidth")
 
 ## Installation
-Installation is pretty straight forward. First you need to configure the plugin:
+The setup is pretty straight forward. First you need to configure the plugin:
 
-Identify the file which will be used by logtail to identify it's position in the log and the path to logtail:
+Define the file which will be used by logtail to identify it's position in the log and the path to logtail:
 
       $statepath = '/usr/local/var/munin/plugin-state'; # directory where logtail will save the state
       $logtail = '/usr/local/bin/logtail';
 
 Multiple logs can be used for the same project/vhost and a regular expression (regex) can be used as a filter:
 
-      %logs = (
-      'prod' => ('/home/prod/log/access.log'),
-      'test' => (
-                  ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-                  '/home/test/log/access.log'
-                )
+      my %logs = (
+        'prod' => [
+                    {'path' => '/home/prod/log/access.log'}
+                  ],
+         'dev' => [
+                    {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                    {'path' => '/home/dev/log/access.log'}
+                  ],
+        'test' => [
+                    {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                    {'path' => '/home/test/log/access.log'}
+                  ],
       );
 
 In the previous example the prod project graph will be using everything in /home/prod/log/access.log. The test project will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in /var/log/httpd/access.log (e.g. "GET /test/).
 
 Then link the file just as any other plugins.
+
+      ln -s /usr/local/sbin/<plugin> /usr/local/etc/munin/plugins/<plugin>

--- a/plugins/nginx/nginx_byprojects/byprojects_access
+++ b/plugins/nginx/nginx_byprojects/byprojects_access
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 #
 # byprojects_access
 #
@@ -10,25 +11,32 @@
 #
 # You need logtail (https://www.fourmilab.ch/webtools/logtail/)
 #
-# Log can be gather from multiple sources by simply specifying multiple log filename and/or an array with two
-# elements: log filename and a regex.
-#   - 'prod' => array('/home/prod/log/access.log'),
+# Log can be gathered from multiple sources by simply specifying multiple log filename 
+# and/or a log filename and a regex.
+#   - 'prod' => [ {'path' => '/home/prod/log/access.log'} ],
 #     Prod graph will be using everything in /home/prod/log/access.log
-#   - 'test' => array(array('/var/log/httpd/access.log', '"[A-Z]+ /test/'), '/home/test/log/access.log')
-#     Test graph will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in 
-#     /var/log/httpd/access.log such as '"GET /test/'
+#   - 'test' => [ {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+#                 {'path' => '/home/test/log/access.log'} ],
+#     Test graph will be using everything in /home/test/log/access.log and stuff that match 
+#     '"[A-Z] /test/' in /var/log/access.log such as '"GET /test/'
 
-$server = 'Nginx';
+my $server = 'Nginx';
 
-$statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
-$logtail = '/usr/local/bin/logtail';
+my $statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
+my $logtail = '/usr/local/bin/logtail';
 
-%logs = (
-'prod' => ('/home/prod/log/access.log'),
-'test' => (
-            ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-            '/home/test/log/access.log'
-          )
+my %logs = (
+    'prod' => [
+                {'path' => '/home/prod/log/access.log'}
+              ],
+    'dev'  => [
+                {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                {'path' => '/home/dev/log/access.log'}
+              ],
+    'test' => [
+                {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                {'path' => '/home/test/log/access.log'}
+              ],
 );
 
 ###########
@@ -38,39 +46,38 @@ if(defined($ARGV[0])) {
     print "yes\n";
     exit(0);
   } elsif ($ARGV[0] eq 'config') {
-    $order = '';
-    while (($client, $files) = each(%logs)) { $order .= $client.' ' }
+    my $order = '';
+    while ((my $project, my @files) = each(%logs)) { $order .= $project.' ' }
     print "graph_order $order\n";
     print "graph_title $server access byprojects\n";
     print "graph_total Total\n";
     print "graph_vlabel Access by \${graph_period}\n";
     print "graph_category $server\n";
     print "graph_info This graph show $server access by various projects.\n";
-    while (($client, $files) = each(%logs)) {
-      print $client.".label $client\n";
-      print $client.".type DERIVE\n";
-      print $client.".min 0\n";
+    while ((my $project, my @files) = each(%logs)) {
+      print $project.".label $project";
+      print $project.".type DERIVE\n";
+      print $project.".min 0\n";
     }
     exit(0);
   }
 }
 
-while (($client, $files) = each(%logs)) {
-  $x = $i = 0;
-  foreach $file ($files) {
-    $regex = '';
-    $state = $statepath.'/'.$client.$x.'_access.state';
-    if(ref($file) eq 'ARRAY') { ($file, $regex) = @file }
-    open(my $lt, "$logtail -f $file -o $state |") or die "Can't open $logtail : $!";
-    while (<$lt>) {
-      $buf = $_;
+foreach my $project ( keys %logs )  {
+  my $i = 0;
+  my $x = 0;
+  foreach my $log ( @{$logs{$project}} ) {
+    my $state = $statepath.'/'.$project.$x.'_access.state';
+    open(LT, "$logtail -f ".$log->{'path'}." -o $state |") or die "Can't open $logtail : $!";
+    while (<LT>) {
+      my $buf = $_;
       if($buf eq '') { next }
-      if(!defined($regex) || $buf =~ m/$regex/) {
+      if(!defined($log->{'regex'}) || $buf =~ m/$log->{'regex'}/) {
         $i++;
       }
     }
-    close($lt);
+    close(LT);
     $x++;
   }
-  print $client.".value $i\n";
+  print $project.".value $i\n";
 }

--- a/plugins/nginx/nginx_byprojects/byprojects_bandwidth
+++ b/plugins/nginx/nginx_byprojects/byprojects_bandwidth
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 #
 # byprojects_bandwidth
 #
@@ -6,34 +7,43 @@
 #
 # Danny Fullerton <northox@mantor.org> 
 # Mantor Organization <www.mantor.org>
+# This work is licensed under a Creative Commons Attribution 3.0 Unported License.
 #
-# You need logtail (https://www.fourmilab.ch/webtools/logtail/) and
+# You need logtail (https://www.fourmilab.ch/webtools/logtail/)
 #
 # Your nginx configuration should look like this (i.e. $request_length $body_bytes_sent at the end):
 #   log_format main  '$remote_addr - $remote_user $time_local "$request" '
 #                    '$status $body_bytes_sent "$http_referer" '
 #                    '"$http_user_agent" $request_length $body_bytes_sent';
 #
-# Log can be gather from multiple sources by simply specifying multiple log filename and/or an array with two
-# elements: log filename and a regex.
-#   - 'prod' => array('/home/prod/log/access.log'),
+# Log can be gathered from multiple sources by simply specifying multiple log filename 
+# and/or a log filename and a regex.
+#   - 'prod' => [ {'path' => '/home/prod/log/access.log'} ],
 #     Prod graph will be using everything in /home/prod/log/access.log
-#   - 'test' => array(array('/var/log/httpd/access.log', '"[A-Z]+ /test/'), '/home/test/log/access.log')
-#     Test graph will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in 
-#     /var/log/httpd/access.log such as '"GET /test/'
+#   - 'test' => [ {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+#                 {'path' => '/home/test/log/access.log'} ],
+#     Test graph will be using everything in /home/test/log/access.log and stuff that match 
+#     '"[A-Z] /test/' in /var/log/access.log such as '"GET /test/'
 
-$statepath = '/usr/local/var/munin/plugin-state'; # directory where logtail will save the state
-$logtail = '/usr/local/bin/logtail';
+my $server = 'Nginx';
 
-$server = 'Nginx';
+my $statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
+my $logtail = '/usr/local/bin/logtail';
 
-%logs = (
-'prod' => ('/home/prod/log/access.log'),
-'test' => (
-            ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-            '/home/test/log/access.log'
-          )
+my %logs = (
+    'prod' => [
+                {'path' => '/home/prod/log/access.log'}
+              ],
+    'dev'  => [
+                {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                {'path' => '/home/dev/log/access.log'}
+              ],
+    'test' => [
+                {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                {'path' => '/home/test/log/access.log'}
+              ],
 );
+
 
 ###########
 
@@ -42,43 +52,42 @@ if(defined($ARGV[0])) {
     print "yes\n";
     exit(0);
   } elsif ($ARGV[0] eq 'config') {
-    $order = '';
-    while (($client, $files) = each(%logs)) { $order .= $client.' ' }
+    my $order = '';
+    while ((my $project, my @files) = each(%logs)) { $order .= $project.' ' }
     print "graph_order $order\n";
     print "graph_title $server total bandwidth byprojects\n";
     print "graph_total Total\n";
     print "graph_vlabel Bits\n";
     print "graph_category $server\n";
     print "graph_info This graph show $server total bandwidth used by various projects.\n";
-    while (($client, $files) = each(%logs)) {
-      print $client.".label $client\n";
-      print $client.".type GAUGE\n";
+    while ((my $project, my @files) = each(%logs)) {
+      print $project.".label $project\n";
+      print $project.".type GAUGE\n";
     }
     exit(0);
   }
 }
 
-while (($client, $files) = each(%logs)) {
-  $i = $o = $x = 0;
-  foreach $file ($files) {
-    $regex = '';
-    $state = $statepath.'/'.$client.$x.'_totalbandwidth.state';
-    if(ref($file) eq 'ARRAY') { ($file, $regex) = @file }
-    open(my $lt, "$logtail -f $file -o $state |") or die "Can't open $logtail : $!";
-    while (<$lt>) {
-      $buf = $_;
+foreach my $project ( keys %logs )  {
+  my $i = 0;
+  my $o = 0;
+  my $x = 0;
+  foreach my $log ( @{$logs{$project}} ) {
+    my $state = $statepath.'/'.$project.$x.'_totalbandwidth.state';
+    open(LT, "$logtail -f ".$log->{'path'}." -o $state |") or die "Can't open $logtail : $!";
+    while (<LT>) {
+      my $buf = $_;
       if($buf eq '') { next }
-      if(!defined($regex) || $buf =~ m/$regex/) {
+      if(!defined($log->{'regex'}) || $buf =~ m/$log->{'regex'}/) {
         if($buf =~ m/(\d+) (\d+)$/) {
           $i += $1;
           $o += $2;
         }
       }
     }
-    close($lt);
+    close(LT);
     $x++;
   }
   $x = $i + $o;
-  print $client.".value $x\n";
+  print $project.".value $x\n";
 }
-

--- a/plugins/nginx/nginx_byprojects/byprojects_inout_bandwidth
+++ b/plugins/nginx/nginx_byprojects/byprojects_inout_bandwidth
@@ -1,4 +1,5 @@
 #!/usr/bin/perl -w
+use strict;
 #
 # byprojects_inout_bandwidth
 #
@@ -6,34 +7,43 @@
 #
 # Danny Fullerton <northox@mantor.org> 
 # Mantor Organization <www.mantor.org>
+# This work is licensed under a Creative Commons Attribution 3.0 Unported License.
 #
-# You need logtail (https://www.fourmilab.ch/webtools/logtail/) and 
+# You need logtail (https://www.fourmilab.ch/webtools/logtail/)
 #
 # Your nginx configuration should look like this (i.e. $request_length $body_bytes_sent at the end):
 #   log_format main  '$remote_addr - $remote_user $time_local "$request" '
 #                    '$status $body_bytes_sent "$http_referer" '
 #                    '"$http_user_agent" $request_length $body_bytes_sent';
 #
-# Log can be gather from multiple sources by simply specifying multiple log filename and/or an array with two
-# elements: log filename and a regex.
-#   - 'prod' => array('/home/prod/log/access.log'),
+# Log can be gathered from multiple sources by simply specifying multiple log filename 
+# and/or a log filename and a regex.
+#   - 'prod' => [ {'path' => '/home/prod/log/access.log'} ],
 #     Prod graph will be using everything in /home/prod/log/access.log
-#   - 'test' => array(array('/var/log/httpd/access.log', '"[A-Z]+ /test/'), '/home/test/log/access.log')
-#     Test graph will be using eveything in /home/test/log/access.log and stuff that match '"[A-Z] /test/' in 
-#     /var/log/httpd/access.log such as '"GET /test/'
+#   - 'test' => [ {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+#                 {'path' => '/home/test/log/access.log'} ],
+#     Test graph will be using everything in /home/test/log/access.log and stuff that match 
+#     '"[A-Z] /test/' in /var/log/access.log such as '"GET /test/'
 
-$server = 'Nginx';
+my $server = 'Nginx';
 
-$statepath = '/usr/local/var/munin/plugin-state'; # directory where logtail will save the state
-$logtail = '/usr/local/bin/logtail';
+my $statepath = '/usr/local/var/munin/plugin-state'; # where logtail will save the state
+my $logtail = '/usr/local/bin/logtail';
 
-%logs = (
-'prod' => ('/home/prod/log/access.log'),
-'test' => (
-            ('/var/log/httpd/access.log', '"[A-Z]+ /test/'),
-            '/home/test/log/access.log'
-          )
+my %logs = (
+    'prod' => [
+                {'path' => '/home/prod/log/access.log'}
+              ],
+    'dev'  => [
+                {'path' => '/var/log/httpd/ssl-dev-access.log'},
+                {'path' => '/home/dev/log/access.log'}
+              ],
+    'test' => [
+                {'path' => '/var/log/access.log', 'regex' => '"[A-Z]+ /test/'},
+                {'path' => '/home/test/log/access.log'}
+              ],
 );
+
 
 ###########
 
@@ -47,40 +57,40 @@ if(defined($ARGV[0])) {
     print "graph_vlabel bits per \${graph_period} in (-) / out (+)\n";
     print "graph_category $server\n";
     print "graph_info This graph show $server in/out bandwidth used by various projects.\n";
-    while (($client, $files) = each(%logs)) {
-      print "i".$client.".label $client\n";
-      print "i".$client.".type GAUGE\n";
-      print "i".$client.".graph no\n";
-      print "i".$client.".cdef i".$client.",8,*\n";
-      print "o".$client.".label $client\n";
-      print "o".$client.".type GAUGE\n";
-      print "o".$client.".negative i".$client."\n";
-      print "o".$client.".cdef o".$client.",8,*\n";
+    while ((my $project, my @files) = each(%logs)) {
+      print "i".$project.".label $project\n";
+      print "i".$project.".type GAUGE\n";
+      print "i".$project.".graph no\n";
+      print "i".$project.".cdef i".$project.",8,*\n";
+      print "o".$project.".label $project\n";
+      print "o".$project.".type GAUGE\n";
+      print "o".$project.".negative i".$project."\n";
+      print "o".$project.".cdef o".$project.",8,*\n";
     }
     exit(0);
   }
 }
 
-while (($client, $files) = each(%logs)) {
-  $i = $o = $x = 0;
-  foreach $file ($files) {
-    $regex = '';
-    $state = $statepath.'/'.$client.$x.'_inoutbandwidth.state';
-    if(ref($file) eq 'ARRAY') { ($file, $regex) = @file }
-    open(my $lt, "$logtail -f $file -o $state |") or die "Can't open $logtail : $!";
-    while (<$lt>) {
-      $buf = $_;
+foreach my $project ( keys %logs )  {
+  my $i = 0;
+  my $o = 0;
+  my $x = 0;
+  foreach my $log ( @{$logs{$project}} ) {
+    my $state = $statepath.'/'.$project.$x.'_inoutbandwidth.state';
+    open(LT, "$logtail -f ".$log->{'path'}." -o $state |") or die "Can't open $logtail : $!";
+    while (<LT>) {
+      my $buf = $_;
       if($buf eq '') { next }
-      if(!defined($regex) || $buf =~ m/$regex/) {
+      if(!defined($log->{'regex'}) || $buf =~ m/$log->{'regex'}/) {
         if($buf =~ m/(\d+) (\d+)$/) {
           $i += $1;
           $o += $2;
         }
       }
     }
-    close($lt);
+    close(LT);
     $x++;
   }
-  print "i".$client.".value $i\n";
-  print "o".$client.".value $o\n";
+  print "i".$project.".value $i\n";
+  print "o".$project.".value $o\n";
 }


### PR DESCRIPTION
Add strict mode to avoid error in munin-run.
Fix hash/array syntax causing regex-based log to fail.
