### PR TITLE
New Minecraft/Bukkit plugins

### DIFF
--- a/plugins/minecraft/minecraft-jsonapi-players
+++ b/plugins/minecraft/minecraft-jsonapi-players
@@ -16,8 +16,10 @@
 
 /**
  * JSONAPI configuration
+ * (get the SDK php file here: https://github.com/alecgorge/jsonapi/raw/master/sdk/php/JSONAPI.php)
  */
 
+$apisdk   = '/var/cache/munin/JSONAPI.php';
 $hostname = 'your-hostname';
 $username = 'your-username';
 $password = 'your-password';
@@ -30,18 +32,18 @@ $port     = 20059;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / JSONAPI - players online
+  print("graph_title Bukkit / JSONAPI - players online
 graph_category bukkit_jsonapi
 graph_vlabel players
 graph_args --base 1000 -l 0
 players.type GAUGE
 players.label players
 ");
-exit();
+  exit();
 }
 
-// Include JSONAPI.php SDK (get this file here: https://github.com/alecgorge/jsonapi/raw/master/sdk/php/JSONAPI.php)
-require('/var/cache/munin/JSONAPI.php'); 
+// Include JSONAPI.php
+require($apisdk);
 
 // Prepare API call
 $api = new JSONAPI($hostname, $port, $username, $password, $salt);

--- a/plugins/minecraft/minecraft-jsonapi-ramusage
+++ b/plugins/minecraft/minecraft-jsonapi-ramusage
@@ -16,8 +16,10 @@
 
 /**
  * JSONAPI configuration
+ * (get the SDK php file here: https://github.com/alecgorge/jsonapi/raw/master/sdk/php/JSONAPI.php)
  */
 
+$apisdk   = '/var/cache/munin/JSONAPI.php';
 $hostname = 'your-hostname';
 $username = 'your-username';
 $password = 'your-password';
@@ -30,7 +32,7 @@ $port     = 20059;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / JSONAPI - RAM usage
+  print("graph_title Bukkit / JSONAPI - RAM usage
 graph_category bukkit_jsonapi
 graph_vlabel RAM usage in GB
 graph_args --base 1024 -l 0
@@ -39,11 +41,11 @@ total.type GAUGE
 used.label used
 used.type GAUGE
 ");
-exit();
+  exit();
 }
 
-// Include JSONAPI.php SDK (get this file here: https://github.com/alecgorge/jsonapi/raw/master/sdk/php/JSONAPI.php)
-require('/var/cache/munin/JSONAPI.php'); 
+// Include JSONAPI.php
+require($apisdk);
 
 // Prepare API call
 $api = new JSONAPI($hostname, $port, $username, $password, $salt);

--- a/plugins/minecraft/minecraft-jsonapi-tps
+++ b/plugins/minecraft/minecraft-jsonapi-tps
@@ -16,8 +16,10 @@
 
 /**
  * JSONAPI configuration
+ * (get the SDK php file here: https://github.com/alecgorge/jsonapi/raw/master/sdk/php/JSONAPI.php)
  */
 
+$apisdk   = '/var/cache/munin/JSONAPI.php';
 $hostname = 'your-hostname';
 $username = 'your-username';
 $password = 'your-password';
@@ -30,18 +32,18 @@ $port     = 20059;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / JSONAPI - ticks per second (TPS)
+  print("graph_title Bukkit / JSONAPI - ticks per second (TPS)
 graph_category bukkit_jsonapi
 graph_vlabel ticks per second
 graph_args --base 1000 -l 0
 tps.type GAUGE
 tps.label TPS
 ");
-exit();
+  exit();
 }
 
-// Include JSONAPI.php SDK (get this file here: https://github.com/alecgorge/jsonapi/raw/master/sdk/php/JSONAPI.php)
-require('/var/cache/munin/JSONAPI.php'); 
+// Include JSONAPI.php
+require($apisdk);
 
 // Prepare API call
 $api = new JSONAPI($hostname, $port, $username, $password, $salt);

