### PR TITLE
don't depend on sudo to run pfctl

### DIFF
--- a/plugins/network/pf_bytes
+++ b/plugins/network/pf_bytes
@@ -66,7 +66,7 @@ END {
 	;;
 esac
 
-sudo pfctl -sl | awk '
+pfctl -sl | awk '
 BEGIN {
  total=0
 }

--- a/plugins/network/pf_packets
+++ b/plugins/network/pf_packets
@@ -77,7 +77,7 @@ END {
 	;;
 esac
 
-sudo pfctl -sl | awk '
+pfctl -sl | awk '
 BEGIN {
  total=0
 }


### PR DESCRIPTION
we should assume plugin is correctly configured, as munin-node can run
plugins as root
