### PR TITLE
append newline to support _mem and multiple GPUs

### DIFF
--- a/plugins/gpu/nvidia_gpu_
+++ b/plugins/gpu/nvidia_gpu_
@@ -180,7 +180,7 @@ case $name in
 			totalMemGpu=`echo "$totalMemGpus" | sed -n $(( $nGpusCounter + 1 ))p`
 			usedMemGpu=`echo "$usedMemGpus" | sed -n $(( $nGpusCounter + 1 ))p`
 			percentMemUsed=$(( $usedMemGpu * 100 / $totalMemGpu ))
-			valueGpus="${valueGpus}${percentMemUsed}"
+			valueGpus="${valueGpus}${percentMemUsed}"$'\n'
 			: $(( nGpusCounter = $nGpusCounter + 1 ))
 		done
 		;;


### PR DESCRIPTION
Memory used percentages were being concatenated into a single string if multiple GPUs were present, e.g. both using 30% would print mem0.value 3030 mem1.value
