### PR TITLE
p: fixing openweather_: replaced fgrep, tr, cut with expr

### DIFF
--- a/plugins/weather/openweather_
+++ b/plugins/weather/openweather_
@@ -19,6 +19,7 @@
 # env.apikey XYZ
 
 query_string=$(printf '%s' "${0#*_}" | tr '_' '=')
+plugin_name=$( basename $0 )
 
 OWAPI=$( curl -s "http://api.openweathermap.org/data/2.5/weather?mode=xml&${query_string}")
 # API returns temp in K, we have to convert it in C
@@ -30,7 +31,7 @@ CITY=$( expr "$OWAPI" : '.*\<city.*name=\"\(.*\)\"><coord.*' )
 if [ "$1" = "config" ];
 then
 	cat <<- EOF
-		multigraph $0
+		multigraph $plugin_name
 		graph_title Temperature in ${CITY}
 		graph_vlabel Celsius
 		graph_category weather
@@ -38,7 +39,7 @@ then
 		temp_avg.label avg
 		temp_avg.cdef $KELVIN_BIAS,-
 
-		multigraph $0.temp
+		multigraph $plugin_name.temp
 		graph_title Temperature in ${CITY}
 		graph_vlabel Celsius
 		graph_category weather
@@ -50,28 +51,28 @@ then
 		temp_max.label max
 		temp_max.cdef $KELVIN_BIAS,-
 
-		multigraph $0.humidity
+		multigraph $plugin_name.humidity
 		graph_title Humidity in ${CITY}
 		graph_vlabel %
 		graph_category weather
 		graph_info This graph show the humidity in ${CITY}
 		humidity.label humidity
 
-		multigraph $0.pressure
+		multigraph $plugin_name.pressure
 		graph_title Pressure in ${CITY}
 		graph_vlabel hPa
 		graph_category weather
 		graph_info This graph show the pressure in ${CITY}
 		pressure.label pressure
 
-		multigraph $0.wind_speed
+		multigraph $plugin_name.wind_speed
 		graph_title Wind Speed in ${CITY}
 		graph_vlabel m/s
 		graph_category weather
 		graph_info This graph show the wind speed in ${CITY}
 		speed.label wind speed
 
-		multigraph $0.wind_direction
+		multigraph $plugin_name.wind_direction
 		graph_title Wind direction in ${CITY}
 		graph_vlabel m/s
 		graph_category weather
@@ -94,24 +95,24 @@ WD_SPEED=$( expr "$OWAPI" : '.*\<speed .*value=\"\(.*\)\" name.*/speed.*' )
 WD_DIREC=$( expr "$OWAPI" : '.*\<direction .*value=\"\(.*\)\" code.*/direction.*' )
 
 cat <<- EOF
-	multigraph $0
+	multigraph $plugin_name
 	temp_avg.value	$TEMP_AVG
 
-	multigraph $0.temp
+	multigraph $plugin_name.temp
 	temp_avg.value $TEMP_AVG
 	temp_min.value $TEMP_MIN
 	temp_max.value $TEMP_MAX
 
-	multigraph $0.humidity
+	multigraph $plugin_name.humidity
 	humidity.value $HUMIDITY
 
-	multigraph $0.pressure
+	multigraph $plugin_name.pressure
 	pressure.value $PRESSURE
 
-	multigraph $0.wind_speed
+	multigraph $plugin_name.wind_speed
 	speed.value $WD_SPEED
 
-	multigraph $0.wind_direction
+	multigraph $plugin_name.wind_direction
 	direction.label $WD_DIREC
 EOF
 

--- a/plugins/weather/openweather_
+++ b/plugins/weather/openweather_
@@ -113,7 +113,7 @@ cat <<- EOF
 	speed.value $WD_SPEED
 
 	multigraph $plugin_name.wind_direction
-	direction.vaule $WD_DIREC
+	direction.value $WD_DIREC
 EOF
 
 

