### PR TITLE
Make capitalization and grammar consistent

### DIFF
--- a/plugins/php/php_apc_
+++ b/plugins/php/php_apc_
@@ -62,7 +62,7 @@ graph_total Total
 mem_avail.label Memory available
 mem_avail.draw STACK
 mem_avail.min 0
-mem_used.label Memory Used
+mem_used.label Memory used
 mem_used.draw AREA
 mem_used.min 0
 EOM
@@ -78,7 +78,7 @@ graph_args -l 0
 graph_vlabel Cache hits
 graph_category php-apc
 graph_total Total
-num_misses.label Missed
+num_misses.label Misses
 num_misses.draw AREA
 num_misses.min 0
 num_hits.label Hits
@@ -96,10 +96,10 @@ graph_title APC Percents
 graph_args -l 0 --upper-limit 100
 graph_vlabel Cache Percents %
 graph_category php-apc
-hits.label hits
+hits.label Hits
 hits.draw AREA
 hits.min 0
-misses.label misses
+misses.label Misses
 misses.draw STACK
 misses.min 0
 misses.warning 50


### PR DESCRIPTION
Make capitalization and grammar consistent (e.g. Missed -> Misses)