### PR TITLE
[apc_status] Added multigraph capabilities and fixed regex

### DIFF
--- a/plugins/ups/apc_status
+++ b/plugins/ups/apc_status
@@ -1,33 +1,55 @@
 #!/bin/sh
 #
-# (c) Andreas Kreisl
+# (c) Andreas Kreisl extended by Tobias Schramm
 #
 # Link name will be used as title: apc_{$title}
 #
 # env.keys LOADPCT BCHARGE LINEV BATTV TIMELEFT
-# env.unit % or Volt or Minutes
 #
 
-
 if [ -z "$keys" ]; then
-        keys="TIMELEFT"
+        keys="LINEV LOADPCT BCHARGE NUMXFERS TIMELEFT"
 fi
+
+apcinfo=`/sbin/apcaccess`
 
 if [ "$1" = "config" ]; then
         title=`basename $0 | sed 's/^apc_//g' | awk '{ sub(/^./,toupper(substr($0,1,1))); print; }'`
-        echo "graph_title APC Status - $title"
-        echo 'graph_args --base 1000 -l 0 '
-        echo "graph_vlabel $unit"
-        echo 'graph_category sensors'
+        echo 'multigraph apc_status'
+        echo "graph_title UPS Status - $title"
+        echo 'graph_args --base 1000'
+        echo 'graph_category hardware'
         title=`/sbin/apcaccess | egrep "^MODEL" | awk '{print $3" "$4" "$5" "$6" "$7" "$8" "$9;}'`
         echo "graph_info $title"
         for key in $keys; do
                 echo "$key.label $key"
-                echo "$key.info Value of $key."
-                echo "$key.draw LINE2"
+                echo "$key.info Value of $key"
+                echo "$key.draw LINE1"
+        done
+        for key in $keys; do
+                key_lower=`echo "$key" | awk '{print tolower($0);}'`
+                unit=`echo "$apcinfo" | egrep "^$key" | awk '{print $4;}'`
+                echo "multigraph apc_status.$key_lower"
+                echo "graph_title $key"
+                echo 'graph_args --base 1000'
+                if [ -n "$unit" ]; then
+                        echo "graph_vlabel $unit"
+                fi
+                echo 'graph_category hardware'
+                echo "$key.label $key"
+                echo "$key.info $key."
+                echo "$key.draw LINE1"
         done
         exit 0
 fi
 
-searchkey=`echo "$keys" | tr " " "\|"`
-/sbin/apcaccess | egrep "$searchkey" | awk '{print $1".value "$3;}'
+echo 'multigraph apc_status'
+for key in $keys; do
+        echo "$apcinfo" | egrep "^$key" | awk '{print $1".value "$3;}'
+done
+for key in $keys; do
+        key_lower=`echo "$key" | awk '{print tolower($0)}'`
+        echo "multigraph apc_status.$key_lower"
+        echo "$apcinfo" | egrep "^$key" | awk '{print $1".value "$3;}'
+done
+


### PR DESCRIPTION
Added mutigraph capabilities and automatic unit detection.

Fixed regex:
`egrep "$key"` was returning multiple matches when using "BATTV" as key.
Fixed by using `egrep "^$key"`.
This prevents the key `NOMBATTV` from being matched by the string `BATTV` while still allowing it to be matched by `NOMBATTV`
