### PR TITLE
Clean field name

### DIFF
--- a/plugins/mythtv/mythtv_status_
+++ b/plugins/mythtv/mythtv_status_
@@ -74,6 +74,7 @@ use DBI;
 use MythTV;
 use strict;
 use warnings;
+use Munin::Plugin;
 
 # SQL parameters are read from mysql.txt
 # There should be no need to change anything after this point
@@ -116,6 +117,7 @@ PrepSQLRead();
      @result=SQLQuery("SELECT `name` FROM `videosource`");
      my $First=0;
      foreach $gata (@result) {
+       $gata = clean_fieldname($gata);
        print "ActiveEncoders$gata.draw ";
        if ( $First == 0 ) {
           print "AREA\n";
@@ -275,7 +277,7 @@ PrepSQLRead();
    }
    foreach $Name (keys %Names) {
      if ( $Name ne "" ) {
-       print "ActiveEncoders$Name.value  $Names{$Name}\n";
+       print "ActiveEncoders" . clean_fieldname($Name) . ".value  $Names{$Name}\n";
      }
    }
    print "FreeEncoders.value $FreeRecorders\n";


### PR DESCRIPTION
Spaces are illegal in munin field names, so clean the name of the encoder before using it.
