### PR TITLE
Use case insensitive grep for Temp lines

### DIFF
--- a/plugins/gpu/nvidia_gpu_
+++ b/plugins/gpu/nvidia_gpu_
@@ -186,7 +186,7 @@ fi
 # Get requested value
 case $name in
 	temp)
-		valueGpus=`echo "$smiOutput" | grep -A 1 "Temperature" | grep "Gpu" | cut -d : -f 2 | cut -d ' ' -f 2`
+		valueGpus=`echo "$smiOutput" | grep -A 1 "Temperature" | grep -i "Gpu" | cut -d : -f 2 | cut -d ' ' -f 2`
 		;;
 	mem)
 		totalMemGpus=`echo "$smiOutput" | grep -A 3 "Memory Usage" | grep "Total" | cut -d : -f 2 | cut -d ' ' -f 2`


### PR DESCRIPTION
xorg-x11-drv-nvidia-340.29-1.el6.x86_64 (CUDA 6.5?) seems to have changed the Temperature lines from "Gpu" to "GPU" prefixes. Case insensitive grep preserves backwards compatibility.