--- a/plugins/minecraft/minecraft-sql-statistician-hostile-kills
+++ b/plugins/minecraft/minecraft-sql-statistician-hostile-kills
@@ -31,7 +31,7 @@ $port     = 3306;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / Statistician - hostile mob kills per day
+    print("graph_title Bukkit / Statistician - hostile mob kills per day
 graph_category bukkit_sql_kills
 graph_vlabel hostile mob kills per day
 graph_args --base 1000 -l 0
@@ -62,7 +62,7 @@ enderdragon.label killed ender dragons
 wither.type GAUGE
 wither.label killed withers
 ");
-exit();
+    exit();
 }
 
 ## Construct 'minumum' timstamp 

--- a/plugins/minecraft/minecraft-sql-statistician-neutral-kills
+++ b/plugins/minecraft/minecraft-sql-statistician-neutral-kills
@@ -31,7 +31,7 @@ $port     = 3306;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / Statistician - neutral mob kills per day
+    print("graph_title Bukkit / Statistician - neutral mob kills per day
 graph_category bukkit_sql_kills
 graph_vlabel neutral mob kills per day
 graph_args --base 1000 -l 0
@@ -44,7 +44,7 @@ zombiepigman.label killed zombie pigmen
 snowman.type GAUGE
 snowman.label killed snowmen
 ");
-exit();
+    exit();
 }
 
 // Construct 'minumum' timstamp 

--- a/plugins/minecraft/minecraft-sql-statistician-newplayers
+++ b/plugins/minecraft/minecraft-sql-statistician-newplayers
@@ -31,14 +31,14 @@ $port     = 3306;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / Statistician - new players per day 
+  print("graph_title Bukkit / Statistician - new players per day 
 graph_category bukkit_sql
 graph_vlabel new players per day
 graph_args --base 1000 -l 0
 players.type GAUGE
 players.label new players
 ");
-exit();
+  exit();
 }
 
 // Construct 'minumum' timstamp 

--- a/plugins/minecraft/minecraft-sql-statistician-passive-kills
+++ b/plugins/minecraft/minecraft-sql-statistician-passive-kills
@@ -31,7 +31,7 @@ $port     = 3306;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / Statistician - passive mob kills per day
+    print("graph_title Bukkit / Statistician - passive mob kills per day
 graph_category bukkit_sql_kills
 graph_vlabel passive mob kills per day
 graph_args --base 1000 -l 0
@@ -54,7 +54,7 @@ squid.label killed squids
 villager.type GAUGE
 villager.label killed villager
 ");
-exit();
+    exit();
 }
 
 // Construct 'minumum' timstamp 

--- a/plugins/minecraft/minecraft-sql-ultrabans-shame
+++ b/plugins/minecraft/minecraft-sql-ultrabans-shame
@@ -32,7 +32,7 @@ $port     = 3306;
 
 if ((count($argv) > 1) && ($argv[1] == 'config'))
 {
-print("graph_title Bukkit / Ultrabans - shame per day 
+    print("graph_title Bukkit / Ultrabans - shame per day 
 graph_category bukkit_sql
 graph_vlabel amount of shame per day
 graph_args --base 1000 -l 0
@@ -55,7 +55,7 @@ permban.label permbans
 mute.type GAUGE
 mute.label mutes
 ");
-exit();
+    exit();
 }
 
 // Construct 'minumum' timstamp 


### PR DESCRIPTION
Added several Minecraft/Bukkit plugins (depending on JSONAPI, Statistician and Ultrabans) to show 
- the current online players
- the RAM usage
- the current TPS (ticks per second)
- hostile/neutral/passive mob kills per day
- new players/visitors per day
- kicks/ban/mutes/jail/unban/etc. per day

http://s.frd.mn/XJsryR for more informations
