### PR TITLE
[FIX] apache_byprojects/byprojects_access: missing \n.

### DIFF
--- a/plugins/apache/apache_byprojects/byprojects_access
+++ b/plugins/apache/apache_byprojects/byprojects_access
@@ -55,7 +55,7 @@ if(defined($ARGV[0])) {
     print "graph_category $server\n";
     print "graph_info This graph show $server access by various projects.\n";
     while ((my $project, my @files) = each(%logs)) {
-      print $project.".label $project";
+      print $project.".label $project\n";
       print $project.".type DERIVE\n";
       print $project.".min 0\n";
     }


### PR DESCRIPTION
A missing \n was fucking up `byprojects_access config`.
