### PR TITLE
mpdstats_: fix example documentation.

### DIFF
--- a/plugins/mpd/mpdstats_
+++ b/plugins/mpd/mpdstats_
@@ -33,7 +33,7 @@ it using the 'netcat' environment variable.
 
 =head2 CONFIGURATION EXAMPLE
 
- [mpd_*]
+ [mpdstats_*]
   env.mpd_host 192.168.0.43
   env.mpd_port 6606
   env.netcat /usr/local/bin/nc


### PR DESCRIPTION
This patch fixes an error in the example configuration in the plugin doc.
The plugin-conf.d/munin-node section had a wrong name.