### PR TITLE
Monitor SSL certificate expiry

### DIFF
--- a/plugins/ssl/ssl_
+++ b/plugins/ssl/ssl_
@@ -46,7 +46,7 @@ case $1 in
         ;;
 esac
 
-cert=$(echo "" | openssl s_client -CApath /etc/ssl/certs -connect "${SITE}:443" 2>/dev/null);
+cert=$(echo "" | openssl s_client -CApath /etc/ssl/certs -servername "${SITE}" -connect "${SITE}:443" 2>/dev/null);
 
 if [[ "${cert}" = *"-----BEGIN CERTIFICATE-----"* ]]; then
   echo "${cert}" | openssl x509 -noout -enddate | awk -F= 'BEGIN { split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec", month, " "); for (i=1; i<=12; i++) mdigit[month[i]] = i; } /notAfter/ { split($0,a,"="); split(a[2],b," "); split(b[3],time,":"); datetime=b[4] " " mdigit[b[1]] " " b[2] " " time[1] " " time[2] " " time[3]; days=(mktime(datetime)-systime())/86400; print "expire.value " days; }'


### PR DESCRIPTION
- Watches SSL certificate validity (http://grokbase.com/t/sf/munin-users/12ay29j7ae/plugin-to-check-ssl-cert-validity) 
- in use: https://munin.buddycloud.com/ssl-day.html
- now also checks the right cert rather than the first vhost's cert.
