### PR TITLE
Fix issue with $uptime being undefined

### DIFF
--- a/plugins/network/bandwidth_
+++ b/plugins/network/bandwidth_
@@ -208,8 +208,8 @@ sub uptime {
     my $puptime = "/proc/uptime";
     open( TIME, "<", $puptime ) || die "Unable to read $puptime: $!";
     while (<TIME>) {
-        split;
-        $uptime = @_[0];
+        my @arr = split;
+        $uptime = $arr[0];
     }
     close(TIME);
     chomp $uptime;


### PR DESCRIPTION
Fix issue with $uptime being undefined.
On my setup perl requires a variable to assign the return value of the split operation. Without this the value of $uptime ends up being undefined.
