### PR TITLE
Fix state file directory in system/auth plugin

### DIFF
--- a/plugins/system/auth
+++ b/plugins/system/auth
@@ -22,7 +22,7 @@
 # Configuration
 #############################
 MAXLABEL=20
-STAT_FILE=/var/lib/munin/plugin-state/plugin-auth.state
+STAT_FILE=$MUNIN_PLUGSTATE/plugin-auth.state
 EXPR_BIN=/usr/bin/expr
 #############################
 


### PR DESCRIPTION
Don't hardcode plugin state file location in auth plugin, use env variable defined by Munin instead
