### PR TITLE
modified data_url for firmware >= 6.20

### DIFF
--- a/plugins/network/avm-fritzbox-wan-traffic
+++ b/plugins/network/avm-fritzbox-wan-traffic
@@ -57,7 +57,7 @@ if(isset($argv[1]) && $argv[1] == "autoconf") {
 
 
 function GetCommonLinkProperties() {
-	$data_url = '/upnp/control/WANCommonIFC1';
+	$data_url = '/igdupnp/control/WANCommonIFC1';
 	$data_soap = '"urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1#GetCommonLinkProperties"';
 	$data_xml = '<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetCommonLinkProperties xmlns:u=urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1 /></s:Body></s:Envelope>';
 	$tmp = DoCurl($data_url,$data_soap,$data_xml);
@@ -70,7 +70,7 @@ function GetCommonLinkProperties() {
 }
 
 function GetAddonInfos() {
-	$data_url = '/upnp/control/WANCommonIFC1';
+	$data_url = '/igdupnp/control/WANCommonIFC1';
 	$data_soap = '"urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1#GetAddonInfos"';
 	$data_xml = '<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetAddonInfos xmlns:u=urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1 /></s:Body></s:Envelope>';
 	$tmp = DoCurl($data_url,$data_soap,$data_xml);
@@ -81,7 +81,7 @@ function GetAddonInfos() {
 }
 
 function GetExternalIP() {
-	$data_url = '/upnp/control/WANIPConn1';
+	$data_url = '/igdupnp/control/WANIPConn1';
 	$data_soap = '"urn:schemas-upnp-org:service:WANIPConnection:1#GetExternalIPAddress"';
 	$data_xml = '<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetExternalIPAddress xmlns:u=urn:schemas-upnp-org:service:WANIPConnection:1 /></s:Body></s:Envelope>';
 	$tmp = DoCurl($data_url,$data_soap,$data_xml);


### PR DESCRIPTION
With the latest firmware update to 6.20 on the fritzbox 7390, the data fetching was broken. The url with the data could not be found anymore.
This corrects the url.