### PR TITLE
Fixed sent/received count and replaced wc -l with -c

### DIFF
--- a/plugins/postfix/postfix_mail_stats
+++ b/plugins/postfix/postfix_mail_stats
@@ -36,6 +36,7 @@ fi
 if [ "$1" = "config" ]; then
 
         echo 'graph_title Postfix Mail Counter'
+        echo 'graph_category postfix'
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel Hourly Messages'
         echo 'recieved.label Delivered'

--- a/plugins/postfix/postfix_mail_stats
+++ b/plugins/postfix/postfix_mail_stats
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Made by Boudewijn Ector, for Boudewijn Ector IT.
+# Comments can be sent to (boudewijn<AT>boudewijnector'dot'NL)
+# Loosely based on http://munin.projects.linpro.no/attachment/wiki/PluginCat/postfix_messages_hourly.txt
+# Script to show postfix stuff
+#
+# Modified by Paul Saunders <darac+munin@darac.org.uk>, 10 Dec 2010
+#
+# Parameters understood:
+#
+#       config   (required)
+#       autoconf (optional - used by munin-config)
+#
+#
+# Magic markers (optional - used by munin-config and installation
+# scripts):
+#
+#%# family=auto
+#%# capabilities=autoconf
+
+
+LOGFILE=${logfile:-/var/log/maillog}	# Allow user to specify logfile through env.logfile
+DATE=`date '+%b %e %H'`
+MAXLABEL=20
+
+if [ "$1" = "autoconf" ]; then
+	if [[ -r $LOGFILE ]]; then
+	        echo yes
+	else
+		echo no
+	fi
+        exit 0
+fi
+
+if [ "$1" = "config" ]; then
+
+        echo 'graph_title Postfix Mail Counter'
+        echo 'graph_args --base 1000 -l 0'
+        echo 'graph_vlabel Hourly Messages'
+        echo 'recieved.label Delivered'
+        echo 'sent.label Outgoing'
+        echo 'rejecthelo.label Invalid HELO'
+        echo 'rejectsenderdomain.label need FQDN'
+        echo 'denyrelay.label Relay Denied'
+	echo 'spamhaus.label Blocked using Spamhaus.org'
+	echo 'spamcop.label Blocked using Spamcop'
+        exit 0
+fi
+
+echo -en "recieved.value "
+echo $(grep "postfix/lmtp\[" $LOGFILE | grep "$DATE" -c)
+echo -n
+echo -en "sent.value "
+echo $(grep "postfix/smtp\[" $LOGFILE | grep "$DATE" -c)
+echo -en "rejecthelo.value "
+echo $(grep "Helo command rejected: need fully-qualified hostname" $LOGFILE | grep "$DATE" -c)
+echo -en "rejectsenderdomain.value "
+echo $(grep "Sender address rejected: Domain not found" $LOGFILE | grep "$DATE" -c)
+
+
+echo -en "denyrelay.value "
+echo $(grep "Relay access denied" $LOGFILE | grep "$DATE" -c)
+echo -en "spamhaus.value "
+echo $(grep "blocked using sbl-xbl.spamhaus.org" $LOGFILE | grep "$DATE" -c)
+echo -en "spamcop.value "
+echo $(grep "blocked using bl.spamcop.net" $LOGFILE | grep "$DATE" -c)
+


### PR DESCRIPTION
Original script was broken and reported all emails as sent.

Also, `grep | wc -l` is pure evil.