### PR TITLE
esxi__sensors documentation update

### DIFF
--- a/plugins/sensors/esxi__sensors
+++ b/plugins/sensors/esxi__sensors
@@ -27,6 +27,11 @@ file:
   env.user monitor
   env.pass passw0rd
 
+To create an account just for monitoring the ESXi, add a user to the host,
+make it a member of the 'root' group, and give it the 'No access' role.
+That will allow the account to connect via WBEM, but not via any of the
+management tools.
+
 In the event that not all sensor types are desired, the plugin can be limited
 to a subset of the types available:
 


### PR DESCRIPTION
In a new deployment of the esxi__sensors plugin, I needed to create a user account for the plugin to use.  This commit documents how to do that for future users of the plugin.
