### PR TITLE
Icecast stats

### DIFF
--- a/plugins/icecast/icecast2_stats_
+++ b/plugins/icecast/icecast2_stats_
@@ -1,0 +1,182 @@
+#!/usr/bin/python3
+#
+# This plugin shows the statistics of every source currently connected to the Icecast2 server.
+# See the Icecast2_ plugin for collecting data of specific mountpoints.
+#
+# An icecast server v2.4 or later is required for this module since it uses the status-json.xsl
+# output (see http://www.icecast.org/docs/icecast-2.4.1/server-stats.html).
+#
+# The following data for each source is available:
+#  * listeners: current count of listeners
+#  * duration: the age of the stream in seconds
+#
+# Additionally the Icecast service uptime is available.
+#
+# This plugin requires Python 3 (e.g. for urllib instead of urllib2).
+#
+#
+# Environment variables:
+#  * status_url: defaults to "http://localhost:8000/status-json.xsl"
+#
+#
+# Copyright (C) 2015 Lars Kruse <devel@sumpfralle.de>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+# Magic markers
+#%# capabilities=autoconf suggest
+#%# family=auto
+
+
+import datetime
+import json
+import os
+import urllib.request
+import sys
+
+
+status_url = os.getenv("status_url", "http://localhost:8000/status-json.xsl")
+PLUGIN_SCOPES = ("sources_listeners", "sources_duration", "service_uptime")
+PLUGIN_NAME_PREFIX = "icecast2_stats_"
+
+
+def clean_fieldname(name):
+    """ see http://munin-monitoring.org/wiki/notes_on_datasource_names
+
+    This function is a bit clumsy as it tries to avoid using a regular
+    expression for the sake of micropython compatibility.
+    """
+    def get_valid(char, position):
+        if char == '_':
+            return '_'
+        elif 'a' <= char.lower() <= 'z':
+            return char
+        elif (position > 0) and ('0' <= char <= '9'):
+            return char
+        else:
+            return '_'
+    return "".join([get_valid(char, position) for position, char in enumerate(name)])
+
+
+def parse_iso8601(datestring):
+    """ try to avoid using an external library for parsing an ISO8601 date string """
+    if datestring.endswith("Z"):
+        timestamp_string = datestring[:-1]
+        time_delta = datetime.timedelta(minutes=0)
+    else:
+        # the "offset_text" is something like "+0500" or "-0130"
+        timestamp_string, offset_text = datestring[:-5], datestring[-5:]
+        offset_minutes = int(offset_text[1:3]) * 60 + int(offset_text[3:])
+        if offset_text.startswith("+"):
+            pass
+        elif offset_text.startswith("-"):
+            offset_minutes *= -1
+        else:
+            # invalid format
+            return None
+        time_delta = datetime.timedelta(minutes=offset_minutes)
+    local_time = datetime.datetime.strptime(timestamp_string, "%Y-%m-%dT%H:%M:%S")
+    return local_time + time_delta
+
+
+def get_iso8601_age_days(datestring):
+    now = datetime.datetime.now()
+    timestamp = parse_iso8601(datestring)
+    if timestamp:
+        return (now - timestamp).total_seconds() / (24 * 60 * 60)
+    else:
+        return None
+
+
+def _get_json_statistics():
+    with urllib.request.urlopen(status_url) as conn:
+        json_body = conn.read()
+    return json.loads(json_body.decode("utf-8"))
+
+
+def get_sources():
+    sources = []
+    for source in _get_json_statistics()["icestats"]["source"]:
+        path_name = source["listenurl"].split("/")[-1]
+        sources.append({"name": path_name,
+                            "fieldname": clean_fieldname(path_name),
+                            "listeners": source["listeners"],
+                            "duration_days": get_iso8601_age_days(source["stream_start_iso8601"])})
+    sources.sort(key=lambda item: item["name"])
+    return sources
+
+
+def get_server_uptime_days():
+    return get_iso8601_age_days(_get_json_statistics()["icestats"]["server_start_iso8601"])
+
+
+def get_scope():
+    called_name = os.path.basename(sys.argv[0])
+    if called_name.startswith(PLUGIN_NAME_PREFIX):
+        scope = called_name[len(PLUGIN_NAME_PREFIX):]
+        if not scope in PLUGIN_SCOPES:
+            print("Invalid scope requested: {0} (expected: {1})".format(scope, "/".join(PLUGIN_SCOPES)), file=sys.stderr)
+            sys.exit(2)
+    else:
+        print("Invalid filename - failed to discover plugin scope", file=sys.stderr)
+        sys.exit(2)
+    return scope
+
+
+if __name__ == "__main__":
+    action = sys.argv[1] if (len(sys.argv) > 1) else None
+    if action == "autoconf":
+        try:
+            get_sources()
+            print("yes")
+        except OSError:
+            print("no")
+    elif action == "suggest":
+        for scope in PLUGIN_SCOPES:
+            print(scope)
+    elif action == "config":
+        scope = get_scope()
+        if scope == "sources_listeners":
+            print("graph_title Total number of listeners")
+            print("graph_vlabel listeners")
+            print("graph_category Icecast")
+            for index, source in enumerate(get_sources()):
+                print("{0}.label {1}".format(source["fieldname"], source["name"]))
+                print("{0}.draw {1}".format(source["fieldname"], ("AREA" if (index == 0) else "STACK")))
+        elif scope == "sources_duration":
+            print("graph_title Duration of sources")
+            print("graph_vlabel duration in days")
+            print("graph_category Icecast")
+            for source in get_sources():
+                print("{0}.label {1}".format(source["fieldname"], source["name"]))
+        elif scope == "service_uptime":
+            print("graph_title Icecast service uptime")
+            print("graph_vlabel uptime in days")
+            print("graph_category Icecast")
+            print("uptime.label service uptime")
+    elif action is None:
+        scope = get_scope()
+        if scope == "sources_listeners":
+            for source in get_sources():
+                print("{0}.value {1}".format(source["fieldname"], source["listeners"]))
+        elif scope == "sources_duration":
+            for source in get_sources():
+                print("{0}.value {1}".format(source["fieldname"], source["duration_days"] or 0))
+        elif scope == "service_uptime":
+            print("uptime.value {0}".format(get_server_uptime_days()))
+    else:
+        print("Invalid argument given: {0}".format(action), file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)

