### PR TITLE
ceph_capacity and ceph_osd: fix autoconf

### DIFF
--- a/plugins/ceph/ceph_capacity
+++ b/plugins/ceph/ceph_capacity
@@ -27,6 +27,8 @@ GPLv2
 
 =cut
 
+command -v ceph >/dev/null 2>&1 || { echo >&2 "ceph is not installed."; exit 1; }
+
 if [ "$1" = "autoconf" ]; then
 	echo yes
 	exit 0

--- a/plugins/ceph/ceph_osd
+++ b/plugins/ceph/ceph_osd
@@ -21,6 +21,8 @@ GPLv2
 
 =cut
 
+command -v ceph >/dev/null 2>&1 || { echo >&2 "ceph is not installed."; exit 1; }
+
 if [ "$1" = "autoconf" ]; then
 	echo yes
 	exit 0


### PR DESCRIPTION
ceph_capacity and ceph_osd always recommend themselves to be installed when using
>munin-node-configure --suggest
this patch adds a test for the ceph command to avoid that.

I tested it successfully on Debian 7, 8 and Ubuntu 14.04