### PR TITLE
Fixes plugins/network/bandwidth_ initialization for first runs

### DIFF
--- a/plugins/network/bandwidth_
+++ b/plugins/network/bandwidth_
@@ -88,7 +88,6 @@ init();
 sub autoconf {
     $0 =~ /bandwidth_(.+)*$/;
     $interface = $1;
-    exit 2 unless defined $interface;
     $history = "/var/lib/munin/plugin-state/bandwidth_$interface.state";
 }
 
@@ -281,8 +280,9 @@ sub munin_output {
 }
 
 sub init {
-    arg();
     autoconf();
+    arg();
+    exit 2 unless defined $interface;
     retrieve_history();
     read_traffic();
     bit32or64();


### PR DESCRIPTION
Previously the script would try to divide by 0 for calculating rates
on the first run, and crash before getting to store() to write initial
values thus never initing itself. This fixes that, and makes it a
little easier to debug in case of future crashes (no need for 'eval'
wrapper).
