### PR TITLE
add ntp_pool_score

### DIFF
--- a/plugins/time/ntp_pool_score_
+++ b/plugins/time/ntp_pool_score_
@@ -77,7 +77,7 @@ SCORE=$(wget "http://www.pool.ntp.org/scores/$target/log?limit=1" \
                 --timeout=30 -O - 2>/dev/null \
                 | tail -n 1 | awk -F ',' '{print $5}')
 
-if echo "$SCORE" | grep -q '^[0-9.]\+$'; then
+if echo "$SCORE" | grep -q '^-\?[0-9.]\+$'; then
     echo "score.value $SCORE"
 else
     echo "score.value U"


### PR DESCRIPTION
`ntp_pool_score_` - Wildcard plugin to monitor the score assigned to a server from pool.ntp.org
