### PR TITLE
Update date format between auth.log and linux system date

### DIFF
--- a/plugins/system/auth
+++ b/plugins/system/auth
@@ -53,13 +53,15 @@ if [ ! -r $STAT_FILE ]; then
 	echo "AUT=0" >> $STAT_FILE
 	echo "VAL=0" >> $STAT_FILE
 fi
+
+TODAY="`date '+%b'` `date '+%d' | sed 's/0\([0-9]\)/ \1/'`"
 #############################
 
 #############################
 # Illegal User
 #############################
 echo -en "illegal_user.value "
-NEW_ILL=$(grep "Illegal user\|no such user" /var/log/auth.log | grep "`date '+%b %d'`" | wc -l)
+NEW_ILL=$(grep "Illegal user\|no such user" /var/log/auth.log | grep "^$TODAY" | wc -l)
 OLD_ILL=$(grep ILL $STAT_FILE | cut -f2 -d '=')
 ILL=$($EXPR_BIN $NEW_ILL - $OLD_ILL)
 if [ $ILL -gt 0 ]; then
@@ -72,7 +74,7 @@ echo -n
 # Possible Breakins
 #############################
 echo -en "possible_breakin.value "
-NEW_POS=$(grep -i "breakin attempt" /var/log/auth.log | grep "`date '+%b %d'`" | wc -l)
+NEW_POS=$(grep -i "breakin attempt" /var/log/auth.log | grep "^$TODAY" | wc -l)
 OLD_POS=$(grep POS $STAT_FILE | cut -f2 -d '=')
 POS=$($EXPR_BIN $NEW_POS - $OLD_POS)
 if [ $POS -gt 0 ]; then
@@ -85,7 +87,7 @@ echo -n
 # Authentication Failures
 #############################
 echo -en "authentication_failure.value "
-NEW_AUT=$(grep "authentication failure" /var/log/auth.log | grep "`date '+%b %d'`" | wc -l)
+NEW_AUT=$(grep "authentication failure" /var/log/auth.log | grep "^$TODAY" | wc -l)
 OLD_AUT=$(grep AUT $STAT_FILE | cut -f2 -d '=')
 AUT=$($EXPR_BIN $NEW_AUT - $OLD_AUT)
 if [ $AUT -gt 0 ]; then
@@ -98,7 +100,7 @@ echo -n
 # Valid Logins
 #############################
 echo -en "valid_login.value "
-NEW_VAL=$(grep "sshd.*Accepted" /var/log/auth.log | grep "`date '+%b %d'`" | wc -l)
+NEW_VAL=$(grep "sshd.*Accepted" /var/log/auth.log | grep "^$TODAY" | wc -l)
 OLD_VAL=$(grep VAL $STAT_FILE | cut -f2 -d '=')
 VAL=$($EXPR_BIN $NEW_VAL - $OLD_VAL)
 if [ $VAL -gt 0 ]; then


### PR DESCRIPTION
I noticed a problem with date format on /var/log/auth.log (tested on debian and ubuntu)

$ date '+%b %d'
Jun 09

/var/log/auth.log
Jun  9 13:17:01

So    grep "`date '+%b %d'`"    can't works fine for day with 1 digit.

I suggest to factorize and change the grep's regex with my update.
