### PR TITLE
Update psad plugin to use DERIVE

### DIFF
--- a/plugins/network/psad
+++ b/plugins/network/psad
@@ -88,12 +88,14 @@ attacks_logged.label Scans detected per hour
 attacks_logged.draw LINE1
 attacks_logged.warning 10
 attacks_logged.critical 20
-attacks_logged.type COUNTER
+attacks_logged.type DERIVE
+attacks_logged.min 0
 attacks_logged.cdef attacks_logged,12,*
 
 autoblocks_logged.label Auto-blocks per hour
 autoblocks_logged.draw LINE1
-autoblocks_logged.type COUNTER
+autoblocks_logged.type DERIVE
+autoblocks_logged.min 0
 autoblocks_logged.cdef autoblocks_logged,12,*
 
 EOM


### PR DESCRIPTION
"psad" plugin updated to use DERIVE, with zero minimum value.
As per suggestion from Kenyon.

Thanks!
Dave Driesen
