### PR TITLE
_mem should use FB memory used, only

### DIFF
--- a/plugins/gpu/nvidia_gpu_
+++ b/plugins/gpu/nvidia_gpu_
@@ -127,7 +127,7 @@ if [ "$1" = "config" ]; then
 			;;
 		mem)
 			# First determine total memory of each GPU...
-			gpusTotalMemOutput=`echo "$smiOutput" | grep -A 3 "Memory Usage" | grep "Total" | cut -d : -f 2 | tr -d ' '`
+			gpusTotalMemOutput=`echo "$smiOutput" | grep -A 3 "FB Memory Usage" | grep "Total" | cut -d : -f 2 | tr -d ' '`
 			gpusTotalMem=''
 			nGpusCounter=0
 			while [ $nGpusCounter -lt $nGpus ]
@@ -146,7 +146,7 @@ if [ "$1" = "config" ]; then
 			echo 'graph_args -l 0 -u 100'
 			echo 'graph_vlabel Percentage'
 			echo 'graph_category gpu'
-			echo "graph_info Memory usage for NVIDIA GPUs using driver version $driverVersion (total memory is $gpusTotalMem)"
+			echo "graph_info FB Memory usage for NVIDIA GPUs using driver version $driverVersion (total memory is $gpusTotalMem)"
 			;;
 		fan)
 			echo 'graph_title GPU fan speed'
@@ -189,8 +189,8 @@ case $name in
 		valueGpus=`echo "$smiOutput" | grep -A 1 "Temperature" | grep "Gpu" | cut -d : -f 2 | cut -d ' ' -f 2`
 		;;
 	mem)
-		totalMemGpus=`echo "$smiOutput" | grep -A 3 "Memory Usage" | grep "Total" | cut -d : -f 2 | cut -d ' ' -f 2`
-		usedMemGpus=`echo "$smiOutput" | grep -A 3 "Memory Usage" | grep "Used" | cut -d : -f 2 | cut -d ' ' -f 2`
+		totalMemGpus=`echo "$smiOutput" | grep -A 3 "FB Memory Usage" | grep "Total" | cut -d : -f 2 | cut -d ' ' -f 2`
+		usedMemGpus=`echo "$smiOutput" | grep -A 3 "FB Memory Usage" | grep "Used" | cut -d : -f 2 | cut -d ' ' -f 2`
 		valueGpus=''
 		nGpusCounter=0
 		while [ $nGpusCounter -lt $nGpus ]


### PR DESCRIPTION
NVIDIA 6 added differentiation between FB and BAR1 memory - use nvidia_gpu_mem for FB Memory _only_ since its definition fits better with the usage prior to BAR1 memory.
