### PR TITLE
xen-multi CPU usage graph, skip list, some cleanup

### DIFF
--- a/plugins/virtualization/xen-multi
+++ b/plugins/virtualization/xen-multi
@@ -19,6 +19,9 @@ configuration:
 
  [xen-multi]
  user root
+ env.xenskip "<space separated module list>"
+
+Modules: cput, cpup, mem, disk, net
 
 Then restart munin-node and you're done.
 
@@ -34,9 +37,13 @@ NOTE: xentop always reports 0 for dom0's disk IOs and network traffic, but
 both graphs show its entry all the same, so each domain can keep its own color
 along the different graphs.
 
-=head2 CPU usage
+=head2 CPU time
 
 This graph shows a percentage of the CPU time used by each domain.
+
+=head2 CPU usage
+
+This graph shows a percentage of the CPU percentage used by each domain.
 
 =head2 Memory usage
 
@@ -66,6 +73,7 @@ Michael Renner for the C<diskstats> plugin which I borrowed some code from.
 =head1 AUTHOR
 
 Raphael HALIMI <raphael.halimi@gmail.com>
+Modified by Krisztian IVANCSO <github-ivan@ivancso.net>
 
 =head1 LICENSE
 
@@ -75,6 +83,8 @@ GPLv2
 
 use strict;
 use Munin::Plugin;
