### PR TITLE
Http request time timeout

### DIFF
--- a/plugins/http/http_request_time
+++ b/plugins/http/http_request_time
@@ -57,7 +57,8 @@ if (! eval "require LWP::UserAgent;")
 my %URLS;
 
 # timeout in seconds for requests
-my $timeout = $ENV{'timeout'} || 15;
+# slightly lower than the default global timeout (5 seconds)
+my $timeout = $ENV{'timeout'} || 3;
 
 for (my $i = 1; $ENV{"url$i"}; $i++)
 {


### PR DESCRIPTION
There are timeouts used in this plugin, but they are hardcoded. It would be good if they would be customizable.