--- a/plugins/network/ath9k_
+++ b/plugins/network/ath9k_
@@ -1,0 +1,453 @@
+#!/bin/sh
+# weird shebang? See below: "interpreter selection"
+#
+# Collect information related to ath9k wireless events and states.
+#   * rate control statistics ("rc_stats")
+#   * events (dropped, transmitted, beacon loss, ...)
+#   * traffic (packets, bytes)
+#
+# All data is collected for each separate station (in case of multiple
+# connected peers). Combined graphs are provided as a summary.
+#
+#
+# This plugin works with the following python interpreters:
+#   * Python 2
+#   * Python 3
+#   * micropython
+#
+#
+# Copyright (C) 2015 Lars Kruse <devel@sumpfralle.de>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Magic markers
+#%# capabilities=autoconf suggest
+#%# family=auto
+
+"""true"
+# ****************** Interpreter Selection ***************
+# This unbelievable dirty hack allows to find a suitable python interpreter.
+# This is specifically useful for OpenWRT where typically only micropython is available.
+#
+# This "execution hack" works as follows:
+#   * the script is executed by busybox ash or another shell
+#   * the above line (three quotes before and one quote after 'true') evaluates differently for shell and python:
+#    * shell: run "true" (i.e. nothing happens)
+#    * python: ignore everything up to the next three consecutive quotes
+# Thus we may place shell code here that will take care for selecting an interpreter.
+
+# prefer micropython if it is available - otherwise fall back to any python (2 or 3)
+if which micropython >/dev/null; then
+    /usr/bin/micropython "$0" "$@"
+else
+    python "$0" "$@"
+fi
+exit $?
+"""
+
+
+"""
+The following graphs are generated for each physical ath9k interface:
+    phy0_wifi0_traffic
+      phy0_wifi0_traffic.station0
+      ...
+    pyh0_wifi0_events
+      phy0_wifi0_events.station0
+      ...
+    pyh0_wifi0_rc_stats
+      phy0_wifi0_rc_stats.station0
+      ...
+"""
+
+
+plugin_version = "0.2"
+
+STATION_TRAFFIC_COUNTERS = ("rx_bytes", "tx_bytes", "rx_packets", "tx_packets")
+STATION_EVENT_COUNTERS = ("tx_retry_count", "tx_retry_failed", "tx_filtered", "tx_fragments",
+                          "rx_dropped", "rx_fragments", "rx_duplicates", "beacon_loss_count")
+# 16 colors (see http://munin-monitoring.org/wiki/fieldname.colour) for visualizing
+# rate control selection (see rc_stats)
+QUALITY_GRAPH_COLORS_16 = ("FF1F00", "FF4500", "FF7000", "FF9700",
+                           "FFBC00", "FAE600", "D1FF00", "7BFF00",
+                           "1CFF00", "06E41B", "00C43B", "009D60",
+                           "007986", "0058A8", "0033CC", "0018DE")
+SYS_BASE_DIR = "/sys/kernel/debug/ieee80211"
+GRAPH_BASE_NAME = "ath9k_stats"
+PLUGIN_SCOPES = ("traffic", "events", "rcstats")
+
+
+import os
+import os.path
+import subprocess
+import sys
+
+
+class Station:
+
+    config_map = {"events": lambda station, **kwargs: station._get_events_config(**kwargs),
+                  "traffic": lambda station, **kwargs: station._get_traffic_config(**kwargs),
+                  "rcstats": lambda station, **kwargs: station._get_rc_stats_config(**kwargs)}
+    values_map = {"events": lambda station: station._events_stats,
+                  "traffic": lambda station: station._traffic_stats,
+                  "rcstats": lambda station: station._get_rc_stats_success()}
+
+    def __init__(self, label, key, path):
+        self._path = path
+        self.label = label
+        self.key = key
+        self._events_stats = self._parse_file_based_stats(STATION_EVENT_COUNTERS)
+        self._traffic_stats = self._parse_file_based_stats(STATION_TRAFFIC_COUNTERS)
+        self._rc_stats = self._parse_rc_stats()
+
+    def _parse_rc_stats(self):
+        """ example content
+
+         type           rate      tpt eprob *prob ret  *ok(*cum)        ok(      cum)
+         HT20/LGI       MCS0      5.6 100.0 100.0   3    0(   0)         3(        3)
+         HT20/LGI       MCS1     10.5 100.0 100.0   0    0(   0)         1(        1)
+         HT20/LGI       MCS2     14.9 100.0 100.0   0    0(   0)         1(        1)
+         HT20/LGI       MCS3     18.7  96.5 100.0   5    0(   0)       261(      328)
+         HT20/LGI       MCS4     25.3  95.6 100.0   5    0(   0)      4267(     5460)
+         HT20/LGI       MCS5     30.6  95.8 100.0   5    0(   0)     11735(    17482)
+         HT20/LGI       MCS6     32.9  95.7 100.0   5    0(   0)     24295(    32592)
+         HT20/LGI    DP MCS7     35.0  90.4  95.2   5    0(   0)     63356(    88600)
+         HT20/LGI       MCS8     10.5 100.0 100.0   0    0(   0)         1(        1)
+
+        beware: sometimes the last two pairs of columns are joined without withespace: "90959383(100188029)"
+        """
+        stats = {}
+        with open(os.path.join(self._path, "rc_stats"), "r") as statsfile:
+            rate_column = None
+            skip_retry_column = False
+            for index, line in enumerate(statsfile.readlines()):
+                # remove trailing linebreak, replace braces (annoyingly present in the lasf four columns)
+                line = line.rstrip().replace("(", " ").replace(")", " ")
+                # ignore the trailing summary lines
+                if not line:
+                    break
+                if index == 0:
+                    # we need to remember the start of the "rate" column (in order to skip the flags)
+                    rate_column = line.index("rate")
+                    if rate_column == 0:
+                        # the following weird format was found on a Barrier Breaker host (2014, Linux 3.10.49):
+                        #   rate      throughput  ewma prob  this prob  this succ/attempt   success    attempts
+                        #   ABCDP  6         5.4       89.9      100.0             0(  0)       171         183
+                        # Thus we just assume that there are five flag letters and two blanks.
+                        # Let's hope for the best!
+                        rate_column = 6
+                        # this format does not contain the "retry" column
+                        skip_retry_column = True
+                    # skip the header line
+                    continue
+                cutoff_line = line[rate_column:]
+                tokens = cutoff_line.split()
+                entry = {}
+                entry["rate"] = tokens.pop(0)
+                entry["throughput"] = float(tokens.pop(0))
+                entry["ewma_probability"] = float(tokens.pop(0))
+                entry["this_probability"] = float(tokens.pop(0))
+                if skip_retry_column:
+                    entry["retry"] = 0
+                else:
+                    entry["retry"] = int(tokens.pop(0))
+                entry["this_success"] = int(tokens.pop(0))
+                entry["this_attempts"] = int(tokens.pop(0))
+                entry["success"] = int(tokens.pop(0))
+                entry["attempts"] = int(tokens.pop(0))
+                # some "rate" values are given in MBit/s - some are MCS0..15
+                try:
+                    entry["rate_label"] = "{rate:d} MBit/s".format(rate=int(entry["rate"]))
+                except ValueError:
+                    # keep the MCS string
+                    entry["rate_label"] = entry["rate"]
+                stats[entry["rate"]] = entry
+        return stats
+
+    def _get_rc_stats_success(self):
+        rc_values = {self._get_rate_fieldname(rate["rate"]): rate["success"] for rate in self._rc_stats.values()}
+        rc_values["sum"] = sum(rc_values.values())
+        return rc_values
+
+    def _parse_file_based_stats(self, counters):
+        stats = {}
+        for counter in counters:
+            # some events are not handled with older versions (e.g. "beacon_loss_count")
+            filename = os.path.join(self._path, counter)
+            if os.path.exists(filename):
+                content = open(filename, "r").read().strip()
+                stats[counter] = int(content)
+        return stats
+
+    def get_values(self, scope, graph_base):
+        func = self.values_map[scope]
+        yield "multigraph {base}_{suffix}.{station}".format(base=graph_base, suffix=scope, station=self.key)
+        for key, value in func(self).items():
+            yield "{key}.value {value}".format(key=key, value=value)
+        yield ""
+
+    @classmethod
+    def get_summary_values(cls, scope, siblings, graph_base):
+        func = cls.values_map[scope]
+        yield "multigraph {base}_{suffix}".format(base=graph_base, suffix=scope)
+        stats = {}
+        for station in siblings:
+            for key, value in func(station).items():
+                stats[key] = stats.get(key, 0) + value
+        for key, value in stats.items():
+            yield "{key}.value {value}".format(key=key, value=value)
+        yield ""
+
+    def get_config(self, scope, graph_base):
+        func = self.config_map[scope]
+        yield "multigraph {base}_{suffix}.{station}".format(base=graph_base, suffix=scope, station=self.key)
+        yield from func(self, label=self.label, siblings=[self])
+
+    @classmethod
+    def get_summary_config(cls, scope, siblings, graph_base):
+        func = cls.config_map[scope]
+        yield "multigraph {base}_{suffix}".format(base=graph_base, suffix=scope)
+        for station in siblings:
+            yield from func(station, siblings=[station])
+
+    @classmethod
+    def _get_traffic_config(cls, label=None, siblings=None):
+        if label:
+            yield "graph_title ath9k Station Traffic {label}".format(label=label)
+        else:
+            yield "graph_title ath9k Station Traffic"
+        yield "graph_args --base 1024"
+        yield "graph_vlabel received (-) / transmitted (+)"
+        yield "graph_category wireless"
+        # convert bytes/s into kbit/s (x * 8 / 1000 = x / 125)
+        yield from _get_up_down_pair("kBit/s", "tx_bytes", "rx_bytes", divider=125, use_negative=False)
+        yield from _get_up_down_pair("Packets/s", "tx_packets", "rx_packets", use_negative=False)
+        yield ""
+
+    @classmethod
+    def _get_events_config(cls, label=None, siblings=None):
+        if label:
+            yield "graph_title ath9k Station Events {label}".format(label=label)
+        else:
+            yield "graph_title ath9k Station Events"
+        yield "graph_vlabel events per ${graph_period}"
+        yield "graph_category wireless"
+        events = set()
+        for station in siblings:
+            for event in STATION_EVENT_COUNTERS:
+                events.add(event)
+        for event in events:
+            yield "{event}.label {event}".format(event=event)
+            yield "{event}.type COUNTER".format(event=event)
+        yield ""
+
+    @classmethod
+    def _get_rate_fieldname(cls, rate):
+        return "rate_{0}".format(rate.lower()).replace(".", "_")
+
+    @classmethod
+    def _get_rc_stats_config(cls, label=None, siblings=None):
+        if label:
+            yield "graph_title ath9k Station Transmit Rates {label} Success".format(label=label)
+        else:
+            yield "graph_title ath9k Station Transmit Rates Success"
+        yield "graph_vlabel transmit rates %"
+        yield "graph_category wireless"
+        yield "graph_args --base 1000 -r --lower-limit 0 --upper-limit 100"
+        all_rates = {}
+        # collect alle unique rates
+        for station in siblings:
+            for rate, details in station._rc_stats.items():
+                all_rates[rate] = details
+        # return all rates
+        is_first = True
+        num_extract = lambda text: int("".join([char for char in text if "0" <= char <= "9"]))
+        get_key = lambda rate_name: cls._get_rate_fieldname(all_rates[rate_name]["rate"])
+        # add all rates for percent visualization ("MCS7,MCS6,MCS5,MCS4,MCS3,MCS2,MCS1,MCS0,+,+,+,+,+,+,+")
+        cdef = None
+        for sum_rate in all_rates:
+            if cdef is None:
+                cdef = get_key(sum_rate)
+            else:
+                cdef = "{key},{cdef},+".format(key=get_key(sum_rate), cdef=cdef)
+        yield "sum.label Sum of all counters"
+        yield "sum.type DERIVE"
+        yield "sum.graph no"
+        for index, rate in enumerate(sorted(all_rates, key=num_extract)):
+            details = all_rates[rate]
+            key = get_key(rate)
+            yield "{key}.label {rate_label}".format(key=key, rate_label=details["rate_label"])
+            yield "{key}.type DERIVE".format(key=key)
+            yield "{key}.min 0".format(key=key)
+            if index < len(QUALITY_GRAPH_COLORS_16):
+                yield "{key}.colour {colour}".format(key=key, colour=QUALITY_GRAPH_COLORS_16[index])
+            yield "{key}.draw {draw_type}".format(key=key, draw_type=("AREA" if is_first else "STACK"))
+            # divide the current value by the above sum of all counters and calculate percent
+            yield "{key}.cdef 100,{key},sum,/,*".format(key=key, cdef=cdef)
+            is_first = False
+        yield ""
+
+
+class WifiInterface:
+
+    def __init__(self, name, path, graph_base):
+        self._path = path
+        self._graph_base = graph_base
+        self.name = name
+        self.stations = tuple(self._parse_stations())
+
+    def _parse_arp_cache(self):
+        """ read IPs and MACs from /proc/net/arp and return a dictionary for MAC -> IP """
+        arp_cache = {}
+        # example content:
+        #   IP address       HW type     Flags       HW address            Mask     Device
+        #   192.168.2.70     0x1         0x0         00:00:00:00:00:00     *        eth0.10
+        #   192.168.12.76    0x1         0x2         24:a4:3c:fd:76:98     *        eth1.10
+        for line in open("/proc/net/arp", "r").read().split("\n"):
+            # skip empty lines
+            if not line: continue
+            tokens = line.split()
+            ip, mac = tokens[0], tokens[3]
+            # the header line can be ignored - all other should have well-formed MACs
+            if not ":" in mac: continue
+            # ignore remote peers outside of the broadcast domain
+            if mac == "00:00:00:00:00:00": continue
+            arp_cache[mac] = ip
+        return arp_cache
+
+    def _parse_stations(self):
+        stations_base = os.path.join(self._path, "stations")
+        arp_cache = self._parse_arp_cache()
+        for item in os.listdir(stations_base):
+            peer_mac = item
+            # use the IP or fall back to the MAC without separators (":")
+            if peer_mac in arp_cache:
+                label = arp_cache[peer_mac]
+                key = peer_mac.replace(":", "")
+            else:
+                label = peer_mac
+                key = "host_" + peer_mac.replace(":", "").replace(".", "")
+            yield Station(label, key, os.path.join(stations_base, item))
+
+    def get_config(self, scope):
+        yield from Station.get_summary_config(scope, self.stations, self._graph_base)
+        for station in self.stations:
+            yield from station.get_config(scope, self._graph_base)
+        yield ""
+
+    def get_values(self, scope):
+        yield from Station.get_summary_values(scope, self.stations, self._graph_base)
+        for station in self.stations:
+            yield from station.get_values(scope, self._graph_base)
+        yield ""
+
+
+class Ath9kDriver:
+
+    def __init__(self, path, graph_base):
+        self._path = path
+        self._graph_base = graph_base
+        self.interfaces = tuple(self._parse_interfaces())
+
+    def _parse_interfaces(self):
+        for phy in os.listdir(self._path):
+            phy_path = os.path.join(self._path, phy)
+            for item in os.listdir(phy_path):
+                if item.startswith("netdev:"):
+                    wifi = item.split(":", 1)[1]
+                    label = "{phy}/{interface}".format(phy=phy, interface=wifi)
+                    wifi_path = os.path.join(phy_path, item)
+                    graph_base = "{base}_{phy}_{interface}".format(base=self._graph_base, phy=phy, interface=wifi)
+                    yield WifiInterface(label, wifi_path, graph_base)
+
+    def get_config(self, scope):
+        for interface in self.interfaces:
+            yield from interface.get_config(scope)
+
+    def get_values(self, scope):
+        for interface in self.interfaces:
+            yield from interface.get_values(scope)
+
+
+
+def _get_up_down_pair(unit, key_up, key_down, factor=None, divider=None, use_negative=True):
+    """ return all required statements for a munin-specific up/down value pair
+        "factor" or "divider" can be given for unit conversions
+    """
+    for key in (key_up, key_down):
+        if use_negative:
+            yield "{key}.label {unit}".format(key=key, unit=unit)
+        else:
+            yield "{key}.label {key} {unit}".format(key=key, unit=unit)
+        yield "{key}.type COUNTER".format(key=key)
+        if factor:
+            yield "{key}.cdef {key},{factor},*".format(key=key, factor=factor)
+        if divider:
+            yield "{key}.cdef {key},{divider},/".format(key=key, divider=divider)
+    if use_negative:
+        yield "{key_down}.graph no".format(key_down=key_down)
+        yield "{key_up}.negative {key_down}".format(key_up=key_up, key_down=key_down)
+
+
+def get_scope():
+    called_name = os.path.basename(sys.argv[0])
+    name_prefix = "ath9k_"
+    if called_name.startswith(name_prefix):
+        scope = called_name[len(name_prefix):]
+        if not scope in PLUGIN_SCOPES:
+            print_error("Invalid scope requested: {0} (expected: {1})".format(scope, PLUGIN_SCOPES))
+            sys.exit(2)
+    else:
+        print_error("Invalid filename - failed to discover plugin scope")
+        sys.exit(2)
+    return scope
+
+
+def print_error(message):
+    # necessary fallback for micropython
+    linesep = getattr(os, "linesep", "\n")
+    sys.stderr.write(message + linesep)
+
+
+if __name__ == "__main__":
+    ath9k = Ath9kDriver(SYS_BASE_DIR, GRAPH_BASE_NAME)
+    # parse arguments
+    if len(sys.argv) > 1:
+        if sys.argv[1]=="config":
+            for item in ath9k.get_config(get_scope()):
+                print(item)
+            sys.exit(0)
+        elif sys.argv[1] == "autoconf":
+            if os.path.exists(SYS_BASE_PATH):
+                print('yes')
+            else:
+                print('no')
+            sys.exit(0)
+        elif sys.argv[1] == "suggest":
+            for scope in PLUGIN_SCOPES:
+                print(scope)
+            sys.exit(0)
+        elif sys.argv[1] == "version":
+            print_error('olsrd Munin plugin, version %s' % plugin_version)
+            sys.exit(0)
+        elif sys.argv[1] == "":
+            # ignore
+            pass
+        else:
+            # unknown argument
+            print_error("Unknown argument")
+            sys.exit(1)
+
+    # output values
+    for item in ath9k.get_values(get_scope()):
+        print(item)

