### PR TITLE
[monit] Not using memory is a warning condition

### DIFF
--- a/plugins/monit/monit_parser
+++ b/plugins/monit/monit_parser
@@ -54,7 +54,7 @@ if len(sys.argv) > 1 and sys.argv[1] == 'config':
     for process in procs:
         for stat in procs[process]:
             print "monit_%s_%s.label %s.%s" % (process, stat, process, stat)
-            print "monit_%s_%s.warning 1:"
+            print "monit_%s_%s.warning 1:" % (process, stat)
     sys.exit(0)
 
 for process in procs:

--- a/plugins/monit/monit_parser
+++ b/plugins/monit/monit_parser
@@ -54,7 +54,8 @@ if len(sys.argv) > 1 and sys.argv[1] == 'config':
     for process in procs:
         for stat in procs[process]:
             print "monit_%s_%s.label %s.%s" % (process, stat, process, stat)
-            print "monit_%s_%s.warning 1:" % (process, stat)
+            if stat == 'total_memory':
+            	print "monit_%s_%s.warning 1:" % (process, stat)
     sys.exit(0)
 
 for process in procs:

--- a/plugins/monit/monit_parser
+++ b/plugins/monit/monit_parser
@@ -54,6 +54,7 @@ if len(sys.argv) > 1 and sys.argv[1] == 'config':
     for process in procs:
         for stat in procs[process]:
             print "monit_%s_%s.label %s.%s" % (process, stat, process, stat)
+            print "monit_%s_%s.warning 1:"
     sys.exit(0)
 
 for process in procs:


### PR DESCRIPTION
When a daemon fails `-nan` is its memory usage.