### PR TITLE
Removing erroneous line from mtr output.

### DIFF
--- a/plugins/network/mtr100_
+++ b/plugins/network/mtr100_
@@ -50,7 +50,7 @@ fi
 
 dotrace() {
 
-LC_ALL=C mtr -nrs 1024 -c 5 $totrace | grep -v "^HOST:" | LC_ALL=C  awk -v C=$1 ' {
+LC_ALL=C mtr -nrs 1024 -c 5 $totrace | grep -vi -E "^HOST:|^Start:" | LC_ALL=C  awk -v C=$1 ' {
 
 label=$2
 x=gsub("\\.","_",label)


### PR DESCRIPTION
Newer versions of mtr outputs a "Start: <date here>" line which would be
picked up and incorrectly graphed in munin. Adding an additional inverse grep
field to remove this extra line if it is present. Also added case insensitive
flag to the grep.

Old output of mtr100_*:
```bash
~  mtr -nrs 1024 -c 5 8.8.8.8 | grep -v "^HOST:"
Start: Tue Dec 23 18:37:19 2014
  1.|-- 192.168.1.1                0.0%     5    0.4   0.4   0.4   0.5   0.0
  2.|-- 10.125.122.129             0.0%     5    8.7   9.0   8.7   9.3   0.0
  3.|-- 69.63.242.49               0.0%     5   12.4  14.6  12.4  21.7   4.0
  4.|-- 64.71.241.97               0.0%     5   15.1  15.4  13.6  17.8   1.5
  5.|-- 69.196.136.68              0.0%     5   17.2  15.6  11.6  24.0   5.1
  6.|-- 72.14.212.134              0.0%     5   12.5  15.8  11.9  20.4   4.0
  7.|-- 72.14.239.187              0.0%     5   14.3  16.3  14.3  22.9   3.6
  8.|-- 8.8.8.8                    0.0%     5   12.4  14.7  12.1  24.3   5.3
```
New output of mtr100_*:
```bash
~  mtr -nrs 1024 -c 5 8.8.8.8 | grep -iv -E "^HOST:|^Start:"
  1.|-- 192.168.1.1                0.0%     5    0.4   0.4   0.4   0.4   0.0
  2.|-- 10.125.122.129             0.0%     5    8.5   8.8   8.2   9.3   0.0
  3.|-- 69.63.242.49               0.0%     5   14.1  13.1  11.6  14.1   0.7
  4.|-- 64.71.241.97               0.0%     5   14.7  14.1  12.8  15.9   1.0
  5.|-- 69.196.136.68              0.0%     5   21.0  13.6  11.0  21.0   4.1
  6.|-- 72.14.212.134              0.0%     5   11.8  14.2  11.8  21.9   4.3
  7.|-- 72.14.239.187              0.0%     5   14.0  15.6  13.1  23.5   4.4
  8.|-- 8.8.8.8                    0.0%     5   11.7  12.5  11.7  13.6   0.5
```