### PR TITLE
mysql_connections_per_user: skip internal user "system user"

### DIFF
--- a/plugins/mysql/mysql_connections_per_user
+++ b/plugins/mysql/mysql_connections_per_user
@@ -91,6 +91,10 @@ sub print_graph_data() {
     my $print_user = "";
     foreach my $user (reverse sort { $counts{$a} <=> $counts{$b} } keys %counts) {
         last if $i++ >= $numusers;
+        if ($user eq "system user") {
+            #skip internal user that manages binlog operations for slave servers.
+            next;
+        }
         $total += $counts{$user};
         $print_user = $user;
         if($print_user eq "root") {
@@ -125,6 +129,10 @@ EOM
     my $i = 0;
     foreach my $user (reverse sort { $counts{$a} <=> $counts{$b} } keys %counts) {
         last if $i++ >= $numusers;
+        if ($user eq "system user") {
+            #skip internal user that manages binlog operations for slave servers.
+            next;
+        }
         my $print_user = $user;
         if($print_user eq "root") {
             $print_user = "root_";


### PR DESCRIPTION
This is the user name used internally by mysql for binlog handling (even
though it's not present in the mysql.user table).

The space in the name makes the plugin freak out about an unknown
"system" value.

Number of connections for this interal user is irrelevant.