### PR TITLE
Update slush_hashrate_

### DIFF
--- a/plugins/bitcoin/slush_hashrate_
+++ b/plugins/bitcoin/slush_hashrate_
@@ -1,13 +1,16 @@
 #!/usr/bin/python
 # based on https://github.com/pdbrown/munin-custom/blob/master/plugins/hashrate
 # improved by @deveth0 (donation to 1GzHgp9hsDRsf96MnVk2oo6EG1VmWP9jGs :) )
-# usage: link to slush_hashrate_YOURAPIKEY
+# usage: set your api key in node-config, eg
+# [slush_*]
+# env.apikey foobar
 import sys
 import urllib2
 import json
+import os
 
 SLUSH_URL = 'https://mining.bitcoin.cz/accounts/profile/json/'
-API_KEY =  sys.argv[0][(sys.argv[0].rfind('_')+1):]
+API_KEY = os.getenv('apikey')
 SLUSH_STATS = SLUSH_URL + API_KEY
 
 mining_stats_raw = urllib2.urlopen(SLUSH_STATS)


### PR DESCRIPTION
Moved from filename to env parameter for the api key. This way the api key is no longer displayed as the chart name