+
+my $XEN_SKIP = $ENV{xenskip} || "";
 
 # autoconf - quite simple
 if ($ARGV[0] eq "autoconf") {
@@ -101,7 +111,7 @@ if ($ARGV[0] eq "autoconf") {
 
 sub trim_label {
   my ($type, $label) = @_; my $data_characters;
-  my ($graph_width, $graph_border_width, $padding_characters, $pixels_per_character) = (400,97,10,6);
+  my ($graph_width, $graph_border_width, $padding_characters, $pixels_per_character) = (497,3,5,6);
   if ($type eq 'pos') {$data_characters = 32;} elsif ($type eq 'neg') {$data_characters = 64;} else {return $label;}
 
   my $available_characters = abs(($graph_width+$graph_border_width)/$pixels_per_character)-$padding_characters-$data_characters;
@@ -117,9 +127,9 @@ sub trim_label {
 }
 
 # Global variables
-my (%domains,$domain,$munindomain,$cpusecs,$memk,$nettxk,$netrxk,$vbdrd,$vbdwr);
+my (%domains,$domain,@domainlist,$munindomain,$cpusecs,$cpupercent,$memk,$nettxk,$netrxk,$vbdrd,$vbdwr);
 
-open (XENTOP,"xentop -b -f -i1 |") or die "Could not execute xentop, $!";
+open (XENTOP,"xentop -b -f -i2 |") or die "Could not execute xentop, $!";
 
 # Now we build a hash of hashes to store information
 while (<XENTOP>) {
@@ -129,7 +139,7 @@ while (<XENTOP>) {
   next if /^NAME/;
 
   # We define only what we need
-  ($domain,undef,$cpusecs,undef,$memk,undef,undef,undef,undef,undef,$nettxk,$netrxk,undef,undef,$vbdrd,$vbdwr,undef,undef,undef) = split(/\s+/);
+  ($domain,undef,$cpusecs,$cpupercent,$memk,undef,undef,undef,undef,undef,$nettxk,$netrxk,undef,undef,$vbdrd,$vbdwr,undef,undef,undef) = split(/\s+/);
 
   # We have to store the sanitised domain name in a separate variable
   $domains{$domain}{'munindomain'} = clean_fieldname($domain);
@@ -137,6 +147,7 @@ while (<XENTOP>) {
   # We need the remaining data only for a normal run
   if ($ARGV[0] eq "") {
     $domains{$domain}{'cpusecs'} = $cpusecs;
+    $domains{$domain}{'cpupercent'} = $cpupercent;
     $domains{$domain}{'mem'} = $memk;
     $domains{$domain}{'nettx'} = $nettxk;
     $domains{$domain}{'netrx'} = $netrxk;
@@ -145,71 +156,94 @@ while (<XENTOP>) {
   }
 }
 
+@domainlist = sort(keys(%domains));
 
 #
 # config - quite simple, too
 #
 
 if ($ARGV[0] eq "config") {
-  print "multigraph xen_cpu_time\n";
-  print "graph_title Xen domains CPU time\n";
-  print "graph_args --base 1000 -l 0\n";
-  print "graph_vlabel %\n";
-  print "graph_scale no\n";
-  print "graph_category xen\n";
-  print "graph_info This graph shows CPU time for each Xen domain.\n";
-  for $domain (sort(keys(%domains))) {
-    print "$domains{$domain}{'munindomain'}_cpu_time.label ".trim_label('pos',$domain)."\n";
-    print "$domains{$domain}{'munindomain'}_cpu_time.type DERIVE\n";
-    print "$domains{$domain}{'munindomain'}_cpu_time.cdef $domains{$domain}{'munindomain'}_cpu_time,100,*\n";
-    print "$domains{$domain}{'munindomain'}_cpu_time.min 0\n";
-    print "$domains{$domain}{'munindomain'}_cpu_time.draw AREASTACK\n";
+  if ($XEN_SKIP !~ /cput/) {
+		print "multigraph xen_cpu_time\n";
+		print "graph_title Xen domains CPU time\n";
+		print "graph_args --base 1000 -l 0\n";
+		print "graph_vlabel cpu seconds\n";
+		print "graph_scale no\n";
+		print "graph_category xen\n";
+		print "graph_info This graph shows CPU time for each Xen domain.\n";
+		for $domain (@domainlist) {
+			print "$domains{$domain}{'munindomain'}_cpu_time.label ".trim_label('pos',$domain)."\n";
+			print "$domains{$domain}{'munindomain'}_cpu_time.type DERIVE\n";
+			print "$domains{$domain}{'munindomain'}_cpu_time.cdef $domains{$domain}{'munindomain'}_cpu_time,100,*\n";
+			print "$domains{$domain}{'munindomain'}_cpu_time.min 0\n";
+			print "$domains{$domain}{'munindomain'}_cpu_time.draw AREASTACK\n";
+		}
   }
 
-  print "\nmultigraph xen_mem\n";
-  print "graph_title Xen domains memory usage\n";
-  print "graph_args --base 1024 -l 0\n";
-  print "graph_vlabel bytes\n";
-  print "graph_category xen\n";
-  print "graph_info This graph shows memory usage for each Xen domain.\n";
-  for $domain (sort(keys(%domains))) {
-    print "$domains{$domain}{'munindomain'}_mem.label ".trim_label('pos',$domain)."\n";
-    print "$domains{$domain}{'munindomain'}_mem.cdef $domains{$domain}{'munindomain'}_mem,1024,*\n";
-    print "$domains{$domain}{'munindomain'}_mem.draw AREASTACK\n";
+  if ($XEN_SKIP !~ /cpup/) {
+		print "\nmultigraph xen_cpu\n";
+		print "graph_title Xen domains CPU utilization\n";
+		print "graph_args --base 1000 -l 0 --upper-limit 100\n";
+		print "graph_vlabel %\n";
+		print "graph_scale no\n";
+		print "graph_category xen\n";
+		print "graph_info This graph shows CPU utilization for each Xen domain.\n";
+		for $domain (@domainlist) {
+			print "$domains{$domain}{'munindomain'}_cpu.label ".trim_label('pos',$domain)."\n";
+			print "$domains{$domain}{'munindomain'}_cpu.draw AREASTACK\n"
+		}
   }
 
-  print "\nmultigraph xen_net\n";
-  print "graph_title Xen domains network traffic\n";
-  print "graph_args --base 1000\n";
-  print "graph_vlabel bits per \${graph_period} in (-) / out (+)\n";
-  print "graph_category xen\n";
-  print "graph_info This graph shows network traffic for each Xen domain.\n";
-  for $domain (sort(keys(%domains))) {
-    print "$domains{$domain}{'munindomain'}_netrx.label none\n";
-    print "$domains{$domain}{'munindomain'}_netrx.cdef $domains{$domain}{'munindomain'}_netrx,8192,*\n";
-    print "$domains{$domain}{'munindomain'}_netrx.type COUNTER\n";
-    print "$domains{$domain}{'munindomain'}_netrx.graph no\n";
-    print "$domains{$domain}{'munindomain'}_nettx.label ".trim_label('neg',$domain)."\n";
-    print "$domains{$domain}{'munindomain'}_nettx.cdef $domains{$domain}{'munindomain'}_nettx,8192,*\n";
-    print "$domains{$domain}{'munindomain'}_nettx.type COUNTER\n";
-    print "$domains{$domain}{'munindomain'}_nettx.draw AREASTACK\n";
-    print "$domains{$domain}{'munindomain'}_nettx.negative $domains{$domain}{'munindomain'}_netrx\n";
+  if ($XEN_SKIP !~ /mem/) {
+		print "\nmultigraph xen_mem\n";
+		print "graph_title Xen domains memory usage\n";
+		print "graph_args --base 1024 -l 0\n";
+		print "graph_vlabel bytes\n";
+		print "graph_category xen\n";
+		print "graph_info This graph shows memory usage for each Xen domain.\n";
+		for $domain (@domainlist) {
+			print "$domains{$domain}{'munindomain'}_mem.label ".trim_label('pos',$domain)."\n";
+			print "$domains{$domain}{'munindomain'}_mem.cdef $domains{$domain}{'munindomain'}_mem,1024,*\n";
+			print "$domains{$domain}{'munindomain'}_mem.draw AREASTACK\n";
+		}
   }
 
-  print "\nmultigraph xen_disk\n";
-  print "graph_title Xen domains disk IOs\n";
-  print "graph_args --base 1000\n";
-  print "graph_vlabel IOs per \${graph_period} read (-) / write (+)\n";
-  print "graph_category xen\n";
-  print "graph_info This graph shows disk IOs for each Xen domain.\n";
-  for $domain (sort(keys(%domains))) {
-    print "$domains{$domain}{'munindomain'}_vbdrd.label none\n";
-    print "$domains{$domain}{'munindomain'}_vbdrd.type COUNTER\n";
-    print "$domains{$domain}{'munindomain'}_vbdrd.graph no\n";
-    print "$domains{$domain}{'munindomain'}_vbdwr.label ".trim_label('neg',$domain)."\n";
-    print "$domains{$domain}{'munindomain'}_vbdwr.type COUNTER\n";
-    print "$domains{$domain}{'munindomain'}_vbdwr.draw AREASTACK\n";
-    print "$domains{$domain}{'munindomain'}_vbdwr.negative $domains{$domain}{'munindomain'}_vbdrd\n";
+  if ($XEN_SKIP !~ /net/) {
+		print "\nmultigraph xen_net\n";
+		print "graph_title Xen domains network traffic\n";
+		print "graph_args --base 1000\n";
+		print "graph_vlabel bits per \${graph_period} in (-) / out (+)\n";
+		print "graph_category xen\n";
+		print "graph_info This graph shows network traffic for each Xen domain.\n";
+		for $domain (@domainlist) {
+			print "$domains{$domain}{'munindomain'}_netrx.label none\n";
+			print "$domains{$domain}{'munindomain'}_netrx.cdef $domains{$domain}{'munindomain'}_netrx,8192,*\n";
+			print "$domains{$domain}{'munindomain'}_netrx.type COUNTER\n";
+			print "$domains{$domain}{'munindomain'}_netrx.graph no\n";
+			print "$domains{$domain}{'munindomain'}_nettx.label ".trim_label('neg',$domain)."\n";
+			print "$domains{$domain}{'munindomain'}_nettx.cdef $domains{$domain}{'munindomain'}_nettx,8192,*\n";
+			print "$domains{$domain}{'munindomain'}_nettx.type COUNTER\n";
+			print "$domains{$domain}{'munindomain'}_nettx.draw AREASTACK\n";
+			print "$domains{$domain}{'munindomain'}_nettx.negative $domains{$domain}{'munindomain'}_netrx\n";
+		}
+  }
+
+  if ($XEN_SKIP !~ /disk/) {
+		print "\nmultigraph xen_disk\n";
+		print "graph_title Xen domains disk IOs\n";
+		print "graph_args --base 1000\n";
+		print "graph_vlabel IOs per \${graph_period} read (-) / write (+)\n";
+		print "graph_category xen\n";
+		print "graph_info This graph shows disk IOs for each Xen domain.\n";
+		for $domain (@domainlist) {
+			print "$domains{$domain}{'munindomain'}_vbdrd.label none\n";
+			print "$domains{$domain}{'munindomain'}_vbdrd.type COUNTER\n";
+			print "$domains{$domain}{'munindomain'}_vbdrd.graph no\n";
+			print "$domains{$domain}{'munindomain'}_vbdwr.label ".trim_label('neg',$domain)."\n";
+			print "$domains{$domain}{'munindomain'}_vbdwr.type COUNTER\n";
+			print "$domains{$domain}{'munindomain'}_vbdwr.draw AREASTACK\n";
+			print "$domains{$domain}{'munindomain'}_vbdwr.negative $domains{$domain}{'munindomain'}_vbdrd\n";
+		}
   }
 
   exit 0;
@@ -220,24 +254,40 @@ if ($ARGV[0] eq "config") {
 # Normal run
 #
 
-print "multigraph xen_cpu_time\n";
-for $domain (sort(keys(%domains))) {
-  print "$domains{$domain}{'munindomain'}_cpu_time.value $domains{$domain}{'cpusecs'}\n";
+if ($XEN_SKIP !~ /cput/) {
+	print "multigraph xen_cpu_time\n";
+	for $domain (@domainlist) {
+		print "$domains{$domain}{'munindomain'}_cpu_time.value $domains{$domain}{'cpusecs'}\n";
+	}
 }
 
-print "\nmultigraph xen_mem\n";
-for $domain (sort(keys(%domains))) {
-  print "$domains{$domain}{'munindomain'}_mem.value $domains{$domain}{'mem'}\n";
+if ($XEN_SKIP !~ /cpup/) {
+	print "\nmultigraph xen_cpu\n";
+	for $domain (@domainlist) {
+		print "$domains{$domain}{'munindomain'}_cpu.value $domains{$domain}{'cpupercent'}\n";
+	}
 }
 
-print "\nmultigraph xen_net\n";
-for $domain (sort(keys(%domains))) {
-  print "$domains{$domain}{'munindomain'}_nettx.value $domains{$domain}{'nettx'}\n";
-  print "$domains{$domain}{'munindomain'}_netrx.value $domains{$domain}{'netrx'}\n";
+if ($XEN_SKIP !~ /mem/) {
+	print "\nmultigraph xen_mem\n";
+	for $domain (@domainlist) {
+		print "$domains{$domain}{'munindomain'}_mem.value $domains{$domain}{'mem'}\n";
+	}
 }
 
-print "\nmultigraph xen_disk\n";
-for $domain (sort(keys(%domains))) {
-  print "$domains{$domain}{'munindomain'}_vbdrd.value $domains{$domain}{'vbdrd'}\n";
-  print "$domains{$domain}{'munindomain'}_vbdwr.value $domains{$domain}{'vbdwr'}\n";
+if ($XEN_SKIP !~ /net/) {
+	print "\nmultigraph xen_net\n";
+	for $domain (@domainlist) {
+		print "$domains{$domain}{'munindomain'}_nettx.value $domains{$domain}{'nettx'}\n";
+		print "$domains{$domain}{'munindomain'}_netrx.value $domains{$domain}{'netrx'}\n";
+	}
 }
+
+if ($XEN_SKIP !~ /disk/) {
+	print "\nmultigraph xen_disk\n";
+	for $domain (@domainlist) {
+		print "$domains{$domain}{'munindomain'}_vbdrd.value $domains{$domain}{'vbdrd'}\n";
+		print "$domains{$domain}{'munindomain'}_vbdwr.value $domains{$domain}{'vbdwr'}\n";
+	}
+}
+


### PR DESCRIPTION
- xenskip option to skip graph types
  env.xenskip "<space separated module list>"
  Modules: cput, cpup, mem, disk, net
- CPU percentage graph added
