### PR TITLE
Fix mediawiki_api when called with admins arg

### DIFF
--- a/plugins/wiki/mediawiki_api
+++ b/plugins/wiki/mediawiki_api
@@ -134,7 +134,8 @@ print "images.value $value\n";
 break;
 
 case "admins":
-print "admins.value $admins\n";
+print "admins.value $value\n";
+break;
 
 default:
 print "link me as mediawiki_<type>, where type can be one of: views, edits, articles, pages, users, images or admins. \n";


### PR DESCRIPTION
Fix the mediawiki_api plugin (that should be named mediawiki_, for the record).
It was not working when querying admins.
It was using wrong var and was missing a break
Tested successfully
