### PR TITLE
Fix getenv usage in swift plugins

### DIFF
--- a/plugins/swift/swift-async_
+++ b/plugins/swift/swift-async_
@@ -43,6 +43,6 @@ try:
 except IndexError:
     pass
 
-async_r = requests.get("http://%s:%d/recon/async" \
-                           % (swift_server, os.getenv("SWIFT_OBJECT_PORT", 6000)))
+async_r = requests.get("http://%s:%s/recon/async" \
+                           % (swift_server, os.getenv("SWIFT_OBJECT_PORT", "6000")))
 print "async_pending.value %d" % json.loads(async_r.text)['async_pending']

--- a/plugins/swift/swift-quarantined_
+++ b/plugins/swift/swift-quarantined_
@@ -49,8 +49,8 @@ try:
 except IndexError:
     pass
 
-quarantined = json.loads(requests.get("http://%s:%d/recon/quarantined" \
-                                          % (swift_server, os.getenv("SWIFT_OBJECT_PORT", 6000))).text)
+quarantined = json.loads(requests.get("http://%s:%s/recon/quarantined" \
+                                          % (swift_server, os.getenv("SWIFT_OBJECT_PORT", "6000"))).text)
 print "quarantined_objects.value %d" % quarantined['objects']
 print "quarantined_containers.value %d" % quarantined['containers']
 print "quarantined_accounts.value %d" % quarantined['accounts']

--- a/plugins/swift/swift-replication-time_
+++ b/plugins/swift/swift-replication-time_
@@ -43,6 +43,6 @@ try:
 except IndexError:
     pass
 
-replication_r = requests.get("http://%s:%d/recon/replication" \
-                                 % (swift_server, os.getenv("SWIFT_OBJECT_PORT", 6000)))
+replication_r = requests.get("http://%s:%s/recon/replication" \
+                                 % (swift_server, os.getenv("SWIFT_OBJECT_PORT", "6000")))
 print "object_replication_time.value %f" % json.loads(replication_r.text)['object_replication_time']


### PR DESCRIPTION
os.getenv returns a string, not an integer, so using %s will fail if the 
variable SWIFT_OBJECT_PORT is set.
