### PR TITLE
p: openweather_: Add OpenWeather API Key

### DIFF
--- a/plugins/weather/openweather_
+++ b/plugins/weather/openweather_
@@ -13,6 +13,11 @@
 #    http://api.openweathermap.org/data/<api>/weather?<query_string>
 #
 
+## From Oct 9 2015 OpenWeather needs you to register and get an APIKEY
+# include this key by setting 'env.apikey' in munin plugin config, i.e.:
+# [openweather_*]
+# env.apikey XYZ
+
 query_string=$(printf '%s' "${0#*_}" | tr '_' '=')
 TMPFILE=$(mktemp)
 trap 'rm -f $TMPFILE' EXIT
@@ -20,7 +25,7 @@ trap 'rm -f $TMPFILE' EXIT
 # API returns temp in K, we have to convert it in C
 KELVIN_BIAS=273
 
-curl -s "http://api.openweathermap.org/data/2.5/weather?mode=xml&${query_string}" > $TMPFILE
+curl -s "http://api.openweathermap.org/data/2.5/weather?mode=xml&${query_string}&APPID=${apikey}" > $TMPFILE
 
 CITY=$(fgrep "<city id=" $TMPFILE | tr -sc '[:alnum:]' ' ' | cut -d " " -f 6)
 


### PR DESCRIPTION
OpenWeather needs you to use an API key since Oct 9 2015. Therefore I added env.apikey.
To get a key just register at OpenWeather.