### PR TITLE
Changed interpreter from /bin/sh to bash

### DIFF
--- a/plugins/processes/process_count
+++ b/plugins/processes/process_count
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Plugin to monitor CPU usage, for a selected set of processes. Tested on Linux.
 #


### PR DESCRIPTION
"cproc=${proc//[^A-Za-z0-9_]/_}" would break the script (Bad Substitution errors) on my Debian Wheezy system. Changed the interpreter to bash and script began to run without issue.
