### PR TITLE
Tweaks for system/pagefaults_by_process

### DIFF
--- a/plugins/system/pagefaults_by_process
+++ b/plugins/system/pagefaults_by_process
@@ -74,12 +74,12 @@ foreach my $process (keys %total_by_process)
 
 close(PS);
 
-if (@ARGV and $ARGV[1] eq "config")
+if (@ARGV and $ARGV[0] eq "config")
 {
 	print <<END;
 graph_title Page faults by Process
 graph_args --base 1000
-graph_vlabel seconds
+graph_vlabel major page faults
 graph_category system
 graph_info Shows number of major page faults caused by each process name
 END


### PR DESCRIPTION
The plugin did not work as is with munin 2.0.6. The follow tweaks appear to get it working again.
1. The vlabel was changed from 'seconds' to 'major page faults.'
2. The script was using ARGV[1] which was throwing a warning. I switched it to ARGV[0] and it appears fixed.

Thanks!

Jesse
