### PR TITLE
Fix Prosody Registered Users

### DIFF
--- a/plugins/prosody/prosody_
+++ b/plugins/prosody/prosody_
@@ -166,7 +166,7 @@ def main():
                     if mode == "config":
                         print "%s.label %s" % (munin_var, vhost)
                     else:
-                        accounts = len([listfiles(account_dir)])
+                        accounts = len(list(listfiles(account_dir)))
                         print "%s.value %s" % (munin_var, accounts)
 
 def listdirs(folder):


### PR DESCRIPTION
I use python 2.6 & python 2.7 
len([listfiles(account_dir)])
returns everytime 1

The generator must be executed to get the corrent number of registed users.

(don't test with python3)
