### PR TITLE
- Fixed key that was based on $index and no unique name (when you change...

### DIFF
--- a/plugins/network/multiping
+++ b/plugins/network/multiping
@@ -22,12 +22,12 @@
 #
 # Parameters:
 #
-# 	ping_args      - Arguments to ping (default "-c 2 -w 1")
-# 	ping_args2     - Arguments after the host name (required for Solaris)
-# 	ping           - Ping program to use
-# 	hosts          - List of comma-separated hosts to ping (IP address or FQDN)
-# 	names          - Friendly display name of each host given in the "hosts" parameter (comma-separated list).
-# 	                 If not set, "hosts" elements will be used
+#   ping_args      - Arguments to ping (default "-c 2 -w 1")
+#   ping_args2     - Arguments after the host name (required for Solaris)
+#   ping           - Ping program to use
+#   hosts          - List of comma-separated hosts to ping (IP address or FQDN)
+#   names          - Friendly display name of each host given in the "hosts" parameter (comma-separated list).
+#                    If not set, "hosts" elements will be used
 #
 # Arguments for Solaris:
 #      ping_args      -s
@@ -58,45 +58,49 @@ my $ping_args = exists $ENV{ping_args} ? $ENV{ping_args} : '-c 2 -w 1';
 my $ping_args2 = exists $ENV{ping_args2} ? $ENV{ping_args2} : '';
 
 if ($#hosts != $#names) {
-	print "unequal amount of hosts and names\n";
-	exit 1;
+  print "unequal amount of hosts and names\n";
+  exit 1;
 }
 
 if ((exists $ARGV[0]) && ($ARGV[0] eq "autoconf")) {
-	my @ping = `$ping_cmd $ping_args $hosts[0] $ping_args2`;
-	chomp @ping;
-	my $ping = join(" ", @ping);
-	if ($ping =~ m@min/avg/max@) {
-		print "yes\n";
-		exit 0;
-	} else {
-		print "no\n";
-		exit 1;
-	}
+  my @ping = `$ping_cmd $ping_args $hosts[0] $ping_args2`;
+  chomp @ping;
+  my $ping = join(" ", @ping);
+  if ($ping =~ m@min/avg/max@) {
+    print "yes\n";
+    exit 0;
+  } else {
+    print "no\n";
+    exit 1;
+  }
 }
 
 if ((exists $ARGV[0]) && ($ARGV[0] eq "config")) {
-	print "graph_title Ping times\n";
-	print "graph_args --base 1000 -o\n";
-	print "graph_vlabel seconds\n";
-	print "graph_category network\n";
-	print "graph_info This graph shows ping RTT statistics.\n";
-    for (my $site=1; $site<=$#hosts+1; $site++) {
-		print "site$site.label $names[$site-1]\n";
-		print "site$site.info Ping RTT statistics for $hosts[$site-1].\n";
-		print "site$site.draw LINE2\n";
-		print "site${site}_packetloss.label $names[$site-1] packet loss\n";
-		print "site${site}_packetloss.graph no\n";
-	}
+  print "graph_title Ping times\n";
+  print "graph_args --base 1000 -o\n";
+  print "graph_vlabel seconds\n";
+  print "graph_category network\n";
+  print "graph_info This graph shows ping RTT statistics.\n";
+  for (my $site=1; $site<=$#hosts+1; $site++) {
+    my $item = lc($hosts[$site-1]); 
+    $item =~ s/\.//g;
+    print "$item.label $names[$site-1]\n";
+    print "$item.info Ping RTT statistics for $hosts[$site-1].\n";
+    print "$item.draw LINE2\n";
+    print "${item}_packetloss.label $names[$site-1] packet loss\n";
+    print "${item}_packetloss.graph no\n";
+  }
     exit 0;
 }
 
 for (my $site=1; $site<=$#hosts+1; $site++) {
-	my $host = $hosts[$site-1];
-	my @ping = `$ping_cmd $ping_args $host $ping_args2`;
-	chomp @ping;
-	my $ping = join(" ", @ping);
-	print "site".$site.".value ".($1 / 1000)."\n" if ($ping =~ m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@);
-	print "site".$site."_packetloss.value $1\n" if ($ping =~ /(\d+)% packet loss/);
+  my $item = lc($hosts[$site-1]); 
+  $item =~ s/\.//g;
+  my $host = $hosts[$site-1];
+  my @ping = `$ping_cmd $ping_args $host $ping_args2`;
+  chomp @ping;
+  my $ping = join(" ", @ping);
+  print $item.".value ".($1 / 1000)."\n" if ($ping =~ m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@);
+  print $item."_packetloss.value $1\n" if ($ping =~ /(\d+)% packet loss/);
 }
 


### PR DESCRIPTION
Before: 

```
site1.value 0.085273
site1_packetloss.value 0
site2.value 0.056873
site2_packetloss.value 0
```

When you changed URL1, stats for old URL1 were still displayed.

Now:

```
wwwgooglecom.value 0.085273
wwwgooglecom_packetloss.value 0
wwwyahoocom.value 0.056873
wwwyahoocom_packetloss.value 0
```

Now stats is attached to URL, so if URL change, it will be a new stat.
Label can be changed without any problem.
