### PR TITLE
Fix freeimpi undefined warnings

### DIFF
--- a/plugins/sensors/freeipmi
+++ b/plugins/sensors/freeipmi
@@ -131,11 +131,11 @@ foreach my $line (@data) {
 		value => $dataline[3],
 		label => $dataline[1]
 	       );
-  $sensor{lwarn} = $dataline[7] ne "N/A" ? $dataline[7] : '';
-  $sensor{hwarn} = $dataline[8] ne "N/A" ? $dataline[8] : '';
+  $sensor{lwarn} = (defined($dataline[7]) and $dataline[7] ne "N/A") ? $dataline[7] : '';
+  $sensor{hwarn} = (defined($dataline[8]) and $dataline[8] ne "N/A") ? $dataline[8] : '';
 
-  $sensor{lcrit} = $dataline[6] ne "N/A" ? $dataline[6] : '';
-  $sensor{hcrit} = $dataline[9] ne "N/A" ? $dataline[9] : '';
+  $sensor{lcrit} = (defined($dataline[6]) and $dataline[6] ne "N/A") ? $dataline[6] : '';
+  $sensor{hcrit} = (defined($dataline[9]) and $dataline[9] ne "N/A") ? $dataline[9] : '';
 
   my $type;
   if ( $dataline[2] eq "Temperature" ) {


### PR DESCRIPTION
Commit https://github.com/munin-monitoring/contrib/commit/548a2b626eb6a794ccd194d943bcc956e14908c4 fixes ipmi for older versions as suggested by me here: https://github.com/munin-monitoring/contrib/pull/217

This works, but gives undefined warnings. This pull request fixes this.

Thanks for the work, @Flameeyes ! 