--- a/plugins/network/olsrd
+++ b/plugins/network/olsrd
@@ -1,0 +1,340 @@
+#!/bin/sh
+# weird shebang? See below: "interpreter selection"
+#
+# Collect basic information about the neighbours of an OLSR node:
+#   * link quality
+#   * neighbour link quality
+#   * number of nodes reachable behind each neighbour
+#   * ping times of direct neighbours
+#
+# This plugin works with the following python interpreters:
+#   * Python 2
+#   * Python 3
+#   * micropython
+#
+# Environment variables:
+#   * OLSRD_HOST: name or IP of the host running the txtinfo plugin (default: localhost)
+#   * OLSRD_TXTINFO_PORT: the port that the txtinfo plugin is listening to (default: 2006)
+#   * OLSRD_BIN_PATH: name of the olsrd binary (only used for 'autoconf', defaults to /usr/sbin/olsrd)
+#   * MICROPYTHON_HEAP: adjust this parameter for micropython if your olsr network contains
+#     more than a few thousand nodes (default: 512k)
+#
+#
+# Copyright (C) 2015 Lars Kruse <devel@sumpfralle.de>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Magic markers
+#%# capabilities=autoconf
+#%# family=auto
+
+"""true"
+# ****************** Interpreter Selection ***************
+# This unbelievable dirty hack allows to find a suitable python interpreter.
+# This is specifically useful for OpenWRT where typically only micropython is available.
+#
+# Additionally we need to run micropython with additional startup options.
+# This is necessary due to our demand for more than 128k heap (this default is sufficient for only 400 olsr nodes).
+#
+# This "execution hack" works as follows:
+#   * the script is executed by busybox ash or another shell
+#   * the above line (three quotes before and one quote after 'true') evaluates differently for shell and python:
+#    * shell: run "true" (i.e. nothing happens)
+#    * python: ignore everything up to the next three consecutive quotes
+# Thus we may place shell code here that will take care for selecting an interpreter.
+
+# prefer micropython if it is available - otherwise fall back to any python (2 or 3)
+if which micropython >/dev/null; then
+    /usr/bin/micropython -X "heapsize=${MICROPYTHON_HEAP:-512k}" "$0" "$@"
+else
+    python "$0" "$@"
+fi
+exit $?
+"""
+
+
+plugin_version = "0.3"
+
+
+import os
+import socket
+import sys
+
+
+LQ_GRAPH_CONFIG = """
+graph_title     {title}
+graph_vlabel    Link Quality (-) / Neighbour Link Quality (+)
+graph_category  network
+graph_info      OLSR estimates the quality of a connection by the ratio of successfully received (link quality) and transmitted (neighbour link quality) hello packets.
+"""
+
+LQ_VALUES_CONFIG = """
+nlq{suffix}.label none
+nlq{suffix}.type GAUGE
+nlq{suffix}.graph no
+nlq{suffix}.draw {draw_type}
+nlq{suffix}.min 0
+lq{suffix}.label {label}
+lq{suffix}.type GAUGE
+lq{suffix}.draw {draw_type}
+lq{suffix}.negative nlq{suffix}
+lq{suffix}.min 0
+"""
+
+NEIGHBOUR_COUNT_CONFIG = """
+graph_title     Reachable nodes via neighbours
+graph_vlabel    Number of Nodes
+graph_category  network
+graph_info      Count the number of locally known routes passing through each direct neighbour. This number is a good approximation of the number of mesh nodes reachable via this specific neighbour. MIDs (alternative addresses of an OLSR node) and HNAs (host network announcements) are ignored.
+"""
+
+NEIGHBOUR_COUNT_VALUE = """
+neighbour_{host_fieldname}.label {host}
+neighbour_{host_fieldname}.type GAUGE
+neighbour_{host_fieldname}.draw {draw_type}
+neighbour_{host_fieldname}.min 0
+"""
+
+NEIGHBOUR_PING_CONFIG = """
+graph_title     {title}
+graph_vlabel    roundtrip time (ms)
+graph_category  network
+graph_info      This graph shows ping RTT statistics.
+graph_args      --base 1000 --lower-limit 0
+graph_scale     no
+"""
+
+NEIGHBOUR_PING_VALUE = """neighbour_{host_fieldname}.label {host}"""
+
+# micropython (as of 2015) does not contain "os.linesep"
+LINESEP = getattr(os, "linesep", "\n")
+
+
+get_clean_fieldname = lambda name: "".join([(("a" <= char.lower() <= "z") or ((index == 0) or ("0" <= char <= "9"))) and char or "_" for index, char in enumerate(name)])
+
+
+def query_olsrd_txtservice(section=""):
+    host = os.getenv("OLSRD_HOST", "localhost")
+    port = os.getenv("OLSRD_TXTINFO_PORT", "2006")
+    conn = socket.create_connection((host, port), 1.0)
+    try:
+        # Python3
+        request = bytes("/%s" % section, "ascii")
+    except TypeError:
+        # Python2
+        request = bytes("/%s" % section)
+    conn.sendall(request)
+    fconn = conn.makefile()
+    # "enumerate" is not suitable since it reads all lines at once (not a generator in micropython)
+    index = 0
+    for line in fconn.readlines():
+        # skip the first five lines - they are headers
+        if index < 5:
+            index += 1
+            continue
+        line = line.strip()
+        if line:
+            yield line
+    fconn.close()
+    conn.close()
+
+
+def get_address_device_mapping():
+    mapping = {}
+    for line in query_olsrd_txtservice("mid"):
+        # example line content:
+        #    192.168.2.171   192.168.22.171;192.168.12.171
+        device_id, mids = line.split()
+        for mid in mids.split(";"):
+            mapping[mid] = device_id
+    return mapping
+
+
+def count_routes_by_neighbour(address_mapping, ignore_list):
+    node_count = {}
+    for line in query_olsrd_txtservice("routes"):
+        # example line content:
+        #    192.168.1.79/32 192.168.12.38   4       4.008   wlan0
+        tokens = line.split()
+        target = tokens[0]
+        via = tokens[1]
+        # we care only about single-host routes
+        if target.endswith("/32"):
+            if target[:-3] in address_mapping:
+                # we ignore MIDs - we want only real nodes
+                continue
+            if target in ignore_list:
+                continue
+            # replace the neighbour's IP with its main IP (if it is an MID)
+            via = address_mapping.get(via, via)
+            # increase the counter
+            node_count[via] = node_count.get(via, 0) + 1
+    return node_count
+
+
+def get_olsr_links():
+    mid_mapping = get_address_device_mapping()
+    hna_list = [line.split()[0] for line in query_olsrd_txtservice("hna")]
+    route_count = count_routes_by_neighbour(mid_mapping, hna_list)
+    result = []
+    for line in query_olsrd_txtservice("links"):
+        tokens = line.split()
+        link = {}
+        link["local"] = tokens.pop(0)
+        remote = tokens.pop(0)
+        # replace the neighbour's IP with its main IP (if it is an MID)
+        link["remote"] = mid_mapping.get(remote, remote)
+        for key in ("hysterese", "lq", "nlq", "cost"):
+            link[key] = float(tokens.pop(0))
+        # add the route count
+        link["route_count"] = route_count.get(link["remote"], 0)
+        result.append(link)
+    result.sort(key=lambda link: link["remote"])
+    return result
+
+
+def _read_file(filename):
+    try:
+        return open(filename, "r").read().split(LINESEP)
+    except OSError:
+        return []
+
+
+def get_ping_times(hosts):
+    tempfile = "/tmp/munin-olsrd-{pid}.tmp".format(pid=os.getpid())
+    command = 'for host in {hosts}; do echo -n "$host "; ping -c 1 -w 1 "$host" | grep /avg/ || true; done >{tempfile}'\
+              .format(hosts=" ".join(hosts), tempfile=tempfile)
+    # micropython supports only "os.system" (as of 2015) - thus we need to stick with it for openwrt
+    returncode = os.system(command)
+    if returncode != 0:
+        return {}
+    lines = _read_file(tempfile)
+    os.unlink(tempfile)
+    # example output for one host:
+    #   192.168.2.41 round-trip min/avg/max = 4.226/4.226/4.226 ms
+    result = {}
+    for line in lines:
+        tokens = line.split(None)
+        if len(tokens) > 1:
+            host = tokens[0]
+            avg_ping = tokens[-2].split("/")[1]
+            result[host] = float(avg_ping)
+    return result
+
+
+if __name__ == "__main__":
+    # parse arguments
+    if len(sys.argv) > 1:
+        if sys.argv[1]=="config":
+            links = list(get_olsr_links())
+
+            # link quality with regard to neighbours
+            print("multigraph olsr_link_quality")
+            print(LQ_GRAPH_CONFIG.format(title="OLSR Link Quality"))
+            is_first = True
+            for link in links:
+                print(LQ_VALUES_CONFIG.format(label=link["remote"],
+                                              suffix="_{host}".format(host=get_clean_fieldname(link["remote"])),
+                                              draw_type=("AREA" if is_first else "STACK")))
+                is_first = False
+            is_first = True
+            for link in links:
+                print("multigraph olsr_link_quality.host_{remote}".format(remote=get_clean_fieldname(link["remote"])))
+                print(LQ_GRAPH_CONFIG.format(title="Link Quality towards {host}".format(host=link["remote"])))
+                print(LQ_VALUES_CONFIG.format(label="Link Quality", suffix="", draw_type="AREA"))
+                is_first = False
+
+            # link count ("number of nodes behind each neighbour")
+            print("multigraph olsr_neighbour_link_count")
+            print(NEIGHBOUR_COUNT_CONFIG)
+            is_first = True
+            for link in links:
+                print(NEIGHBOUR_COUNT_VALUE
+                      .format(host=link["remote"],
+                              host_fieldname=get_clean_fieldname(link["remote"]),
+                              draw_type=("AREA" if is_first else "STACK")))
+                is_first = False
+
+            # neighbour ping
+            print("multigraph olsr_neighbour_ping")
+            print(NEIGHBOUR_PING_CONFIG.format(title="Ping time of neighbours"))
+            for link in links:
+                print(NEIGHBOUR_PING_VALUE
+                      .format(host=link["remote"],
+                              host_fieldname=get_clean_fieldname(link["remote"])))
+            # neighbour pings - single subgraphs
+            for link in links:
+                remote = get_clean_fieldname(link["remote"])
+                print("multigraph olsr_neighbour_ping.host_{remote}".format(remote=remote))
+                print(NEIGHBOUR_PING_CONFIG.format(title="Ping time of {remote}".format(remote=remote)))
+                print(NEIGHBOUR_PING_VALUE.format(host=link["remote"], host_fieldname=remote))
+
+            sys.exit(0)
+        elif sys.argv[1] == "autoconf":
+            if os.path.exists(os.getenv('OLSRD_BIN_PATH', '/usr/sbin/olsrd')):
+                print('yes')
+            else:
+                print('no')
+            sys.exit(0)
+        elif sys.argv[1] == "version":
+            print('olsrd Munin plugin, version %s' % plugin_version)
+            sys.exit(0)
+        elif sys.argv[1] == "":
+            # ignore
+            pass
+        else:
+            # unknown argument
+            sys.stderr.write("Unknown argument{eol}".format(eol=LINESEP))
+            sys.exit(1)
+
+    # output values
+    links = list(get_olsr_links())
+
+    # overview graph for the link quality (ETX) of all neighbours
+    print("multigraph olsr_link_quality")
+    for link in links:
+        print("lq_{remote}.value {lq:f}".format(lq=link["lq"],
+                                                remote=get_clean_fieldname(link["remote"])))
+        print("nlq_{remote}.value {nlq:f}".format(nlq=link["nlq"],
+                                                  remote=get_clean_fieldname(link["remote"])))
+    # detailed ETX graph for each single neighbour link
+    for link in links:
+        print("multigraph olsr_link_quality.host_{remote}"
+              .format(remote=get_clean_fieldname(link["remote"])))
+        print("lq.value {lq:f}".format(lq=link["lq"]))
+        print("nlq.value {nlq:f}".format(nlq=link["nlq"]))
+
+    # count the links/nodes behind each neighbour node
+    print("multigraph olsr_neighbour_link_count")
+    for link in links:
+        print("neighbour_{host_fieldname}.value {value}"
+              .format(value=link["route_count"],
+                      host_fieldname=get_clean_fieldname(link["remote"])))
+
+    # overview of ping roundtrip times
+    print("multigraph olsr_neighbour_ping")
+    ping_times = get_ping_times([link["remote"] for link in links])
+    for link in links:
+        ping_time = ping_times.get(link["remote"], None)
+        if ping_time is not None:
+            print("neighbour_{remote}.value {value:.4f}"
+                  .format(value=ping_time,
+                          remote=get_clean_fieldname(link["remote"])))
+    # single detailed graphs for the ping time of each link
+    for link in links:
+        ping_time = ping_times.get(link["remote"], None)
+        if ping_time is not None:
+            remote = get_clean_fieldname(link["remote"])
+            print("multigraph olsr_neighbour_ping.host_{remote}".format(remote=remote))
+            print("neighbour_{remote}.value {value:.4f}".format(remote=remote, value=ping_time))