--- a/plugins/weather/openweather_
+++ b/plugins/weather/openweather_
@@ -19,15 +19,13 @@
 # env.apikey XYZ
 
 query_string=$(printf '%s' "${0#*_}" | tr '_' '=')
-TMPFILE=$(mktemp)
-trap 'rm -f $TMPFILE' EXIT
 
+OWAPI=$( curl -s "http://api.openweathermap.org/data/2.5/weather?mode=xml&${query_string}")
 # API returns temp in K, we have to convert it in C
+# &units=metric would change that ;-)
 KELVIN_BIAS=273
 
-curl -s "http://api.openweathermap.org/data/2.5/weather?mode=xml&${query_string}&APPID=${apikey}" > $TMPFILE
-
-CITY=$(fgrep "<city id=" $TMPFILE | tr -sc '[:alnum:]' ' ' | cut -d " " -f 6)
+CITY=$( expr "$OWAPI" : '.*\<city.*name=\"\(.*\)\"><coord.*' )
 
 if [ "$1" = "config" ];
 then
@@ -85,15 +83,15 @@ then
 	[ "$MUNIN_CAP_DIRTYCONFIG" = 1 ] || exit 0
 fi
 
-TEMP_AVG=$(fgrep "<temperature value=" $TMPFILE | tr -sc '[:alnum:].' ' ' | cut -d " " -f 4)
-TEMP_MIN=$(fgrep "<temperature value=" $TMPFILE | tr -sc '[:alnum:].' ' ' | cut -d " " -f 6)
-TEMP_MAX=$(fgrep "<temperature value=" $TMPFILE | tr -sc '[:alnum:].' ' ' | cut -d " " -f 8)
+TEMP_AVG=$( expr "$OWAPI" : '.*\<temperature value=\"\(.*\)\" min.*/temperature.*' )
+TEMP_MIN=$( expr "$OWAPI" : '.*\<temperature .*min=\"\(.*\)\" max.*/temperature.*' )
+TEMP_MAX=$( expr "$OWAPI" : '.*\<temperature .*max=\"\(.*\)\" unit.*/temperature.*' )
 
-HUMIDITY=$(fgrep "<humidity value=" $TMPFILE | tr -sc '[:alnum:].' ' ' | cut -d " " -f 4)
-PRESSURE=$(fgrep "<pressure value=" $TMPFILE | tr -sc '[:alnum:].' ' ' | cut -d " " -f 4)
+HUMIDITY=$( expr "$OWAPI" : '.*\<humidity .*value=\"\(.*\)\" unit.*/humidity.*' )
+PRESSURE=$( expr "$OWAPI" : '.*\<pressure .*value=\"\(.*\)\" unit.*/pressure.*' )
 
-WD_SPEED=$(fgrep "<speed value=" $TMPFILE | tr -sc '[:alnum:].' ' ' | cut -d " " -f 4)
-WD_DIREC=$(fgrep "<direction value=" $TMPFILE | tr -sc '[:alnum:].' ' ' | cut -d " " -f 4)
+WD_SPEED=$( expr "$OWAPI" : '.*\<speed .*value=\"\(.*\)\" name.*/speed.*' )
+WD_DIREC=$( expr "$OWAPI" : '.*\<direction .*value=\"\(.*\)\" code.*/direction.*' )
 
 cat <<- EOF
 	multigraph $0

--- a/plugins/weather/openweather_
+++ b/plugins/weather/openweather_
@@ -113,7 +113,7 @@ cat <<- EOF
 	speed.value $WD_SPEED
 
 	multigraph $plugin_name.wind_direction
-	direction.label $WD_DIREC
+	direction.vaule $WD_DIREC
 EOF
 
 


### PR DESCRIPTION
Use expr to extract values and names from the OpenWeather API xml instead of the, when having a city with spaces in its name not correctly working fgrep | tr | cut construct.
