### PR TITLE
Fixing Regexp for kvm plugins to be aware of underscores in vm names

### DIFF
--- a/plugins/virtualization/kvm_cpu
+++ b/plugins/virtualization/kvm_cpu
@@ -68,7 +68,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))
     return result
     
 def list_pids():
@@ -99,3 +99,4 @@ if __name__ == "__main__":
             fetch(find_vm_names(list_pids()))
     else:
         fetch(find_vm_names(list_pids()))
+

--- a/plugins/virtualization/kvm_io
+++ b/plugins/virtualization/kvm_io
@@ -85,7 +85,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))
     return result
     
 def list_pids():

--- a/plugins/virtualization/kvm_mem
+++ b/plugins/virtualization/kvm_mem
@@ -82,7 +82,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))
     return result
     
 def list_pids():

--- a/plugins/virtualization/kvm_net
+++ b/plugins/virtualization/kvm_net
@@ -84,7 +84,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-]*)\x00\-.*$",r"\1", cmdline.readline()))        
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))        
     return result
     
 def get_vm_mac(pid):


### PR DESCRIPTION
If underscores arent in the regexp and youll name your vms with some, the name of this attribute will get really long and cause munin to not write rrd files etc. because of too long filenames like this:

mem-g.rrd: opening '/var/lib/munin/host.tld/host.tld-kvm_mem-_usr_bin_kvm__S__M_pc_1_0__cpu_core2duo__abm__lahf_lm__rdtscp__pdpe1gb__aes__popcnt__x2apic__sse4_2__sse4_1__xtpr__cx16__tm2__est__vmx__ds_cpl__pbe__tm__ht__ss__acpi__ds__enable_kvm__m_4096__smp_1_sockets_1_cores_1_threads_1__name_debian_services__uuid_198c23fc_15a9_863c_d273_6465b5d10762__nodefconfig__nodefaults__chardev_socket_id_charmonitor_path__var_lib_libvirt_qemu_debian_services_monitor_server_nowait__mon_chardev_charmonitor_id_monitor_mode_control__rtc_base_utc__no_shutdown__drive_file__dev_vg0_debian_services_if_none_id_drive_virtio_disk0_format_raw_cache_none__device_virtio_blk_pci_bus_pci_0_addr_0x4_drive_drive_virtio_disk0_id_virtio_disk0_bootindex_1__drive_if_none_media_cdrom_id_drive_ide0_1_0_readonly_on_format_raw__device_ide_drive_bus_ide_1_unit_0_drive_drive_ide0_1_0_id_ide0_1_0__netdev_tap_fd_16_id_hostnet0_vhost_on_vhostfd_17__device_virtio_net_pci_netdev_hostnet0_id_net0_mac_52_54_00_62_75_af_bus_pci_0_addr_0x3__chardev_pty_id_charserial0__device_isa_serial_chardev_charserial0_id_serial0__usb__device_usb_tablet_id_input0__vnc_127_0_0_1_0_password__vga_cirrus__device_virtio_balloon_pci_id_balloon0_bus_pci_0_addr_0x5__mem-g.rrd': File name too long
