### PR TITLE
fix example comment with proper wildcard examples

### DIFF
--- a/plugins/disk/megaraid-controller-information
+++ b/plugins/disk/megaraid-controller-information
@@ -5,7 +5,7 @@
 # 
 #---------------------
 # Examples
-# Create a symbolic link to MegaRaid_<AdapterNumber>_<temp|media|other|predictive>
+# Create a symbolic link to MegaRaid_<AdapterNumber>_<temp|error|other|predictive>
 #       ln -s /usr/share/munin/plugins/MegaRaid_ /etc/munin/plugins/MegaRaid_0_temp
 #           graph temperature on adapter 0
 # 


### PR DESCRIPTION
removed media in favor of error - since valid wildcard values are temp, error, other, predictive
