### PR TITLE
rewrite memcached family plugins for unix socket usage

### DIFF
--- a/plugins/memcached_ext/memcached_ext_bytes_
+++ b/plugins/memcached_ext/memcached_ext_bytes_
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+# ex:ts=4
+
+use strict;
+use warnings;
+
+use Cache::Memcached;
+
+# Based on original plugin, extended to unix socket use
+# https://github.com/western, westroads@gmail.com
+
+=head1 example config for /plugin-conf.d/munin-node
+
+[memcached_bytes_1]
+env.server 127.0.0.1:11211
+env.label "first local server"
+
+[memcached_bytes_2]
+env.server /var/run/memcached/memcached.sock
+env.label "second local server"
+
+=cut
+
+my $label = exists $ENV{'label'} ? $ENV{'label'} : '';
+unless( $label ){
+	
+	if( $0 =~ /memcached_ext_bytes_([\d\w]+)$/ ){
+		$label = $1;
+	}
+}
+
+my $cmd = shift || '';
+if ($cmd eq 'config') {
+	print "graph_title Memcached bytes used on $label\n";
+	print "graph_args --base 1024 -l 0\n";
+	print "graph_vlabel bytes\n";
+	print "graph_category memcached\n";
+	print "graph_info This graph monitors the size of the memcached cache.\n";
+	print "bytes.label bytes used\n";
+	print "bytes.info Number of bytes currently used\n";
+	print "bytes.min 0\n";
+	print "bytes.draw AREA\n";
+	print "maxbytes.label maximum available\n";
+	print "maxbytes.info The configured cache size\n";
+	print "maxbytes.min 0\n";
+	exit 0;
+}
+
+
+my $server = exists $ENV{'server'} ? $ENV{'server'} : '127.0.0.1:11211';
+
+my $memd = new Cache::Memcached { 'servers' => [$server] };
+my $memstats = $memd->stats(['misc']);
+
+print "bytes.value " . $memstats->{hosts}->{$server}->{misc}->{bytes} . "\n";
+print "maxbytes.value " .
+	$memstats->{hosts}->{$server}->{misc}->{limit_maxbytes} . "\n";

--- a/plugins/memcached_ext/memcached_ext_connections_
+++ b/plugins/memcached_ext/memcached_ext_connections_
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+# ex:ts=4
+
+use strict;
+use warnings;
+
+use Cache::Memcached;
+
+# Based on original plugin, extended to unix socket use
+# https://github.com/western, westroads@gmail.com
+
+=head1 example config for /plugin-conf.d/munin-node
+
+[memcached_connections_1]
+env.server 127.0.0.1:11211
+env.label "first local server"
+
+[memcached_connections_2]
+env.server /var/run/memcached/memcached.sock
+env.label "second local server"
+
+=cut
+
+my $label = exists $ENV{'label'} ? $ENV{'label'} : '';
+unless( $label ){
+	
+	if( $0 =~ /memcached_ext_connections_([\w\d]+)$/ ){
+		$label = $1;
+	}
+}
+
+my $cmd = shift || '';
+if ($cmd eq 'config') {
+	print "graph_title Memcached connections on $label\n";
+	print "graph_args --base 1000 -l 0\n";
+	print "graph_vlabel connections\n";
+	print "graph_category memcached\n";
+	print "graph_info This graph monitors the connections to the memcached server.\n";
+	print "connections.label connections\n";
+	print "connections.info Number of connections to memcached\n";
+	print "connections.min 0\n";
+	print "connections.draw AREA\n";
+	exit 0;
+}
+
+
+my $server = exists $ENV{'server'} ? $ENV{'server'} : '127.0.0.1:11211';
+
+my $memd = new Cache::Memcached { 'servers' => [$server] };
+my $memstats = $memd->stats(['misc']);
+
+print "connections.value " .
+	$memstats->{hosts}->{$server}->{misc}->{curr_connections} . "\n";

