### PR TITLE
Fix hit rate calculation for varnish4 plugin

### DIFF
--- a/plugins/varnish4/README.md
+++ b/plugins/varnish4/README.md
@@ -8,7 +8,7 @@ Installation
 ------------
 
 - Copy `varnish4_` to the Munin plugins directory (`/usr/share/munin/plugins/`)
-- Make varnish_ runnable (`chmod +x /usr/share/munin/plugins/varnish_`)
+- Make `varnish4_` runnable (`chmod +x /usr/share/munin/plugins/varnish4_`)
 
 Configuration
 -------------

--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -885,7 +885,6 @@ sub usage
 my %state = (
 	'stat' => 0,     # inside <stat> or not
 	'field' => 'none', # <name>, <value>, <stat>, etc.
-	'values' => ()
 );
 
 # Reset the state of XML, mainly used for end-elements.
@@ -924,7 +923,7 @@ sub xml_commit_state
 		if ($key eq 'flag') {
 			$data = translate_type($data);
 		}
-		if (defined($type) and $type ne "") {
+		if (defined($type) and $type ne "" and defined($ident) and $ident ne "") {
 			$data{$type}{$ident}{$name}{$key} = $data;
 		} else {
 			$data{$name}{$key} = $data

--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -923,7 +923,7 @@ sub xml_commit_state
 		if ($key eq 'flag') {
 			$data = translate_type($data);
 		}
-		if (defined($type) and $type ne "" and defined($ident) and $ident ne "") {
+		if (defined($type) and $type ne '' and defined($ident) and $ident ne '') {
 			$data{$type}{$ident}{$name}{$key} = $data;
 		} else {
 			$data{$name}{$key} = $data

--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -923,7 +923,7 @@ sub xml_commit_state
 		if ($key eq 'flag') {
 			$data = translate_type($data);
 		}
-		if (defined($type) and $type ne '' and defined($ident) and $ident ne '') {
+		if (defined($type) and $type ne "" and defined($ident) and $ident ne "") {
 			$data{$type}{$ident}{$name}{$key} = $data;
 		} else {
 			$data{$name}{$key} = $data

--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -305,6 +305,7 @@ my %ASPECTS = (
 	},
 	'objects' => {
 		'title' => 'Number of objects',
+		'order' => 'n_object n_objectcore n_vampireobject n_objecthead',
 		'values' => {
 			'n_object' => {
 				'type' => 'GAUGE',
@@ -674,6 +675,7 @@ my %ASPECTS = (
 	},
 	'expunge' => {
 		'title' => 'Object expunging',
+		'order' => 'n_expired n_lru_nuked',
 		'values' => {
 			'n_expired' => {
 				'type' => 'DERIVE',

--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -238,7 +238,8 @@ my %ASPECTS = (
 			'client_req' => {
 				'type' => 'DERIVE',
 				'min' => '0',
-				'graph' => 'off'
+				'graph' => 'off',
+				'rpn' => [ 'cache_hit' , 'cache_miss' , 'cache_hitpass' , '+' , '+' ]
 			},
 			'cache_hit' => {
 				'type' => 'DERIVE',


### PR DESCRIPTION
The hit rate caluclation is correct as long as no purges are performed. If purges are performed, they are counted in client_req, but not counted in cache_(hit|miss|hitpass). This would lead to wrong values for the hit rate because client_req is bigger than the sum of cache_(hit|miss|hitpass).

Additionally there are some minor bugfixes.