### PR TITLE
svdrpsend.pl was renamed

### DIFF
--- a/plugins/vdr/vdr_
+++ b/plugins/vdr/vdr_
@@ -21,7 +21,7 @@ $0 =~ /vdr_(.+)*$/;
 my $host  = $1 || "localhost";;
 
 #print "Name: $0\nHost: $host\n";
-my $SVDRPSENDPL="/usr/bin/svdrpsend.pl -d $host";
+my $SVDRPSENDPL="/usr/bin/svdrpsend -d $host";
 
 sub ermittelnTimer;
 sub ermittelnAufnahmen;


### PR DESCRIPTION
The script "svdrpsend.pl" was renamed to "svdrpsend" in VDR Version 1.7.23.
see http://www.vdr-wiki.de/wiki/index.php/SVDRP#svdrpsend

The plugin doesn't work with current vdr-versions.
