### PR TITLE
Fix indexcounters and globallock in 2.2 and 2.4 version

### DIFF
--- a/plugins/mongodb/mongo_btree
+++ b/plugins/mongodb/mongo_btree
@@ -16,7 +16,11 @@ def getServerStatus():
     return json.loads( raw )["serverStatus"]
 
 def get():
-    return getServerStatus()["indexCounters"]["btree"]
+    status = getServerStatus()
+    if status["version"] >= "2.4.0":
+        return getServerStatus()["indexCounters"]
+    else:
+        return getServerStatus()["indexCounters"]["btree"]
 
 def doData():
     for k,v in get().iteritems():

--- a/plugins/mongodb/mongo_lock
+++ b/plugins/mongodb/mongo_lock
@@ -18,7 +18,12 @@ def getServerStatus():
 name = "locked"
 
 def doData():
-    print name + ".value " + str( 100 * getServerStatus()["globalLock"]["ratio"] )
+    status = getServerStatus()
+    if status["version"] >= "2.2.0":
+        ratio = status["globalLock"]["lockTime"] / status["globalLock"]["totalTime"]
+    else:
+        ratio = status["globalLock"]["ratio"]
+    print name + ".value " + str( 100 * ratio )
 
 def doConfig():
 


### PR DESCRIPTION
btree sub-document has been removed in 2.4 :
http://docs.mongodb.org/manual/reference/command/serverStatus/#serverStatus.indexCounters

ratio sub-document has been removed in 2.2
http://docs.mongodb.org/manual/reference/command/serverStatus/#serverStatus.globalLock.ratio
