### PR TITLE
Support for Debian Jessie.

### DIFF
--- a/plugins/virtualization/kvm_cpu
+++ b/plugins/virtualization/kvm_cpu
@@ -75,7 +75,7 @@ def list_pids():
     ''' Find the pid of kvm processes
     @return a list of pids from running kvm
     '''
-    pid = Popen("pidof kvm", shell=True, stdout=PIPE)
+    pid = Popen("pidof qemu-system-x86_64", shell=True, stdout=PIPE)
     return pid.communicate()[0].split()
 
 def fetch(vms):

--- a/plugins/virtualization/kvm_io
+++ b/plugins/virtualization/kvm_io
@@ -92,7 +92,7 @@ def list_pids():
     ''' Find the pid of kvm processes
     @return a list of pids from running kvm
     '''
-    pid = Popen("pidof kvm", shell=True, stdout=PIPE)
+    pid = Popen("pidof qemu-system-x86_64", shell=True, stdout=PIPE)
     return pid.communicate()[0].split()
     
 if __name__ == "__main__":

--- a/plugins/virtualization/kvm_mem
+++ b/plugins/virtualization/kvm_mem
@@ -89,7 +89,7 @@ def list_pids():
     ''' Find the pid of kvm processes
     @return a list of pids from running kvm
     '''
-    pid = Popen("pidof kvm", shell=True, stdout=PIPE)
+    pid = Popen("pidof qemu-system-x86_64", shell=True, stdout=PIPE)
     return pid.communicate()[0].split()
     
 if __name__ == "__main__":

--- a/plugins/virtualization/kvm_net
+++ b/plugins/virtualization/kvm_net
@@ -100,7 +100,7 @@ def list_pids():
     ''' Find the pid of kvm processes
     @return a list of pids from running kvm
     '''
-    pid = Popen("pidof kvm", shell=True, stdout=PIPE)
+    pid = Popen("pidof qemu-system-x86_64", shell=True, stdout=PIPE)
     return pid.communicate()[0].split()
 
 def find_vms_tap():


### PR DESCRIPTION
Debian Jessie processes name are ```qemu-system-x86_64``` not ```kvm```.
Maybe the plugin should detect  ```qemu-system-x86_64``` or ```kvm``` and chose the right one.

So here is a patch for Debian Jessie (only? Maybe recent KVM?).