### PR TITLE
Unicorn memory status fixes

### DIFF
--- a/plugins/unicorn/unicorn_memory_status
+++ b/plugins/unicorn/unicorn_memory_status
@@ -49,7 +49,7 @@ module Munin
       ps_output = `ps auxw | grep unicorn`
       ps_output.split("\n").each do |line|
         chunks = line.strip.split(/\s+/, 11)
-        pid, pmem_rss, pcmd = chunks.values_at(1, 5, 10)
+        pid, pmem_rss, _ = chunks.values_at(1, 5, 10)
         pmem = pmem_rss.to_i * 1024
         pid = pid.to_i
 


### PR DESCRIPTION
If using the `unicorn` command instead `unicorn_rails` command, so the plugin does not work fixed. In addition, fixed ruby warning.
