### PR TITLE
Varnish 4.1 update

### DIFF
--- a/plugins/varnish4/README.md
+++ b/plugins/varnish4/README.md
@@ -19,9 +19,12 @@ your actual plugins directory.
 In your plugins.conf add
 ```
 [varnish4_*]
+     group varnish
      env.varnishstat varnishstat
      env.name
 ```
+`group varnish` Since Varnish version 4.1, Varnish shared log utilities must be run in a context with *varnish* group membership.
+
 `env.varnishstat` can be a full path to varnishstat if it's
 not in the path already.
 

--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -715,31 +715,24 @@ my %ASPECTS = (
 			},
 			'sess_drop' => {
 				'type' => 'DERIVE'
-
 			},
 			'backend_unhealthy' => {
 				'type' => 'DERIVE'
-
 			},
 			'fetch_failed' => {
 				'type' => 'DERIVE'
-
 			},
 			'backend_busy' => {
 				'type' => 'DERIVE'
-
 			},
 			'threads_failed' => {
 				'type' => 'DERIVE'
-
 			},
 			'threads_limited' => {
 				'type' => 'DERIVE'
-
 			},
 			'threads_destroyed' => {
 				'type' => 'DERIVE'
-
 			},
 			'thread_queue_len' => {
 				'type' => 'GAUGE'
@@ -749,11 +742,9 @@ my %ASPECTS = (
 			},
 			'esi_errors' => {
 				'type' => 'DERIVE'
-
 			},
 			'esi_warnings' => {
 				'type' => 'DERIVE'
-
 			},
 			'sess_fail' => {
 				'type' => 'DERIVE'

--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -34,6 +34,7 @@ The plugin needs to be able to execute varnishstat.
 
 The configuration section shows the defaults
   [varnish4_*]
+     group varnish
      env.varnishstat varnishstat
      env.name
 
@@ -630,15 +631,15 @@ my %ASPECTS = (
 			},
 			'bans_tested' => {
 				'type' => 'DERIVE',
-                                'min' => '0'
+                'min' => '0'
 			},
 			'bans_obj_killed' => {
 				'type' => 'DERIVE',
-                                'min' => '0'
+                'min' => '0'
 			},
 			'bans_tests_tested' => {
 				'type' => 'DERIVE',
-                                'min' => '0'
+                'min' => '0'
 			},
 			'bans_dups' => {
 				'type' => 'GAUGE'
@@ -714,24 +715,31 @@ my %ASPECTS = (
 			},
 			'sess_drop' => {
 				'type' => 'DERIVE'
+
 			},
 			'backend_unhealthy' => {
 				'type' => 'DERIVE'
+
 			},
 			'fetch_failed' => {
 				'type' => 'DERIVE'
+
 			},
 			'backend_busy' => {
 				'type' => 'DERIVE'
+
 			},
 			'threads_failed' => {
 				'type' => 'DERIVE'
+
 			},
 			'threads_limited' => {
 				'type' => 'DERIVE'
+
 			},
 			'threads_destroyed' => {
 				'type' => 'DERIVE'
+
 			},
 			'thread_queue_len' => {
 				'type' => 'GAUGE'
@@ -741,15 +749,18 @@ my %ASPECTS = (
 			},
 			'esi_errors' => {
 				'type' => 'DERIVE'
+
 			},
 			'esi_warnings' => {
 				'type' => 'DERIVE'
+
 			},
 			'sess_fail' => {
 				'type' => 'DERIVE'
 			},
 			'sess_pipe_overflow' => {
 				'type' => 'DERIVE'
+
 			}
 		}
 	},
@@ -778,9 +789,9 @@ my %ASPECTS = (
 sub translate_type
 {
 	my $d = $_[0];
-	if ($d eq "i") {
+	if ($d eq "i" or $d eq "g") {
 		$d = "GAUGE";
-	} elsif ($d eq "a") {
+	} elsif ($d eq "a" or $d eq "c") {
 		$d = "DERIVE";
 	}
 	return $d;


### PR DESCRIPTION
Updated README.md with the config changes needed for 4.1
Updated varnish4_ so it is displays graphs that were not generated in 4.1 because the type was unknown to munin. 
This will resolve issue #660  