### PR TITLE
relayd: adjust PATH properly

### DIFF
--- a/plugins/relayd/relayd
+++ b/plugins/relayd/relayd
@@ -62,6 +62,7 @@ need_multigraph();
 
 (defined($ENV{'logfile'})) and $logfile = $ENV{'logfile'};
 (defined($ENV{'configfile'})) and $configfile = $ENV{'configfile'};
+$ENV{'PATH'} .= ':/usr/local/sbin';
 
 my $cmd = (defined($ARGV[0])) ? $ARGV[0] : '';
 


### PR DESCRIPTION
in FreeBSD, relayd is more likely installed in /usr/local/sbin.
