### PR TITLE
Fix syslog ng stat

### DIFF
--- a/plugins/syslog/syslog_ng_stats
+++ b/plugins/syslog/syslog_ng_stats
@@ -2,12 +2,13 @@
 
 =head1 NAME
 
-syslog_ng_stats - Plugin for syslog-ng use C<syslog-ng-ctl> utility to
-make grapths.
+syslog_ng_stats - Plugin for syslog-ng.
+It uses the C<syslog-ng-ctl> utility to grab values.
 
 =head1 DESCRIPTION
 
-See C<man syslog-ng-ctl> for C<stats> option. All options used as regexp.
+See C<man syslog-ng-ctl> for the C<stats> option.
+All options used are regexp.
 
 =over
 


### PR DESCRIPTION
@rshadow: This is a complement to munin-monitoring/contrib#301.

I cannot send it to dr-co/contrib:master as it isn't recognised.
