### PR TITLE
Minor mailman-queue-check changes

### DIFF
--- a/plugins/mail/mailman-queue-check
+++ b/plugins/mail/mailman-queue-check
@@ -17,6 +17,7 @@
 
 if [ "$1" = "config" ]; then
   echo "graph_title Mailman Queue"
+  echo "graph_category mailman"
   echo "graph_args --base 1000 -l 0"
   echo "archive.label Archive"
   echo "archive.draw LINE2"


### PR DESCRIPTION
`mailman-queue-check` wasn't in the `plugins/mail/` folder (it was in `plugins/other/`), and didn't have a `graph_category`. This fixes that
