### PR TITLE
Add TITLE_PREFIX to redis_

### DIFF
--- a/plugins/redis/redis_
+++ b/plugins/redis/redis_
@@ -40,6 +40,7 @@ use Switch;
 my $HOST = exists $ENV{'host'} ? $ENV{'host'} : "127.0.0.1";
 my $PORT = exists $ENV{'port'} ? $ENV{'port'} : 6379;
 my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : undef;
+my $TITLE_PREFIX = exists $ENV{'title_prefix'} ? $ENV{'title_prefix'} . ": " : "";
 
 my $sock = &get_conn();
 my $config = ( defined $ARGV[0] and $ARGV[0] eq "config" );
@@ -75,7 +76,7 @@ switch ($0) {
     case "connected_clients" {
         if ( $config ) {
             my $maxclients= get_config("maxclients")->{"maxclients"};
-            print "graph_title Connected clients\n";
+            print "graph_title ${TITLE_PREFIX}Connected clients\n";
             print "graph_vlabel Connected clients\n";
             print "graph_category redis\n";
             print "graph_args -l 0\n";
@@ -90,7 +91,7 @@ switch ($0) {
 
     case "keys_per_sec" {
         if ( $config ) {
-            print "graph_title Keys Per Second\n";
+            print "graph_title ${TITLE_PREFIX}Keys Per Second\n";
             print "graph_vlabel per \${graph_period}\n";
             print "graph_category redis\n";
             print "graph_args -l 0\n";
@@ -113,7 +114,7 @@ switch ($0) {
 
     case "key_ratio" {
         if ( $config ) {
-            print "graph_title Key Hit vs Miss Ratio\n";
+            print "graph_title ${TITLE_PREFIX}Key Hit vs Miss Ratio\n";
             print "graph_vlabel per \${graph_period}\n";
             print "graph_category redis\n";
             print "graph_args -u 100 -l 0 -r --base 1000\n";
@@ -140,7 +141,7 @@ switch ($0) {
 
     case "per_sec" {
         if ( $config ) {
-            print "graph_title Per second\n";
+            print "graph_title ${TITLE_PREFIX}Per second\n";
             print "graph_vlabel per \${graph_period}\n";
             print "graph_category redis\n";
             print "graph_args -l 0\n";
@@ -159,7 +160,7 @@ switch ($0) {
     case "used_memory" {
         if ( $config ) {
             my $maxmemory = get_config("maxmemory")->{"maxmemory"};
-            print "graph_title Used memory\n";
+            print "graph_title ${TITLE_PREFIX}Used memory\n";
             print "graph_vlabel Used memory\n";
             print "graph_category redis\n";
             print "graph_args -l 0 --base 1024\n";
@@ -184,7 +185,7 @@ switch ($0) {
         }
 
         if ( $config ) {
-            print "graph_title Used keys\n";
+            print "graph_title ${TITLE_PREFIX}Used keys\n";
             print "graph_vlabel Used keys\n";
             print "graph_category redis\n";
             print "graph_args -l 0\n";


### PR DESCRIPTION
This allows setup of multiple redis instances on a single server instance and allows the graphs to be distinguishable.

Currently if you setup multiple by using instance1_redis_connections and instance2_redis_connections both set of graphs have the same name.