### PR TITLE
Add port number and fix process matching

### DIFF
--- a/plugins/thin/thin_memory
+++ b/plugins/thin/thin_memory
@@ -81,11 +81,12 @@ when "config"
   puts "graph_args --base 1024 -l 0"
   puts "graph_scale yes"
   puts "graph_info Tracks the size of individual thin processes"
-  mpm.get_pids.sort.each do |pid|
-    puts "thin_#{pid}.label thin_#{pid}"
-    puts "thin_#{pid}.info Process memory"
-    puts "thin_#{pid}.type GAUGE"
-    puts "thin_#{pid}.min 0"
+  mpm.get_pids.sort.each do |instance|
+    pid, port = instance.split("|")
+    puts "thin_#{port}.label thin_#{port}"
+    puts "thin_#{port}.info Process memory"
+    puts "thin_#{port}.type GAUGE"
+    puts "thin_#{port}.min 0"
   end
 when "autoconf"
   if mpm.autoconf

--- a/plugins/thin/thin_threads
+++ b/plugins/thin/thin_threads
@@ -85,11 +85,12 @@ when "config"
   puts "graph_args -l 0"
   puts "graph_scale yes"
   puts "graph_info Tracks how many threads per thin processes"
-  mpm.get_pids.sort.each do |pid|
-    puts "thin_#{pid}.label thin_#{pid}"
-    puts "thin_#{pid}.info Threads per Thin process"
-    puts "thin_#{pid}.type GAUGE"
-    puts "thin_#{pid}.min 0"
+  mpm.get_pids.sort.each do |instance|
+    pid, port = instance.split("|")    
+    puts "thin_#{port}.label thin_#{port}"
+    puts "thin_#{port}.info Threads per Thin process"
+    puts "thin_#{port}.type GAUGE"
+    puts "thin_#{port}.min 0"
   end
 when "autoconf"
   if mpm.autoconf

--- a/plugins/thin/thins_peak_memory
+++ b/plugins/thin/thins_peak_memory
@@ -83,7 +83,8 @@ when "config"
   puts "graph_args -l 0"
   puts "graph_scale yes"
   puts "graph_info Tracks the peak memory of thin processes, aka High Water Mark."
-  mpm.get_pids.sort.each do |pid,port|
+  mpm.get_pids.sort.each do |instance|
+    pid, port = instance.split("|")    
     puts "thin_#{port}.label thin_#{port}"
     puts "thin_#{port}.info Peak Memory"
     puts "thin_#{port}.type GAUGE"


### PR DESCRIPTION
Hi,

As explained [here](https://github.com/munin-monitoring/contrib/issues/256), this is a pull request which allow better readability.
Today, graph label are `thin_xxxx` where xxxx is the pid number. After each restart, pid changes so you can't collect data.
This pull request will **replace pid by port** which is static.
