### PR TITLE
tests: test compiling with python3 if given as shebang interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: perl
 install:
   - sudo apt-get update
-  - sudo apt-get --no-install-recommends install devscripts python ruby php5-cli gawk ksh pylint
+  - sudo apt-get --no-install-recommends install devscripts python python3 ruby php5-cli gawk ksh pylint
   - sudo apt-get --no-install-recommends install pkg-config libdb-dev libvirt-dev libexpat-dev
   # - Munin/Plugin.pm is in "munin-node" on precise
   - sudo apt-get --no-install-recommends install munin-node

--- a/t/test.t
+++ b/t/test.t
@@ -94,6 +94,14 @@ sub process_file {
             }
         );
     }
+    elsif ( $interpreter =~ m{python3} ) {
+        run_check(
+            {   command     => [ 'python3', '-m', 'py_compile', $file ],
+                description => 'python3 compile',
+                filename    => $filename
+            }
+        );
+    }
     elsif ( $interpreter =~ m{python} ) {
         run_check(
             {   command     => [ 'python', '-m', 'py_compile', $file ],


### PR DESCRIPTION
Currently plugins fail to compile if they use Python 3 syntax features,
even though they use a correct shebang.