### PR TITLE
Fixed light bug in asterisk_channels plugin

### DIFF
--- a/plugins/asterisk/asterisk_channels
+++ b/plugins/asterisk/asterisk_channels
@@ -27,5 +27,5 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
-asterisk -x "core show channels" | awk '/active channels/ { print "channels.value " $1 }'
+asterisk -rx "core show channels" | awk '/active channels/ { print "channels.value " $1 }'
 exit 0


### PR DESCRIPTION
Updated asterisk_channels plugin to connect to running asterisk (probably what was intended) instead of starting new process.
