### PR TITLE
Fixed typo in rabbitmq_queue_memory

### DIFF
--- a/plugins/rabbitmq/rabbitmq_queue_memory
+++ b/plugins/rabbitmq/rabbitmq_queue_memory
@@ -35,8 +35,8 @@ QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
 		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
  
 if [ "$1" = "config" ]; then
-        QUEUE_WARN=${queue_warn:-10000}
-        QUEUE_CRIT=${queue_crit:-20000}
+        QUEUE_WARN=${queue_warn:-$[100 * 1024 * 1024]}
+        QUEUE_CRIT=${queue_crit:-$[200 * 1024 * 1024]}
 
 	# The host name this plugin is for. (Can be overridden to have
 	# one machine answer for several)

--- a/plugins/rabbitmq/rabbitmq_queue_memory
+++ b/plugins/rabbitmq/rabbitmq_queue_memory
@@ -30,7 +30,7 @@ fi
 
 HOME=/tmp/
 VHOST=${vhost:-"/"}
-QUEUES=$(rabbitmqctl list_queues -p $VHOST name | \
+QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
 		grep -v '^Listing' | \
 		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
  

--- a/plugins/rabbitmq/rabbitmq_queue_memory
+++ b/plugins/rabbitmq/rabbitmq_queue_memory
@@ -35,8 +35,8 @@ QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
 		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
  
 if [ "$1" = "config" ]; then
-        QUEUE_WARN=${queue_warn:-$[100 * 1024 * 1024]}
-        QUEUE_CRIT=${queue_crit:-$[200 * 1024 * 1024]}
+        QUEUE_WARN=${queue_warn:-104857600}  # 100 MB
+        QUEUE_CRIT=${queue_crit:-209715200}  # 200 MB
 
 	# The host name this plugin is for. (Can be overridden to have
 	# one machine answer for several)


### PR DESCRIPTION
```
Error output from rabbitmq_queue_memory:
    erlexec: HOME must be set
```