### PR TITLE
Stack postfix mailqueues instead of overlapping.

### DIFF
--- a/plugins/postfix/postfix_mailqueue_
+++ b/plugins/postfix/postfix_mailqueue_
@@ -114,6 +114,12 @@ maildrop.label maildrop
 incoming.label incoming
 corrupt.label corrupt
 hold.label held
+active.draw AREA
+deferred.draw STACK
+maildrop.draw STACK
+incoming.draw STACK
+corrupt.draw STACK
+hold.draw STACK
 EOF
 		for field in active deferred maildrop incoming corrupt hold; do
 			print_warning $field


### PR DESCRIPTION
It is very hard to see the real values in the postfix queue when they
are overlapping. Having a stacked graph eleviates this whil still
retaining all the necessary data.