### PR TITLE
Enhanced used memory calculation for values displayed in G

### DIFF
--- a/plugins/system/dar_memusage
+++ b/plugins/system/dar_memusage
@@ -88,13 +88,13 @@ for ( $i = 1;  ($i < $#top and $quit == 0); $i++ ) {
 		$active =~ s/^.+?, (\d+)M active.+$/$1/; chomp $active; $active = $active * 1024 * 1024;
 		$inactive =~ s/^.+?, (\d+)M inactive.+$/$1/; chomp $inactive; $inactive = $inactive * 1024 * 1024;
 		$free =~ s/^.+?, (\d+)([M|K]) free.+$/$1/; chomp $free; $free = $free * 1024 * 1024; if ( $2 eq "K" ) { $free = $free / 1024; }
-		$used =~ s/^.+?, (\d+)M used.+$/$1/; chomp $used; $used = $used * 1024 * 1024;
+		$used =~ s/^.+?, (\d+)([M|G]) used.+$/$1/; chomp $used; $used = $used * 1024 * 1024; if ( $2 eq "G" ) { $used = $used * 1024; }
 		print "wired.value " . $wired . "\n";
 		print "active.value " . $active . "\n";
 		print "inactive.value " . $inactive . "\n";
 		print "free.value " . $free . "\n";
 		print "used.value " . $used . "\n";
-		$quit = 1; 
+		$quit = 1;
 	}
 }
 


### PR DESCRIPTION
I encountered errors with this plugin and figured out my system displayed G-values instead of the expected M-values for used memory readout. I simply fixed this by adding a conditional calculation.
