### PR TITLE
fix zpool_iostat plugin

### DIFF
--- a/plugins/zfs/zpool_iostat
+++ b/plugins/zfs/zpool_iostat
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/bin/sh
+
+#%# family=auto
+#%# capabilities=autoconf
 
 if [ "$1" = "autoconf" ]; then
                 echo yes


### PR DESCRIPTION
- use /bin/sh instead of /bin/bash
- add autoconf capabilities