### PR TITLE
Fix bug where can't read MongoDB lock ratio

### DIFF
--- a/plugins/mongodb/mongo_lock
+++ b/plugins/mongodb/mongo_lock
@@ -20,7 +20,10 @@ name = "locked"
 def doData():
     status = getServerStatus()
     if status["version"] >= "2.2.0":
-        ratio = float(status["globalLock"]["lockTime"]) / status["globalLock"]["totalTime"]
+        if status["globalLock"]["lockTime"]["$numberLong"]:
+            ratio = float(status["globalLock"]["lockTime"]["$numberLong"]) / float(status["globalLock"]["totalTime"]["$numberLong"])
+        else:
+            ratio = float(status["globalLock"]["lockTime"]) / status["globalLock"]["totalTime"]
     else:
         ratio = status["globalLock"]["ratio"]
     print name + ".value " + str( 100 * ratio )


### PR DESCRIPTION
The `globalLock.totalTime` and `globalLock.lockTime` have `$numberLong` field on MongoDB 2.6:

```
globalLock: {
  totalTime: {
    $numberLong: "2858903123000"
  },
  lockTime: {
    $numberLong: "144783780"
  },
  ...
```

It needs to read `$numberLong` field.