### PR TITLE
Configuration for local ipmi monitoring

### DIFF
--- a/plugins/sensors/freeipmi
+++ b/plugins/sensors/freeipmi
@@ -5,6 +5,9 @@
   freeipmi - Multigraph-plugin to monitor sensors using FreeIPMI
 
 =head1 CONFIGURATION
+When used to monitor the local host, plugin config should define user root for direct ipmi access:
+	[freeipmi]
+		user root
 
 =head2 ENVIRONMENT VARIABLES
 


### PR DESCRIPTION
Added comment with guide how to configure plugin for local monitoring,
by default munin-node running it with user munin, and don't throwing explicit error for permission denied 