--- a/plugins/memcached_ext/memcached_ext_hits_
+++ b/plugins/memcached_ext/memcached_ext_hits_
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+# ex:ts=4
+
+use strict;
+use warnings;
+
+use Cache::Memcached;
+
+# Based on original plugin, extended to unix socket use
+# https://github.com/western, westroads@gmail.com
+
+=head1 example config for /plugin-conf.d/munin-node
+
+[memcached_hits_1]
+env.server 127.0.0.1:11211
+env.label "first local server"
+
+[memcached_hits_2]
+env.server /var/run/memcached/memcached.sock
+env.label "second local server"
+
+=cut
+
+my $label = exists $ENV{'label'} ? $ENV{'label'} : '';
+unless( $label ){
+	
+	if( $0 =~ /memcached_ext_hits_([\w\d]+)$/ ){
+		$label = $1;
+	}
+}
+
+
+
+my $cmd = shift || '';
+if ($cmd eq 'config') {
+	print "graph_title Memcached cache hits and misses on $label\n";
+	print "graph_args --base 1000 -l 0\n";
+	print "graph_vlabel requests\n";
+	print "graph_category memcached\n";
+	print "graph_info This graph monitors the number of cache hits and misses.\n";
+	print "hits.label hits\n";
+	print "hits.info Number of cache hits\n";
+	print "hits.min 0\n";
+	print "hits.type DERIVE\n";
+	print "misses.label misses\n";
+	print "misses.info Number of cache misses\n";
+	print "misses.min 0\n";
+	print "misses.type DERIVE\n";
+	print "misses.draw AREA\n";
+	exit 0;
+}
+
+my $server = exists $ENV{'server'} ? $ENV{'server'} : '127.0.0.1:11211';
+
+my $memd = new Cache::Memcached { 'servers' => [$server] };
+my $memstats = $memd->stats(['misc']);
+
+print "hits.value " . $memstats->{hosts}->{$server}->{misc}->{get_hits} . "\n";
+print "misses.value " .
+	$memstats->{hosts}->{$server}->{misc}->{get_misses} . "\n";

--- a/plugins/memcached_ext/memcached_ext_items_
+++ b/plugins/memcached_ext/memcached_ext_items_
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+# ex:ts=4
+
+use strict;
+use warnings;
+
+use Cache::Memcached;
+
+# Based on original plugin, extended to unix socket use
+# https://github.com/western, westroads@gmail.com
+
+=head1 example config for /plugin-conf.d/munin-node
+
+[memcached_items_1]
+env.server 127.0.0.1:11211
+env.label "first local server"
+
+[memcached_items_2]
+env.server /var/run/memcached/memcached.sock
+env.label "second local server"
+
+=cut
+
+my $label = exists $ENV{'label'} ? $ENV{'label'} : '';
+unless( $label ){
+	
+	if( $0 =~ /memcached_ext_items_([\w\d]+)$/ ){
+		$label = $1;
+	}
+}
+
+
+my $cmd = shift || '';
+if ($cmd eq 'config') {
+	print "graph_title Memcached cached items on $label\n";
+	print "graph_args --base 1000 -l 0\n";
+	print "graph_vlabel items\n";
+	print "graph_category memcached\n";
+	print "graph_info This graph monitors the number of items stored by the memcached server.\n";
+	print "items.label items\n";
+	print "items.info Number of cached items\n";
+	print "items.min 0\n";
+	print "items.draw AREA\n";
+	exit 0;
+}
+
+my $server = exists $ENV{'server'} ? $ENV{'server'} : '127.0.0.1:11211';
+
+my $memd = new Cache::Memcached { 'servers' => [$server] };
+my $memstats = $memd->stats(['misc']);
+
+print "items.value " .
+	$memstats->{hosts}->{$server}->{misc}->{curr_items} . "\n";

--- a/plugins/memcached_ext/memcached_ext_requests_
+++ b/plugins/memcached_ext/memcached_ext_requests_
@@ -1,0 +1,59 @@
+#!/usr/bin/env perl
+# ex:ts=4
+
+use strict;
+use warnings;
+
+use Cache::Memcached;
+
+# Based on original plugin, extended to unix socket use
+# https://github.com/western, westroads@gmail.com
+
+=head1 example config for /plugin-conf.d/munin-node
+
+[memcached_requests_1]
+env.server 127.0.0.1:11211
+env.label "first local server"
+
+[memcached_requests_2]
+env.server /var/run/memcached/memcached.sock
+env.label "second local server"
+
+=cut
+
+my $label = exists $ENV{'label'} ? $ENV{'label'} : '';
+unless( $label ){
+	
+	if( $0 =~ /memcached_ext_requests_([\w\d]+)$/ ){
+		$label = $1;
+	}
+}
+
+
+my $cmd = shift || '';
+if ($cmd eq 'config') {
+	print "graph_title Memcached requests on $label\n";
+	print "graph_args --base 1000 -l 0\n";
+	print "graph_vlabel requests\n";
+	print "graph_category memcached\n";
+	print "graph_info This graph monitors the number of get and set requests.\n";
+	print "gets.label gets\n";
+	print "gets.info Number of get requests\n";
+	print "gets.min 0\n";
+	print "gets.type DERIVE\n";
+	print "gets.draw AREA\n";
+	print "sets.label sets\n";
+	print "sets.info Number of set requests\n";
+	print "sets.min 0\n";
+	print "sets.type DERIVE\n";
+	print "sets.draw STACK\n";
+	exit 0;
+}
+
+my $server = exists $ENV{'server'} ? $ENV{'server'} : '127.0.0.1:11211';
+
+my $memd = new Cache::Memcached { 'servers' => [$server] };
+my $memstats = $memd->stats(['misc']);
+
+print "gets.value " . $memstats->{hosts}->{$server}->{misc}->{cmd_get} . "\n";
+print "sets.value " . $memstats->{hosts}->{$server}->{misc}->{cmd_set} . "\n";

