### PR TITLE
fix - remove error message, fetch correct count source

### DIFF
--- a/plugins/disk/raid-mismatch-count
+++ b/plugins/disk/raid-mismatch-count
@@ -24,7 +24,7 @@
 # #%# capabilities=autoconf
 
 
-targets=`ls /sys/devices/virtual/block/*/md/mismatch_cnt | cut -d/ -f6`
+targets=`ls /sys/devices/virtual/block/*/md/mismatch_cnt 2> /dev/null | cut -d/ -f6`
 returnval=$?
 
 if [ "x$1" = "xautoconf" ]; then
@@ -55,5 +55,5 @@ __EOF__
 fi
 
 for target in $targets; do
-	echo $target.value $(cat /sys/devices/virtual/block/$target/md/sync_completed)
+	echo $target.value $(cat /sys/devices/virtual/block/$target/md/mismatch_cnt)
 done


### PR DESCRIPTION
* redirect error message of `ls` to /dev/null
  * ```ls: cannot access /sys/devices/virtual/block/*/md/mismatch_cnt: No such file or directory```
* fetch mismatch_cnt to get correct count

* https://www.kernel.org/doc/Documentation/md.txt
  * sync_completed: the number of sectors that have been completed
  * mismatch_cnt: the number of errors that are found