### PR TITLE
vnstat_month: suppress warnings in perl 5.18+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
   - cpanm --notest XML::Smart
   - cpanm --notest XML::Twig
   - cpanm --notest nvidia::ml
+  - cpanm --notest experimental
   # - Sys::Virt version matching the test system's libvirt-dev
   - cpanm --notest DANBERR/Sys-Virt-0.9.8.tar.gz
   # Modules used by plugins, but missing on cpan

--- a/plugins/network/vnstat_month
+++ b/plugins/network/vnstat_month
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use autodie;
 use List::Util 'sum';
+use experimental 'switch';
 
 =head1 NAME
 


### PR DESCRIPTION
This broke in an update to Debian Jessie.