### PR TITLE
fork the mysql_connections plugin to add per-user support

### DIFF
--- a/plugins/mysql/mysql_connections_per_user
+++ b/plugins/mysql/mysql_connections_per_user
@@ -63,15 +63,13 @@ my $arg = shift();
 # Check to see how the script was called 
 if ($arg eq 'config') {
     print_graph_information();
-    exit();
 } elsif ($arg eq 'autoconf') {
     if (test_service()) { print "yes\n"; }
     else { print "no\n"; }
-    exit;
 } else {
     print_graph_data();
-    exit;
 }
+exit;
 
 sub print_graph_data() {
 	# Define the values that are returned to munin


### PR DESCRIPTION
This is very similar to the mysql_connections plugin, but I figured it could be too intense for some servers to make it default.
