### PR TITLE
Add snmp__synology_* plugins

### DIFF
--- a/plugins/snmp/snmp__synology_hddtemp
+++ b/plugins/snmp/snmp__synology_hddtemp
@@ -1,0 +1,109 @@
+#!/usr/bin/perl -w
+# -*- perl -*-
+# vim: ft=perl
+
+=head1 NAME
+
+snmp__syno_hddtemp - Munin plugin to monitor the temperature of 
+harddisks in an Synology NAS.
+
+=head1 APPLICABLE SYSTEMS
+
+Any Synology NAS device which provides the synoDisk MIB.
+
+=head1 CONFIGURATION
+
+As a rule SNMP plugins need site specific configuration.  The default
+configuration (shown here) will only work on insecure sites/devices.
+
+   [snmp_*]
+	env.version 2
+        env.community public
+
+In general SNMP is not very secure at all unless you use SNMP version
+3 which supports authentication and privacy (encryption).  But in any
+case the community string for your devices should not be "public".
+
+Please see 'perldoc Munin::Plugin::SNMP' for further configuration
+information.
+
+=head1 INTERPRETATION
+
+The temperature of each disk installed in °C.
+
+=head1 MIB INFORMATION
+
+This plugin requires support for the synoDisk.  It reports 
+the temperature of the installed disks.
+
+=head1 MAGIC MARKERS
+
+  #%# family=snmpauto
+  #%# capabilities=snmpconf
+
+=head1 VERSION
+
+  $Id$
+
+=head1 BUGS
+
+None known.
+
+=head1 AUTHOR
+
+Copyright (C) 2015 Thomas Arthofer
+
+This plugin was derived from snmp__netstat by Lars Strand with updates
+by Matthew Boyle.
+
+=head1 LICENSE
+
+GPLv2.
+
+=cut
+
+use strict;
+use Munin::Plugin::SNMP;
+
+my $oid_drives = '1.3.6.1.4.1.6574.2.1.1';
+
+if (defined $ARGV[0] and $ARGV[0] eq 'snmpconf') {
+    print "require ${oid_drives}. [0-9]\n";
+    exit 0;
+}
+
+my ($session, $error) = Munin::Plugin::SNMP->session();
+
+my $table = $session->get_hash(
+                      -baseoid => $oid_drives, # IF-MIB
+                      -cols    => {
+                                   2 => 'name',
+                                   3 => 'type',
+                                   6 => 'temp',
+                                  }
+                   );
+
+if (defined $ARGV[0] and $ARGV[0] eq 'config') {
+    my ($host) = Munin::Plugin::SNMP->config_session();
+
+    print "host_name $host\n" unless $host eq 'localhost';
+    print "graph_title HDD temperature\n";
+    print "graph_category sensors\n";
+    print "graph_vlabel Degrees Celsius\n";
+    print "graph_info This graph shows the temperature of all HDDs in the Diskstation.\n";
+
+    foreach my $key ( sort keys %$table )
+    {
+      print "temp$key.label $table->{$key}->{'name'}\n";
+      print "temp$key.info Temperature of $table->{$key}->{'name'} ($table->{$key}->{'type'})\n";
+    }
+    exit 0;
+}
+
+
+my $names = $session->get_entries(-columns => [ $oid_drives ]);
+
+foreach my $key ( sort keys %$table )
+{
+  print "temp$key.value $table->{$key}->{'temp'}\n";
+}

--- a/plugins/snmp/snmp__synology_temperature
+++ b/plugins/snmp/snmp__synology_temperature
@@ -1,0 +1,91 @@
+#!/usr/bin/perl -w
+# -*- cperl -*-
+# vim: ft=perl
+
+=head1 NAME
+
+snmp__syno_temperature - Munin plugin to retrieve current temperature from a 
+Synology NAS.
+
+=head1 APPLICABLE SYSTEMS
+
+Any Synology NAS device which provides the synoSystem MIB.
+
+=head1 CONFIGURATION
+
+As a rule SNMP plugins need site specific configuration.  The default
+configuration (shown here) will only work on insecure sites/devices.
+
+   [snmp_*]
+        env.version 2
+        env.community public
+
+In general SNMP is not very secure at all unless you use SNMP version
+3 which supports authentication and privacy (encryption).  But in any
+case the community string for your devices should not be "public".
+
+Please see 'perldoc Munin::Plugin::SNMP' for further configuration
+information.
+
+=head1 INTERPRETATION
+
+This plugin queries the current temperature of the NAS.
+
+=head1 MIB INFORMATION
+
+This plugin requires support for the synoSystem MIB by Synology.
+It reports the contents of the temperature OID.
+
+=head1 MAGIC MARKERS
+
+  #%# family=snmpauto
+  #%# capabilities=snmpconf
+
+=head1 VERSION
+
+  $Id$
+
+=head1 BUGS
+
+None known.
+
+=head1 AUTHOR
+
+Copyright (C) 2015 Thomas Arthofer
+
+=head1 LICENSE
+
+GPLv2 or (at your option) any later version.
+
+=cut
+
+use strict;
+use Munin::Plugin::SNMP;
+
+if (defined $ARGV[0] and $ARGV[0] eq "snmpconf") {
+        print "require 1.3.6.1.4.1.6574.1.2.0 [0-9]\n"; # Number
+        exit 0;
+}
+
+if (defined $ARGV[0] and $ARGV[0] eq "config") {
+    my ($host) = Munin::Plugin::SNMP->config_session();
+        print "host_name $host\n" unless $host eq 'localhost';
+        print "graph_title Temperatures
+graph_args --base 1000 -l 0
+graph_vlabel Degrees Celsius
+graph_category sensors
+graph_info This graph shows the temperature of the diskstation.
+temp.label CPU
+temp.info The temperature of the onboard CPU.
+";
+        exit 0;
+}
+
+my $session = Munin::Plugin::SNMP->session(-translate =>
+                                           [ -timeticks => 0x0 ]);
+
+my $temp = $session->get_single (".1.3.6.1.4.1.6574.1.2.0") || 'ERROR';
+
+print "Retrived uptime is '$temp'\n" if $Munin::Plugin::SNMP::DEBUG;
+
+print "temp.value ", $temp, "\n";

