### PR TITLE
config directives for e2_*

### DIFF
--- a/plugins/disk/e2.conf
+++ b/plugins/disk/e2.conf
@@ -1,0 +1,2 @@
+[e2_*]
+group disk,floppy


### PR DESCRIPTION
block devices being monitored by e2_\* are
owned by disk and floppy groups on Debian systems
