### PR TITLE
Update plugins/zfs/zfs_stats_

### DIFF
--- a/plugins/zfs/zfs_stats_
+++ b/plugins/zfs/zfs_stats_
@@ -109,8 +109,10 @@ else
 fi
 
 L2_ACCESSES_TOTAL=`echo "$L2_HITS+$L2_MISSES" | $BC`
-L2_HIT_RATIO_PERC=`echo "scale=2 ; (100*$L2_HITS/$L2_ACCESSES_TOTAL)" | $BC`
-L2_MISS_RATIO_PERC=`echo "scale=2 ; (100*$L2_MISSES/$L2_ACCESSES_TOTAL)" | $BC`
+if [ $L2_ACCESSES_TOTAL -gt 0 ]; then
+	L2_HIT_RATIO_PERC=`echo "scale=2 ; (100*$L2_HITS/$L2_ACCESSES_TOTAL)" | $BC`
+	L2_MISS_RATIO_PERC=`echo "scale=2 ; (100*$L2_MISSES/$L2_ACCESSES_TOTAL)" | $BC`
+fi
 
 efficiency() {
         if [ "$1" = "config" ]; then


### PR DESCRIPTION
Don't divide by zero if there is no l2arc

Error output from zfs_stats_cachehitlist:
dc: divide by zero
