### PR TITLE
Added new non Ruby based Unicorn Plugin

### DIFF
--- a/plugins/unicorn/unicorn_
+++ b/plugins/unicorn/unicorn_
@@ -25,7 +25,7 @@ if [ "$mode" = "memory" ]; then
 
         for i in "${memory_array[@]}"
             do
-                 sum=$(( $sum + $i ))
+                 sum=$(( $sum + ( $i * 1024) ))
         done
                  echo -n "ram.value "
                  echo $sum


### PR DESCRIPTION
The existing Unicorn plugins are written in Ruby, which didn't work well for me due to ENV variables etc.

This plugin monitors number of workers, total memory used and average memory per process for Unicorn.

ln -s /usr/share/munin/plugins/unicorn_ /etc/munin/plugins/unicorn_average
ln -s /usr/share/munin/plugins/unicorn_ /etc/munin/plugins/unicorn_memory
ln -s /usr/share/munin/plugins/unicorn_ /etc/munin/plugins/unicorn_processes

It can easily be adapated to any multi threaded server by just changing the value it searches for 'unicorn worker' in this case.
