### PR TITLE
Use /usr/bin/env bash in shebang for portability

### DIFF
--- a/plugins/nfs-freebsd/nfs_client
+++ b/plugins/nfs-freebsd/nfs_client
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- sh -*-
 
 : << =cut

--- a/plugins/nfs-freebsd/nfs_client_cache
+++ b/plugins/nfs-freebsd/nfs_client_cache
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- sh -*-
 
 : << =cut

--- a/plugins/nfs-freebsd/nfsd
+++ b/plugins/nfs-freebsd/nfsd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- sh -*-
 
 : << =cut


### PR DESCRIPTION
Since there's no `/bin/bash` on FreeBSD, it's preferable to use `/usr/bin/env bash` so `/usr/local/bin/bash` is used instead.

You might also need to set the `PATH` variable in the Munin plugin configuration file, depending on how your environment is set up.

```
[nfs*]
env.PATH /usr/bin:/usr/local/bin
```
