### PR TITLE
fixed kvm_* plugins

### DIFF
--- a/plugins/virtualization/kvm_cpu
+++ b/plugins/virtualization/kvm_cpu
@@ -68,7 +68,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$",r"\1", cmdline.readline()))
     return result
     
 def list_pids():

--- a/plugins/virtualization/kvm_io
+++ b/plugins/virtualization/kvm_io
@@ -85,7 +85,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$",r"\1", cmdline.readline()))
     return result
     
 def list_pids():

--- a/plugins/virtualization/kvm_mem
+++ b/plugins/virtualization/kvm_mem
@@ -82,7 +82,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$",r"\1", cmdline.readline()))
     return result
     
 def list_pids():

--- a/plugins/virtualization/kvm_net
+++ b/plugins/virtualization/kvm_net
@@ -84,7 +84,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_]*)\x00\-.*$",r"\1", cmdline.readline()))        
+        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$",r"\1", cmdline.readline()))        
     return result
     
 def get_vm_mac(pid):


### PR DESCRIPTION
fixed regex for "vm_name" resolving, so VMs with dash (e.g. "db-test") in the name will be displayed correctly.