### PR TITLE
varnish4: lower limit 0 in hit rate graph args

### DIFF
--- a/plugins/varnish4/varnish4_
+++ b/plugins/varnish4/varnish4_
@@ -232,7 +232,7 @@ my %ASPECTS = (
 		'order' => 'client_req cache_hit cache_miss '
 			 . 'cache_hitpass' ,
 		'vlabel' => '%',
-		'args' => '-u 100 --rigid',
+		'args' => '-l 0 -u 100 --rigid',
 		'scale' => 'no',
 		'values' => {
 			'client_req' => {


### PR DESCRIPTION
As usual for percentage based graphs (cpu, df etc).
Otherwise it might autoscale and look weird.