### PR TITLE
added hsperf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/hsperf"]
+	path = plugins/hsperf
+	url = https://github.com/bebbodl/hsperf.git


### PR DESCRIPTION
# New Plugin hsperf 
I wrote a new plugin to read Java JVM hsperfdata_* files. This way you can monitor JVMs without using JMX.
