### PR TITLE
Allow for a custom puppet directory

### DIFF
--- a/plugins/puppet/puppetmaster
+++ b/plugins/puppet/puppetmaster
@@ -17,6 +17,7 @@
 # [puppet*]
 # env.puppet_logfile /var/log/message
 # env.puppet_logformat "^%b %d"
+# env.puppet_factsdir /var/puppet/yaml/facts/
 #
 # the logfile is where the puppetmaster is expected to log its
 # compilation statistics. the format is the format of the date syslog
@@ -120,7 +121,7 @@ case ARGV[0]
 		plist("puppetmasterd") if $0 =~ /puppet_mem$/
 		plist("puppetd") if $0 =~ /puppet_mem$/
 		if $0 =~ /puppet_clients$/		
-			puts "known_clients.value #{Dir.entries('/var/lib/puppet/yaml/facts/').size-2}"
+			puts "known_clients.value #{Dir.entries(ENV['puppet_factsdir'] || '/var/lib/puppet/yaml/facts/').size-2}"
 			phaselog
 		end
 end


### PR DESCRIPTION
For example on OpenBSD, /var/lib/puppet doesn't exist and /var/puppet is used