--- a/plugins/memcached_ext/memcached_ext_traffic_
+++ b/plugins/memcached_ext/memcached_ext_traffic_
@@ -1,0 +1,60 @@
+#!/usr/bin/env perl
+# ex:ts=4
+
+use strict;
+use warnings;
+
+use Cache::Memcached;
+
+# Based on original plugin, extended to unix socket use
+# https://github.com/western, westroads@gmail.com
+
+=head1 example config for /plugin-conf.d/munin-node
+
+[memcached_traffic_1]
+env.server 127.0.0.1:11211
+env.label "first local server"
+
+[memcached_traffic_2]
+env.server /var/run/memcached/memcached.sock
+env.label "second local server"
+
+=cut
+
+my $label = exists $ENV{'label'} ? $ENV{'label'} : '';
+unless( $label ){
+	
+	if( $0 =~ /memcached_ext_traffic_([\w\d]+)$/ ){
+		$label = $1;
+	}
+}
+
+
+my $cmd = shift || '';
+if ($cmd eq 'config') {
+	print "graph_title Memcached network traffic on $label\n";
+	print "graph_args --base 1000 -l 0\n";
+	print "graph_vlabel bits per \${graph_period}\n";
+	print "graph_category memcached\n";
+	print "graph_info This graph monitors the network traffic of the memcached server.\n";
+	print "up.label bits in\n";
+	print "up.info Traffic received by memcached\n";
+	print "up.min 0\n";
+	print "up.cdef up,8,*\n";
+	print "up.type COUNTER\n";
+	print "up.draw AREA\n";
+	print "down.label bits out\n";
+	print "down.info Traffic sent by memcached\n";
+	print "down.min 0\n";
+	print "down.cdef down,8,*\n";
+	print "down.type COUNTER\n";
+	exit 0;
+}
+
+my $server = exists $ENV{'server'} ? $ENV{'server'} : '127.0.0.1:11211';
+
+my $memd = new Cache::Memcached { 'servers' => [$server] };
+my $memstats = $memd->stats(['misc']);
+
+print "up.value " . $memstats->{hosts}->{$server}->{misc}->{bytes_read} . "\n";
+print "down.value " . $memstats->{hosts}->{$server}->{misc}->{bytes_written} . "\n";

--- a/plugins/redis/redis_
+++ b/plugins/redis/redis_
@@ -35,9 +35,11 @@
 
 use strict;
 use IO::Socket::INET;
+use IO::Socket::UNIX;
 use Switch;
 
 my $HOST = exists $ENV{'host'} ? $ENV{'host'} : "127.0.0.1";
+my $UNIX_SOCKET = exists $ENV{'unixsocket'} ? $ENV{'unixsocket'} : ''; # path to Redis Unix sock file
 my $PORT = exists $ENV{'port'} ? $ENV{'port'} : 6379;
 my $PASSWORD = exists $ENV{'password'} ? $ENV{'password'} : undef;
 my $TITLE_PREFIX = exists $ENV{'title_prefix'} ? $ENV{'title_prefix'} . ": " : "";
@@ -208,12 +210,26 @@ switch ($0) {
 close ($sock);
 
 sub get_conn {
-    my $sock = IO::Socket::INET->new(
-        PeerAddr => $HOST,
-        PeerPort => $PORT,
-        Timeout => 10,
-        Proto => 'tcp'
-    );
+    
+    my $sock;
+    
+    if( $UNIX_SOCKET && -S $UNIX_SOCKET ){
+	
+	$sock = IO::Socket::UNIX->new(
+		Type => SOCK_STREAM(),
+		Peer => $UNIX_SOCKET,
+	);
+	
+    }else{
+	
+	$sock = IO::Socket::INET->new(
+		PeerAddr => $HOST,
+		PeerPort => $PORT,
+		Timeout => 10,
+		Proto => 'tcp'
+	);
+    }
+    
     if ( defined( $PASSWORD )  ) {
         print $sock "AUTH ", $PASSWORD, "\r\n";
         my $result = <$sock> || die "can't read socket: $!";


### PR DESCRIPTION
rewrite memcached family plugins: bytes_, connections_, hits_, items_, requests_, traffic_
for unix socket usage