--- a/plugins/snmp/snmp__synology_ups
+++ b/plugins/snmp/snmp__synology_ups
@@ -1,0 +1,102 @@
+#!/usr/bin/perl -w
+# -*- cperl -*-
+# vim: ft=perl
+
+=head1 NAME
+
+snmp__syno_ups - Munin plugin to retrieve various information of the 
+UPS attached to a Synology NAS.
+
+=head1 APPLICABLE SYSTEMS
+
+Any Synology NAS device which provides the synoUPS MIB.
+
+=head1 CONFIGURATION
+
+As a rule SNMP plugins need site specific configuration.  The default
+configuration (shown here) will only work on insecure sites/devices.
+
+   [snmp_*]
+        env.version 2
+        env.community public
+
+In general SNMP is not very secure at all unless you use SNMP version
+3 which supports authentication and privacy (encryption).  But in any
+case the community string for your devices should not be "public".
+
+Please see 'perldoc Munin::Plugin::SNMP' for further configuration
+information.
+
+=head1 INTERPRETATION
+
+The plugin reports the following stats about the UPS attached:
+ - Load in %
+ - Charge in %
+
+=head1 MIB INFORMATION
+
+This plugin requires support for the synoUPS MIB by Synology.
+
+=head1 MAGIC MARKERS
+
+  #%# family=snmpauto
+  #%# capabilities=snmpconf
+
+=head1 VERSION
+
+  $Id$
+
+=head1 BUGS
+
+None known.
+
+=head1 AUTHOR
+
+Copyright (C) 2015 Thomas Arthofer
+
+=head1 LICENSE
+
+GPLv2 or (at your option) any later version.
+
+=cut
+
+use strict;
+use Munin::Plugin::SNMP;
+
+if (defined $ARGV[0] and $ARGV[0] eq "snmpconf") {
+        print "require 1.3.6.1.4.1.6574.4.3.1.1.0 [0-9]\n"; # Charge
+        print "require 1.3.6.1.4.1.6574.4.2.12.1.0 [0-9]\n"; # Load
+        exit 0;
+}
+
+if (defined $ARGV[0] and $ARGV[0] eq "config") {
+    my ($host) = Munin::Plugin::SNMP->config_session();
+        print "host_name $host\n" unless $host eq 'localhost';
+        print "graph_title UPS
+graph_args --base 1000 -l 0
+graph_vlabel Status of UPS
+graph_category system
+graph_info This graph shows the status of the attached UPS.
+charge.label Charge
+charge.info Charge status of battery.
+charge.draw LINE2
+load.label Load
+load.info Load on the UPS
+";
+        exit 0;
+}
+
+my $session = Munin::Plugin::SNMP->session(-translate =>
+                                           [ -timeticks => 0x0 ]);
+
+my $charge = $session->get_single (".1.3.6.1.4.1.6574.4.3.1.1.0") || 'ERROR';
+$charge = unpack "f", reverse pack "H*", $charge;
+
+my $load = $session->get_single (".1.3.6.1.4.1.6574.4.2.12.1.0") || 'ERROR';
+$load = unpack "f", reverse pack "H*", $load;
+
+print "Retrived charge '$charge'\n" if $Munin::Plugin::SNMP::DEBUG;
+print "Retrived load '$load'\n" if $Munin::Plugin::SNMP::DEBUG;
+
+print "charge.value ", $charge, "\n";
+print "load.value ", $load, "\n";


### PR DESCRIPTION
Synology specific snmp plugins for:
- System temperature
- HDD temperature
- UPS Charge & Load

I noticed there is already a multigraph plugin for temperatures, but sadly the other one is using python with pysnmp which may not be installed on every system.

![snmp_synology_syno_temperature-day](https://cloud.githubusercontent.com/assets/1294885/8237783/f912b1ea-15f1-11e5-849c-7d4685321f69.png)

![snmp_synology_syno_hddtemp-day](https://cloud.githubusercontent.com/assets/1294885/8237782/f90feac8-15f1-11e5-9547-7cb5df93018e.png)

![snmp_synology_syno_ups-day](https://cloud.githubusercontent.com/assets/1294885/8237784/f916e404-15f1-11e5-8d07-b29bff1d1061.png)

