### PR TITLE
Add ServerQuery login support to ts3v2 plugin

### DIFF
--- a/plugins/teamspeak/ts3v2_
+++ b/plugins/teamspeak/ts3v2_
@@ -54,7 +54,6 @@ if ($password ne "") {
   my $response = $telnet->getline(Timeout=>1);
   if ($response !~ "error id=0 msg=ok") {
         $telnet->close;
-        print("Test: ".($response eq "error id=0 msg=ok"));
         die "ServerQuery login failed: ".$response;
   }
 }


### PR DESCRIPTION
Some servers require a login before allowing to fetch server data over telnet.
This patch adds optional parameters (user, password) to do this and changes the default value of hostname to something more useful.

I'm no Perl programmer, so maybe someone should look over my changes.
