### PR TITLE
Added traffic_percent multigraph to traffic plugin.

### DIFF
--- a/plugins/network/traffic
+++ b/plugins/network/traffic
@@ -21,6 +21,7 @@ If trouble reading files, use:
 =over
 
 =item 2012.09.20: Initial version by Arturo Borrero Gonzalez <aborrero@cica.es>
+
 =item 2013.01.12: Added percentage graphing by Michiel Holtkamp <michiel@supermind.nl>
 
 =back


### PR DESCRIPTION
First time doing a pull request, and first time trying to contribute to munin. Feedback very welcome!

This small change adds another graph (via multigraph) to the traffic plugin. Not only volume/throughput is graphed (the original traffic plugin), but also a new graph, which plots the percentage of IPv4 and IPv6 (so basically, you can see the ratio between the two).

This allows you to see how much percentage of your traffic is IPv6 and which is IPv4 (and of course min, avg and max).

Please let me know if I can improve something!