--- a/plugins/network/wireless_channel_occupation_
+++ b/plugins/network/wireless_channel_occupation_
@@ -1,0 +1,105 @@
+#!/bin/sh
+#
+# Monitor the wifi channel occupation (taken from "iw dev wlan0 survey dump").
+#
+# Symlink this plugin with the name of the wifi interface added (e.g. "wlan0").
+#
+#
+# Copyright (C) 2015 Lars Kruse <devel@sumpfralle.de>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Magic markers
+#%# capabilities=autoconf suggest
+#%# family=auto
+
+set -eu
+
+
+SCRIPT_PREFIX="wireless_channel_occupation_"
+
+
+clean_fieldname() {
+	echo "$1" | sed 's/^\([^A-Za-z_]\)/_\1/; s/[^A-Za-z0-9_]/_/g'
+}
+
+
+get_wifi_devices() {
+	iw dev | grep Interface | awk '{print $2}'
+}
+
+
+get_wifi_device_from_suffix() {
+	local suffix
+	local called
+	called=$(basename "$0")
+	suffix="${called#$SCRIPT_PREFIX}"
+	# empty result if the prefix did not match (and was not removed)
+	[ "$suffix" = "$0" ] && echo "" || echo "$suffix"
+}
+
+
+if [ "${1:-}" = "autoconf" ]; then
+	if which iw 2>/dev/null; then
+		if [ -n "$(get_wifi_devices)" ]; then
+			echo "yes"
+		else
+			echo "no (missing wifi devices)"
+		fi
+	else
+		echo "no (missing 'iw' dependency)"
+	fi
+elif [ "${1:-}" = "suggest" ]; then
+	get_wifi_devices
+elif [ "${1:-}" = "config" ]; then
+	device=$(get_wifi_device_from_suffix)
+	[ -z "$device" ] && echo >&2 "Invalid wifi device name given" && exit 1
+	echo "graph_title Channel Occupation of $device"
+	echo "graph_vlabel %"
+	echo "graph_category wireless"
+	echo "graph_args --base 1000 -r --lower-limit 0 --upper-limit 100"
+	dev_field=$(clean_fieldname "$device")
+
+	# active: listening time on this channel (usually: 5 minutes = 300000ms)
+	echo "${dev_field}_active.label Transmit"
+	echo "${dev_field}_active.type DERIVE"
+	echo "${dev_field}_active.graph no"
+
+	# busy = receive + transmit + unknown
+	echo "${dev_field}_busy.label unknown"
+	echo "${dev_field}_busy.type DERIVE"
+	echo "${dev_field}_busy.draw AREA"
+	echo "${dev_field}_busy.cdef 100,1,${dev_field}_active,${dev_field}_busy,${dev_field}_receive,${dev_field}_transmit,+,-,/,/,*"
+
+	# receive: this radio receives traffic for itself
+	echo "${dev_field}_receive.label Receive"
+	echo "${dev_field}_receive.type DERIVE"
+	echo "${dev_field}_receive.draw STACK"
+	echo "${dev_field}_receive.cdef 100,${dev_field}_receive,${dev_field}_active,/,*"
+
+	# transmit: this radio transmits traffic
+	echo "${dev_field}_transmit.label Transmit"
+	echo "${dev_field}_transmit.type DERIVE"
+	echo "${dev_field}_transmit.draw STACK"
+	echo "${dev_field}_transmit.cdef 100,${dev_field}_transmit,${dev_field}_active,/,*"
+else
+	device=$(get_wifi_device_from_suffix)
+	[ -z "$device" ] && echo >&2 "Invalid wifi device name given" && exit 1
+	iw dev "$device" survey dump \
+		| grep -F -A 5 "[in use]" \
+		| grep -E "channel (busy|receive|transmit|active) time:" \
+		| awk '{print "'${device}_'"$2"'.value'",$4}'
+fi
+
+exit 0


### PR DESCRIPTION
This icecast plugin captures a set of data similar to the "icecast2_" and "icecast2_all" plugin. Sadly both are not configurable (manual changes are required for target host and access credentials). Additionally they use the rather old-fashioned (and password restricted) xml status output.

This new plugin "icecast2_stats" (written from scratch) contains the following notable differences:

* runs with Python 3
* supports a real "autoconf" and "suggest" interface
* is configurable (target host and port) via environment settings
* uses the json status output instead of the xml data
* contains no hard-coded stream filename patterns