### PR TITLE
exit 0 and some notices ...

### DIFF
--- a/plugins/samba/samba_users
+++ b/plugins/samba/samba_users
@@ -11,6 +11,12 @@
 # Revision 1.0  2007/04/16  Jon Higgs 
 # Initial Release - Adapated from jimmyo's processses plugin. 
 #
+# Revision 1.1  2014/07/24  MangaII
+# Add exit 0
+# WARNING : Samba 3.6 and newer block access to smbstatus for no root user
+# On Debian make a "chmod a+w /run/samba/sessionid.tdb" 
+# smbstatus must open this file with RW option
+#
 # Magick markers (optional - used by munin-config and som installation
 # scripts):
 #%# family=auto
@@ -36,3 +42,5 @@ fi
 
 echo -n "samba_users.value "
 smbstatus -b 2> /dev/null | grep -c -v -e "^Samba" -e "^---" -e "^PID" -e ^$
+
+exit 0


### PR DESCRIPTION
Add exit 0
# WARNING : Samba 3.6 and newer block access to smbstatus for no root user
# On Debian make a "chmod a+w /run/samba/sessionid.tdb"
# smbstatus must open this file with RW option
