### PR TITLE
Plugin runs, even if no access to list DBs.

### DIFF
--- a/plugins/postgresql/postgres_space_
+++ b/plugins/postgresql/postgres_space_
@@ -67,9 +67,6 @@ if (exists $ARGV[0]) {
 my (undef, undef, $dbname) = split (/_/, $0, 3);
 die "No dbname configured (did you make the proper symlink?)" unless $dbname;
 
-my @datasources = DBI->data_sources ('Pg')
-    or die ("Can't read any possible data sources: $?");
-
 my $dsn = "DBI:Pg:dbname=$dbname";
 $dsn .= ";host=$dbhost" if $dbhost;
 print "#$dsn\n" if $debug;


### PR DESCRIPTION
If the user as whom "munin" connects has no rights to list existing DBs,
the plugin crashes. Even though the rest of the code is OK. Listing DBs
is only necessary in the case of auto-configuring the plugin. Not for
running it.

This removes the line which causes the bug. The variable which is set in
this line is anyway not used.