### PR TITLE
php_fpm_process update

### DIFF
--- a/plugins/php/php_fpm_process
+++ b/plugins/php/php_fpm_process
@@ -3,7 +3,7 @@
 
 =head1 NAME
 
-php_fpm_processes - Munin plugin to show number of number of use processes on php-fpm.
+php_fpm_process - Munin plugin to show number of number of use processes on php-fpm.
 
 
 Inspirated by php5-fpm_status plugin by Daniel Caillibaud
@@ -77,31 +77,6 @@ if (!$sock) {
 	        ''
 	);
 
-
-if ( defined $ARGV[0] and $ARGV[0] eq "config" )
-{
-
-  print "graph_title php5-fpm status $pool";
-  print "graph_args --base 1000 -l 0";
-  print "graph_vlabel Processes";
-  print "graph_scale yes";
-  print "graph_category php";
-  print "graph_info This graph shows the php5-fpm process manager status from pool: $pool";
-  print "active.label Active processes";
-  print "active.type GAUGE";
-  print "active.draw AREA";
-  print "active.info The number of active processes";
-  print "idle.label Idle processes";
-  print "idle.type GAUGE";
-  print "idle.draw STACK";
-  print "idle.info The number of idle processes";
-  print "total.label Total processes";
-  print "total.type GAUGE";
-  print "total.draw LINE2";
-  print "total.info The number of idle + active processes";
-  exit 0
-}
-
 $stdout =~ s/\r//g;
 
 while($stdout =~ /([^\n]*)\n?/g) {
@@ -114,6 +89,34 @@ while($stdout =~ /([^\n]*)\n?/g) {
 	} else {
 		$body .= $1."\n";
 	}
+}
+
+if ( defined $ARGV[0] and $ARGV[0] eq "config" )
+{
+ 
+  if($body =~ m/pool:\s+(.*?)\n/) {
+    $pool = $1;
+  }
+
+  print "graph_title php5-fpm status $pool\n";
+  print "graph_args --base 1000 -l 0\n";
+  print "graph_vlabel Processes\n";
+  print "graph_scale yes\n";
+  print "graph_category php\n";
+  print "graph_info This graph shows the php5-fpm process manager status from pool: $pool\n";
+  print "active.label Active processes\n";
+  print "active.type GAUGE\n";
+  print "active.draw AREA\n";
+  print "active.info The number of active processes\n";
+  print "idle.label Idle processes\n";
+  print "idle.type GAUGE\n";
+  print "idle.draw STACK\n";
+  print "idle.info The number of idle processes\n";
+  print "total.label Total processes\n";
+  print "total.type GAUGE\n";
+  print "total.draw LINE2\n";
+  print "total.info The number of idle + active processes\n";
+  exit 0
 }	
 
 if($body =~ m/idle processes: (.*?)\n/) {


### PR DESCRIPTION
- The name in =head1 did not match the filename.
- The $pool-variable was used in the config-section, but was never initialized. It is now extracted from the fcgi-response.
