### PR TITLE
Fix failure to monitor bean counters for servers with long names.

### DIFF
--- a/plugins/openvz/openvz_
+++ b/plugins/openvz/openvz_
@@ -30,9 +30,9 @@ if [ "$1" = "config" ]; then
         echo "graph_vlabel $ATTRIBUTE Value"
         echo "graph_category openvz"
         echo "graph_info This graph shows OpenVZ: $ATTRIBUTE"
-        vzlist -a -H -o hostname | awk '{gsub(/\./,"_",$1)
-        print("'$ATTRIBUTE'"$1".label "$1"\n" \
-        "'$ATTRIBUTE'"$1".info '$ATTRIBUTE' for VE"$1)}'
+        vzlist -a -H --no-trim -o hostname | awk '{gsub(/\./,"_",$1)
+        print("'$ATTRIBUTE'_"$1".label "$1"\n" \
+        "'$ATTRIBUTE'_"$1".info '$ATTRIBUTE' for VE"$1)}'
         exit 0
 fi
 
@@ -41,8 +41,8 @@ filter() { cat; }
 [ "$ATTRIBUTE" = 'status' ] && filter() { sed -e 's/running/10/g;s/stopped/0/g'; }
 #TODO: filter for uptime
 
-vzlist -a -H -o hostname,$ATTRIBUTE | filter | awk '{gsub(/\./,"_",$1)
-         print("'$ATTRIBUTE'"$1".value "$2)}'
+vzlist -a -H --no-trim -o hostname,$ATTRIBUTE | filter | awk '{gsub(/\./,"_",$1)
+         print("'$ATTRIBUTE'_"$1".value "$2)}'
 
 exit 0
 


### PR DESCRIPTION
`vzlist -a -H --no-trim -o hostname` doesn't truncate hostnames, but
`vzlist -a -H --no-trim -o hostname,numflock` does. So the data values being
output by the plugin were truncated, and some didn't match any of the counter
names output by "openvz config", so no data was stored for those counters.

I'm also adding an underscore between the counter name and the server name,
for readability.