### PR TITLE
zfs-filesystem-graph: remove --upper-limit

### DIFF
--- a/plugins/zfs/zfs-filesystem-graph
+++ b/plugins/zfs/zfs-filesystem-graph
@@ -39,7 +39,7 @@ if [ "$1" = "config" ]; then
 
 	echo <<EOF "graph_title zfs $myname
 graph_order usedbydataset usedbychildren usedbysnapshots usedbyrefreservation available total quota
-graph_args --base 1024 -r -l 0 --vertical-label Bytes --upper-limit ${values[6]}
+graph_args --base 1024 -r -l 0 --vertical-label Bytes
 graph_info This graph shows how is used a zfs filesystems.
 graph_category filesystem
 graph_period second


### PR DESCRIPTION
Providing a --upper-limit parameter is only useful if the size of the
filesystem never changes. On ZFS, this assumption is only true for the
zpool; for all other filesystems, the available space is shared, and the
totalled values will vary. When this is the case, the --upper-limit
parameter will obscure peaks in the graph.