### PR TITLE
Added memory graphing and swapwait cpu graph

### DIFF
--- a/plugins/virtualization/vmware/esx_
+++ b/plugins/virtualization/vmware/esx_
@@ -400,6 +400,9 @@ foreach $host_name (@host_names) {
             {   selector => { group => qr/^cpu$/i, name => qr/^wait$/i, instance => qr/^$/ },
                   config => { groupBy => "group", graphName => "host_cpu_wait", graphTitle => "Amount of time spent in wait state per " }
             },
+            {   selector => { group => qr/^cpu$/i, name => qr/^swapwait$/i, instance => qr/^$/ },
+                  config => { groupBy => "group", graphName => "host_cpu_swapwait", graphTitle => "Amount of time spent in swapwait state per " }
+            },
             {   selector => { group => qr/^disk$/i, name => qr/^(read|usage|write)$/i, instance => qr/.+/ },
                   config => { groupBy => "group", graphName => "host_disk_transfer", graphTitle => "Disk Transfer Rates per " }
             },
@@ -409,8 +412,17 @@ foreach $host_name (@host_names) {
             {   selector => { group => qr/^disk$/i, name => qr/^.+Latency$/i, instance => qr/.+/, vm => qr/^$/ },
                   config => { groupBy => "vm", graphName => "host_disk_latency", graphTitle => "Disk latency for " }
             },
-            {   selector => { group => qr/^mem$/i, unit => qr/^KB$/i, rollup => qr/^none$/, vm => qr/^$/ },
-                  config => { groupBy => "vm", graphName => "host_memory", graphTitle => "Memory usage for " }
+            {   selector => { group => qr/^mem$/i, name => qr/^usage$/i, unit => qr/^KB$/i, vm => qr/^$/ },
+                  config => { groupBy => "vm", graphName => "host_memory_usage", graphTitle => "Memory usage for " }
+            },
+            {   selector => { group => qr/^mem$/i, name => qr/^active$/i, unit => qr/^KB$/i, vm => qr/^$/ },
+                  config => { groupBy => "vm", graphName => "host_memory_active", graphTitle => "Active memory usage for " }
+            },
+            {   selector => { group => qr/^mem$/i, name => qr/^consumed$/i, unit => qr/^KB$/i, vm => qr/^$/ },
+                  config => { groupBy => "vm", graphName => "host_memory_consumed", graphTitle => "Consumed memory usage for " }
+            },
+            {   selector => { group => qr/^mem$/i, name => qr/^shared$/i, unit => qr/^KB$/i, vm => qr/^$/ },
+                  config => { groupBy => "vm", graphName => "host_memory_shared", graphTitle => "Shared memory usage for " }
             },
             {   selector => { group => qr/^datastore$/i, unit => qr/^Bytes$/i, vm => qr/^$/ },
                   config => { groupBy => "vm", graphName => "usage_datastore", graphTitle => "Disk space usage for ", graphArgs => "--lower-limit 10737418240 --logarithmic --alt-autoscale-min --units=si" }
@@ -445,8 +457,23 @@ foreach $host_name (@host_names) {
                 {   selector => { group => qr/^cpu$/i, name => qr/^wait$/i, vm => qr/^$_$/ },
                       config => { groupBy => "vm", graphName => "$vmName.vm_cpu_wait", graphTitle => "Amount of time spent in wait state per " }
                 },
-                {   selector => { group => qr/^mem$/i, unit => qr/^KB$/i, rollup => qr/^none$/, vm => qr/^$_$/ },
+                {   selector => { group => qr/^cpu$/i, name => qr/^swapwait$/i, vm => qr/^$_$/ },
+                      config => { groupBy => "vm", graphName => "$vmName.vm_cpu_swapwait", graphTitle => "Amount of time spent in swapwait state per " }
+                },
+                {   selector => { group => qr/^mem$/i, unit => qr/^KB$/i, name => qr/^usage$/i, vm => qr/^$_$/ },
                       config => { groupBy => "vm", graphName => "$vmName.vm_memory", graphTitle => "Memory usage for " }
+                },
+                {   selector => { group => qr/^mem$/i, unit => qr/^KB$/i, name => qr/^active$/i, vm => qr/^$_$/ },
+                      config => { groupBy => "vm", graphName => "$vmName.vm_memory_active", graphTitle => "Active memory usage for " }
+                },
+                {   selector => { group => qr/^mem$/i, unit => qr/^KB$/i, name => qr/^consumed$/i, vm => qr/^$_$/ },
+                      config => { groupBy => "vm", graphName => "$vmName.vm_memory_consumed", graphTitle => "Consumed memory usage for " }
+                },
+                {   selector => { group => qr/^mem$/i, unit => qr/^KB$/i, name => qr/^shared$/i, vm => qr/^$_$/ },
+                      config => { groupBy => "vm", graphName => "$vmName.vm_memory_shared", graphTitle => "Shared memory usage for " }
+                },
+                {   selector => { group => qr/^mem$/i, unit => qr/^KB$/i, name => qr/^swapped$/i, vm => qr/^$_$/ },
+                      config => { groupBy => "vm", graphName => "$vmName.vm_memory_swapped", graphTitle => "Swapped memory usage for " }
                 },
                 {   selector => { group => qr/^datastore$/i, unit => qr/^Bytes$/i, vm => qr/^$_$/ },
                       config => { groupBy => "vm", graphName => "$vmName.vm_datastore", graphTitle => "Disk space usage for ", graphArgs => "--lower-limit 10485760 --logarithmic --alt-autoscale-min --units=si" }


### PR DESCRIPTION
Original memory graphs didn't seem to work on ESX 5.5, so added new ones (active, consumed, shared and swapped), plus a cpu swapwait graph which looked useful.
