### PR TITLE
unicorn: display name of application.

### DIFF
--- a/plugins/unicorn/unicorn_memory_status
+++ b/plugins/unicorn/unicorn_memory_status
@@ -68,7 +68,7 @@ case ARGV[0]
 when "autoconf"
   puts "yes"
 when "config"
-  puts "graph_title Unicorn - Memory usage"
+  puts "graph_title Unicorn [#{File.basename(__FILE__).gsub(/^unicorn_memory_status_/, '')}] - Memory usage"
   puts "graph_args --base 1024 -l 0"
   puts "graph_vlabel bytes"
   puts "graph_category Unicorn"

--- a/plugins/unicorn/unicorn_status
+++ b/plugins/unicorn/unicorn_status
@@ -66,7 +66,7 @@ case ARGV[0]
 when "autoconf"
   puts "yes"
 when "config"
-  puts "graph_title Unicorn - Status"
+  puts "graph_title Unicorn [#{File.basename(__FILE__).gsub(/^unicorn_status_/, '')}] - Status"
   puts "graph_args -l 0"
   puts "graph_vlabel number of workers"
   puts "graph_category Unicorn"


### PR DESCRIPTION
It would helpful, if the unicorn plugin would display the name of each application monitored, when monitoring several applications.

Instead of reading

* unicorn
  * Unicorn - Memory usage
  * Unicorn - Memory usage
  * Unicorn - Memory usage

I would like to read

* unicorn
  * Unicorn [app1] - Memory usage
  * Unicorn [app2] - Memory usage
  * Unicorn [app3] - Memory usage

for applications configured with the symbolic links

* `/etc/munin/plugins/unicorn_memory_usage_app1`
* `/etc/munin/plugins/unicorn_memory_usage_app2`
* `/etc/munin/plugins/unicorn_memory_usage_app3`

This PR implements the change proposed for both `unicorn_memory_usage` and for `unicorn_status`.