### PR TITLE
fix cpu_by_process time parser

### DIFF
--- a/plugins/system/cpu_by_process
+++ b/plugins/system/cpu_by_process
@@ -60,7 +60,12 @@ while (<PS>)
 	$process =~ tr|a-zA-Z0-9|_|c;
 
 	my @times = split /:/, $cputime;
-	$cputime = (($times[0] * 60) + $times[1]) * 60 + $times[2];
+	my @days = split /-/, $times[0];
+	if ($days[1]) {
+		$cputime = ((($days[0] * 24) + $days[1]) * 60 + $times[1]) * 60 + $times[2];
+	} else {
+		$cputime = (($times[0] * 60) + $times[1]) * 60 + $times[2];
+	}
 	$total_cpu_by_process{$process} += $cputime;
 }
 


### PR DESCRIPTION
cumulated CPU time is in [DD-]hh:mm:ss format
