### PR TITLE
Revert "Avoid bashism"

### DIFF
--- a/plugins/gpu/nvidia_gpu_
+++ b/plugins/gpu/nvidia_gpu_
@@ -198,7 +198,7 @@ case $name in
 			totalMemGpu=`echo "$totalMemGpus" | sed -n $(( $nGpusCounter + 1 ))p`
 			usedMemGpu=`echo "$usedMemGpus" | sed -n $(( $nGpusCounter + 1 ))p`
 			percentMemUsed=$(( $usedMemGpu * 100 / $totalMemGpu ))
-			valueGpus="${valueGpus}${percentMemUsed}"$(printf '\n')
+			valueGpus="${valueGpus}${percentMemUsed}"$'\n'
 			: $(( nGpusCounter = $nGpusCounter + 1 ))
 		done
 		;;


### PR DESCRIPTION
The "Avoid bashism" commit does not work with /bin/bash (including RedHat, etc where /bin/sh is symlinked to /bin/bash). A subsequent commit to fix the shebang to /bin/bash solved the issue (for Debian/Ubuntu at least, theoretically everywhere).