### PR TITLE
various improvements on Puppetmaster  plugin

### DIFF
--- a/plugins/puppet/puppetmaster
+++ b/plugins/puppet/puppetmaster
@@ -1,5 +1,28 @@
 #!/usr/bin/ruby
 
+# this plugin reports various performance statistics from a puppetmaster
+# server and client
+#
+# linked as puppet_mem, it will display memory usage of the puppet
+# client and puppet master on the local server.
+#
+# linked as puppet_clients, it will report the average compile time, the
+# number of clients that checked in in the last 5 minutes and 24h and
+# the number of known clients.
+#
+# it requires read access to the puppet logfile.
+#
+# CONFIGURATION
+#
+# [puppet*]
+# env.puppet_logfile /var/log/message
+# env.puppet_logformat "^%b %d"
+#
+# the logfile is where the puppetmaster is expected to log its
+# compilation statistics. the format is the format of the date syslog
+# writes to the file, which may vary according to locale and
+# configuration.
+
 # returns the mem usage of a given process
 def plist(psname)
 	counter = 0


### PR DESCRIPTION
This pull request does three distinct things:
- use `/usr/bin/ruby` as an interpreter instead of `/bin/env`, which doesn't exist in Debian (it's in /usr/bin/env) - and I think it's fair to assume that /usr/bin/ruby exists
- allow the date format to be overriden _and_ use the default one that is used in Debian
- clarify that compile time is in seconds
