### PR TITLE
Jenkins fixes

### DIFF
--- a/plugins/jenkins/jenkins_
+++ b/plugins/jenkins/jenkins_
@@ -74,6 +74,7 @@ my %states = (
 	'red'=>'failing',
 	'red_anime'=>'failing',
 	'disabled'=>'disabled',
+	'notbuilt' => 'disabled',
 	'notbuilt_anime' =>'disabled',
 	'aborted'=>'failing',
 	'aborted_anime'=>'failing'

--- a/plugins/jenkins/jenkins_
+++ b/plugins/jenkins/jenkins_
@@ -79,7 +79,7 @@ my %states = (
 	'aborted'=>'failing',
 	'aborted_anime'=>'failing'
 );
-my %counts = ('blue' => 0, 'yellow'=>0, 'red'=>0, 'disabled'=>0);
+my %counts = ('stable' => 0, 'unstable'=>0, 'failing'=>0, 'disabled'=>0);
 
 if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
 	if( $type eq "results" ) {
@@ -136,14 +136,14 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
 		my $parsed = decode_json($result);
 		foreach my $cur(@{$parsed->{'jobs'}}) {
 			if (defined $states{$cur->{'color'}}) {
-				$counts{$cur->{'color'}} += 1;
+				$counts{$states{$cur->{'color'}}} += 1;
 			} else {
 				warn "Ignoring unknown color " . $cur->{'color'} . "\n"
 			}
 		}
 		
 		foreach my $status (keys %counts) {
-			print "build_$states{$status}.value $counts{$status}\n";
+			print "build_$status.value $counts{$status}\n";
 		}
 		exit;
 	}

--- a/plugins/jenkins/jenkins_
+++ b/plugins/jenkins/jenkins_
@@ -66,7 +66,18 @@ my $wgetBin = "/usr/bin/wget";
 my $type = basename($0);
 $type =~ s/jenkins_//;
 
-my %states = ('blue' =>'stable', 'blue_anime' =>'stable', 'yellow'=>'unstable', 'yellow_anime'=>'unstable', 'red'=>'failing', 'red_anime'=>'failing', 'disabled'=>'disabled', 'notbuilt_anime' =>'disabled', 'aborted'=>'failing', 'aborted_anime'=>'failing' );
+my %states = (
+	'blue' =>'stable',
+	'blue_anime' =>'stable',
+	'yellow'=>'unstable',
+	'yellow_anime'=>'unstable',
+	'red'=>'failing',
+	'red_anime'=>'failing',
+	'disabled'=>'disabled',
+	'notbuilt_anime' =>'disabled',
+	'aborted'=>'failing',
+	'aborted_anime'=>'failing'
+);
 my %counts = ('blue' => 0, 'yellow'=>0, 'red'=>0, 'disabled'=>0);
 
 if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {

--- a/plugins/jenkins/jenkins_
+++ b/plugins/jenkins/jenkins_
@@ -134,7 +134,11 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
 		my $result = `$cmd/api/json`;
 		my $parsed = decode_json($result);
 		foreach my $cur(@{$parsed->{'jobs'}}) {
-			$counts{$cur->{'color'}} += 1;
+			if (defined $states{$cur->{'color'}}) {
+				$counts{$cur->{'color'}} += 1;
+			} else {
+				warn "Ignoring unknown color " . $cur->{'color'} . "\n"
+			}
 		}
 		
 		foreach my $status (keys %counts) {


### PR DESCRIPTION
Some build statuses reported by Jenkins were not counted by this plugin, since counting was done using the unmapped versions of the status names. This PR fixes that, with some related (though trivial) improvements along the way.