### PR TITLE
wordpress-multisite

### DIFF
--- a/plugins/other/wordpress-multisite
+++ b/plugins/other/wordpress-multisite
@@ -2,6 +2,7 @@
 # wordpress-multisite plugin
 # 
 # Author Jonas Palm
+# E-Mail jonaspalm . posteo. de
 # Version 0.1
 # Date 2016-02-07
 # 
@@ -20,13 +21,14 @@ The plugin need access to the wordpress database
 =head2 Config file
 Create the config file plugin-conf.d/wordpress with the following values:
 
-=over 5
+=over 6
 =item * [wordpress*]
 =item * env.DB_USER <database user (mandatory)>
 =item * env.DB_PASSWORD <database password (mandatory)>
 =item * env.DB_NAME <database name (defaults to wordpress>
 =item * env.DB_PREFIX <database prefix (defaults to wp_)>
 =item * env.DB_HOST <database host (defaults to localhost)>
+=item * env.DB_PORT <database port (defaults to 3306)>
 
 =back
 

--- a/plugins/other/wordpress-multisite
+++ b/plugins/other/wordpress-multisite
@@ -1,40 +1,51 @@
 #!/usr/bin/env sh
 # wordpress-multisite plugin
-# 
+#
+# Version 0.3
+# Date 2017-01-12
+# Some last minor fixes
+#
 # Version 0.2
 # Date 2016-10-24
 # Code improvements
-# 
+#
 # Version 0.1
 # Date 2016-02-07
 # Initial release
 #
 : <<=cut
 =head1 NAME
+
 Wordpress-Multisite Munin Plugin
 
 A Munin plugin to monitor posts, comments and pingbacks from every multisite instance.
 It uses multigraphs and also shows the combined number of posts, comments, pingbacks, instances and users.
 
-Most database requests came from the wordpress-mu-plugin which was written by Andre Darafarin and Chris Bair
+Most database queries came from the wordpress-mu-plugin which was written by Andre Darafarin and Chris Bair
 
 =head1 CONFIGURATION
+
 The plugin need access to the wordpress database
 
 =head2 Config file
+
 Create the config file plugin-conf.d/wordpress with the following values:
 
-=over 4
-=item * [wordpress*]
-=item * env.mysqlopts <ie -uroot -prootpass>
-=item * env.mysqlconnection <defaults to -hlocalhost>
-=item * env.database <ie -Dwordpress>
-=item * env.dbprefix <defaults to wp_>
+  [wordpress*]
+  env.mysqlopts		# i.e. -uroot -prootpass
+  env.mysqlconnection	# defaults to -hlocalhost
+  env.database		# i.e. -Dwordpress
+  env.dbprefix		# defaults to wp_
 
-=back
+=head1 VERSION
 
-=head1 VERSION																														   
-Version 0.2 (2016-02-07)
+Version 0.3 (2017-01-12)
+
+=head2 Some minor fixes:
+
+  * fixed perldoc
+  * fixed some syntax warnings from shellcheck
+  * replaced expr by $(( ))
 
 =head1 AUTHOR
 
@@ -43,7 +54,6 @@ Jonas Palm <jonaspalm . posteo . de>
 =head1 LICENSE
 
 GPLv3 or higher
-
 =cut
 
 # fill vars
@@ -84,10 +94,10 @@ else
 		i=
 		test "$n" -gt "1" && i=${n}_
 
-		POSTS=$(expr $POSTS + $(wp_get posts $i))
-		COMMENTS=$(expr $COMMENTS + $(wp_get comments $i))
-		PINGBACKS=$(expr $PINGBACKS + $(wp_get pingbacks $i))
-		CNT=$(expr $CNT + 1)
+		POSTS=$((POSTS + $(wp_get posts "$i")))
+		COMMENTS=$((COMMENTS + $(wp_get comments "$i")))
+		PINGBACKS=$((PINGBACKS + $(wp_get pingbacks "$i")))
+		CNT=$((CNT + 1))
 	done
 
 	echo "multigraph wordpress"
@@ -106,7 +116,7 @@ for n in $(wp_get ids); do
 
 	if [ "$1" = "config" ]; then
 		echo "multigraph wordpress.site_${n}"
-		echo "graph_title $(wp_get title $i)"
+		echo "graph_title $(wp_get title "$i")"
 		echo "graph_order posts comments pingbacks"
 		echo "graph_vlabel Wordpress ID ${n}"
 		echo "posts.label Posts"
@@ -114,8 +124,8 @@ for n in $(wp_get ids); do
 		echo "pingbacks.label Pingbacks"
 	else
 		echo "multigraph wordpress.site_${n}"
-		echo "posts.value $(wp_get posts $i)"
-		echo "comments.value $(wp_get comments $i)"
-		echo "pingbacks.value $(wp_get pingbacks $i)"
+		echo "posts.value $(wp_get posts "$i")"
+		echo "comments.value $(wp_get comments "$i")"
+		echo "pingbacks.value $(wp_get pingbacks "$i")"
 	fi
 done

--- a/plugins/other/wordpress-multisite
+++ b/plugins/other/wordpress-multisite
@@ -1,0 +1,126 @@
+#!/bin/bash
+# wordpress-multisite plugin
+# 
+# Author Jonas Palm
+# Version 0.1
+# Date 2016-02-07
+# 
+: <<=cut
+=head1 NAME
+Wordpress-Multisite Munin Plugin
+
+A Munin plugin to monitor posts, comments and pingbacks from every multisite instance.
+It uses multigraphs and also shows the combined number of posts, comments, pingbacks, instances and users.
+
+Most database requests came from the wordpress-mu-plugin which was written by Andre Darafarin and Chris Bair
+
+=head1 CONFIGURATION
+The plugin need access to the wordpress database
+
+=head2 Config file
+Create the config file plugin-conf.d/wordpress with the following values:
+
+=over 5
+=item * [wordpress*]
+=item * env.DB_USER <database user (mandatory)>
+=item * env.DB_PASSWORD <database password (mandatory)>
+=item * env.DB_NAME <database name (defaults to wordpress>
+=item * env.DB_PREFIX <database prefix (defaults to wp_)>
+=item * env.DB_HOST <database host (defaults to localhost)>
+
+=back
+
+=head1 VERSION                                                                                                                                                                                                                      
+
+0.1 2016-02-07
+
+=head1 AUTHOR
+
+Jonas Palm <jonaspalm . posteo . de>
+
+=cut
+
+# Fill some variables
+DB_USER=${DB_USER}
+DB_PASSWORD=${DB_PASSWORD}
+DB_NAME=${DB_NAME:-wordpress}
+DB_PREFIX=${DB_PREFIX:-wp_}
+DB_HOST=${DB_HOST:-localhost}
+DB_PORT=${DB_PORT:-3306}
+
+MYSQLOPTS="-h$DB_HOST -P $DB_PORT -p$DB_PASSWORD -u$DB_USER -D $DB_NAME --column-names=0 -s"
+
+if [ "$1" = "config" ]; then
+        echo "multigraph wordpress"
+        echo "graph_title Wordpress Mulitsite"
+        echo "graph_order instances users posts comments pingbacks"
+        echo "graph_vlabel Wordpress"
+        echo "graph_category Wordpress"
+        echo "graph_info Some Statistics of Wordpress"
+        echo "instances.label Instances"
+        echo "users.label Users"
+        echo "posts.label Posts"
+        echo "comments.label Comments"
+        echo "pingbacks.label Pingbacks"
+else
+        CNT=0
+        for n in `mysql $MYSQLOPTS --execute="select blog_id from ${DB_PREFIX}blogs"`; do
+                if [ "$n" == "1" ]; then
+                        i=
+                else
+                        i=${n}_
+                fi
+
+                POSTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}posts WHERE post_status = 'publish' AND post_password = '' AND post_type = 'post';"`
+                (( POSTS_ += POSTS ))
+
+                COMMENTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = '';"`
+                (( COMMENTS_ += COMMENTS ))
+
+                PINGBACKS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = 'pingback';"`
+                (( PINGBACKS_ += PINGBACKS ))
+
+                (( CNT += 1 ))
+        done
+
+        # return values
+        echo "multigraph wordpress"
+        echo "posts.value $POSTS_"
+        echo "comments.value $COMMENTS_"
+        echo "pingbacks.value $PINGBACKS_"
+        echo "instances.value $CNT"
+        echo "users.value `mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}users ;"`"
+fi
+
+# single blogs
+for n in `mysql $MYSQLOPTS --execute="select blog_id from ${DB_PREFIX}blogs"`; do
+        if [ "${n}" == "1" ]; then
+                i=
+        else
+                i=${n}_
+        fi
+
+        if [ "$n" -le "9" ]; then
+                n=0${n}
+        fi
+
+        if [ "$1" = "config" ]; then
+                echo "multigraph wordpress.site_${n}"
+                echo "graph_title `mysql $MYSQLOPTS --execute=\"select option_value from ${DB_PREFIX}${i}options where option_name = 'siteurl';\"`"
+                echo "graph_order posts comments pingbacks"
+                echo "graph_vlabel Wordpress ID ${n}"
+                echo "posts.label Posts"
+                echo "comments.label Comments"
+                echo "pingbacks.label Pingbacks"
+        else
+                POSTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}posts WHERE post_status = 'publish' AND post_password = '' AND post_type = 'post';"`
+                COMMENTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = '';"`
+                PINGBACKS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = 'pingback';"`
+
+                # return values
+                echo "multigraph wordpress.site_${n}"
+                echo "posts.value $POSTS"
+                echo "comments.value $COMMENTS"
+                echo "pingbacks.value $PINGBACKS"
+        fi
+done

--- a/plugins/other/wordpress-multisite
+++ b/plugins/other/wordpress-multisite
@@ -1,18 +1,5 @@
-#!/usr/bin/env sh
+#!/bin/sh
 # wordpress-multisite plugin
-#
-# Version 0.3
-# Date 2017-01-12
-# Some last minor fixes
-#
-# Version 0.2
-# Date 2016-10-24
-# Code improvements
-#
-# Version 0.1
-# Date 2016-02-07
-# Initial release
-#
 : <<=cut
 =head1 NAME
 
@@ -32,20 +19,18 @@ The plugin need access to the wordpress database
 Create the config file plugin-conf.d/wordpress with the following values:
 
   [wordpress*]
-  env.mysqlopts		# i.e. -uroot -prootpass
-  env.mysqlconnection	# defaults to -hlocalhost
-  env.database		# i.e. -Dwordpress
-  env.dbprefix		# defaults to wp_
+  env.mysqlopts		# I.e. -uroot -prootpass
+  env.mysqlconnection	# Defaults to -hlocalhost
+  env.database		# I.e. wordpress
+  env.dbprefix		# Defaults to wp_
+  env.networksize	# Blogs are ordered by id in multigraph view. This value should contain the numbers
+  			# of digits that are needed to fit all the blog id's in. This value influences the
+			# designation of data to munin and it will start collecting fresh data if you change
+			# this number. Defaults to 2, (so networks with <= 99 blogs will be sorted correctly)
 
 =head1 VERSION
 
-Version 0.3 (2017-01-12)
-
-=head2 Some minor fixes:
-
-  * fixed perldoc
-  * fixed some syntax warnings from shellcheck
-  * replaced expr by $(( ))
+Version 0.4 (2017-01-13)
 
 =head1 AUTHOR
 
@@ -61,19 +46,30 @@ DB_OPTIONS=${mysqlopts}
 DB_CONNECTION=${mysqlconnection:--hlocalhost}
 DB_NAME=${database}
 DB_PREFIX=${dbprefix:-wp_}
+NETWORK_SIZE=${network_size:-2}
 
 MYSQL_CMD=$(which mysql)
+
+# wp_get dataname [blogid]
 wp_get() {
+	local DB_QUERY=
+	local BLOGID=
+	if [ -n "$2" ] && [ "$2" -gt "1" ]; then
+		# DB prefix for every wordpress instance in the network
+		# Nr 1 is the main network blog and doesn't has a prefix
+		BLOGID=${2}_
+	fi
+
 	case $1 in
-		comments) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${2}comments WHERE comment_approved = '1' AND comment_type = '';" ;;
-		ids) QUERY="SELECT blog_id FROM ${DB_PREFIX}blogs;" ;;
-		pingbacks) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${2}comments WHERE comment_approved = '1' AND comment_type = 'pingback';" ;;
-		posts) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${2}posts WHERE post_status = 'publish' AND post_password = '' AND post_type = 'post';" ;;
-		title) QUERY="SELECT option_value FROM ${DB_PREFIX}${2}options WHERE option_name = 'siteurl';" ;;
-		users) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}users;"
+		comments) DB_QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${BLOGID}comments WHERE comment_approved = '1' AND comment_type = '';" ;;
+		ids) DB_QUERY="SELECT blog_id FROM ${DB_PREFIX}blogs;" ;;
+		pingbacks) DB_QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${BLOGID}comments WHERE comment_approved = '1' AND comment_type = 'pingback';" ;;
+		posts) DB_QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${BLOGID}posts WHERE post_status = 'publish' AND post_password = '' AND post_type = 'post';" ;;
+		title) DB_QUERY="SELECT option_value FROM ${DB_PREFIX}${BLOGID}options WHERE option_name = 'siteurl';" ;;
+		users) DB_QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}users;"
 	esac
 
-	$MYSQL_CMD $DB_CONNECTION $DB_OPTIONS $DB_NAME --column-names=0 -s --execute="$QUERY"
+	"$MYSQL_CMD" $DB_CONNECTION $DB_OPTIONS "$DB_NAME" --column-names=0 -s --execute="$DB_QUERY"
 }
 
 # whole network
@@ -91,12 +87,9 @@ if [ "$1" = "config" ]; then
 	echo "pingbacks.label Pingbacks"
 else
 	for n in $(wp_get ids); do
-		i=
-		test "$n" -gt "1" && i=${n}_
-
-		POSTS=$((POSTS + $(wp_get posts "$i")))
-		COMMENTS=$((COMMENTS + $(wp_get comments "$i")))
-		PINGBACKS=$((PINGBACKS + $(wp_get pingbacks "$i")))
+		POSTS=$((POSTS + $(wp_get posts "$n")))
+		COMMENTS=$((COMMENTS + $(wp_get comments "$n")))
+		PINGBACKS=$((PINGBACKS + $(wp_get pingbacks "$n")))
 		CNT=$((CNT + 1))
 	done
 
@@ -110,22 +103,20 @@ fi
 
 # single blogs
 for n in $(wp_get ids); do
-	i=
-	test "$n" -gt "1" && i=${n}_
-	test "$n" -le "9" && n=0${n}
+	blogid_sortable="$(printf "%0${NETWORK_SIZE}d" "$n")"
 
 	if [ "$1" = "config" ]; then
-		echo "multigraph wordpress.site_${n}"
-		echo "graph_title $(wp_get title "$i")"
+		echo "multigraph wordpress.site_${blogid_sortable}"
+		echo "graph_title $(wp_get title "$n")"
 		echo "graph_order posts comments pingbacks"
-		echo "graph_vlabel Wordpress ID ${n}"
+		echo "graph_vlabel Wordpress ID ${blogid_sortable}"
 		echo "posts.label Posts"
 		echo "comments.label Comments"
 		echo "pingbacks.label Pingbacks"
 	else
-		echo "multigraph wordpress.site_${n}"
-		echo "posts.value $(wp_get posts "$i")"
-		echo "comments.value $(wp_get comments "$i")"
-		echo "pingbacks.value $(wp_get pingbacks "$i")"
+		echo "multigraph wordpress.site_${blogid_sortable}"
+		echo "posts.value $(wp_get posts "$n")"
+		echo "comments.value $(wp_get comments "$n")"
+		echo "pingbacks.value $(wp_get pingbacks "$n")"
 	fi
 done

--- a/plugins/other/wordpress-multisite
+++ b/plugins/other/wordpress-multisite
@@ -1,11 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # wordpress-multisite plugin
 # 
-# Author Jonas Palm
-# E-Mail jonaspalm . posteo. de
+# Version 0.2
+# Date 2016-10-24
+# Code improvements
+# 
 # Version 0.1
 # Date 2016-02-07
-# 
+# Initial release
+#
 : <<=cut
 =head1 NAME
 Wordpress-Multisite Munin Plugin
@@ -21,108 +24,98 @@ The plugin need access to the wordpress database
 =head2 Config file
 Create the config file plugin-conf.d/wordpress with the following values:
 
-=over 6
+=over 4
 =item * [wordpress*]
-=item * env.DB_USER <database user (mandatory)>
-=item * env.DB_PASSWORD <database password (mandatory)>
-=item * env.DB_NAME <database name (defaults to wordpress>
-=item * env.DB_PREFIX <database prefix (defaults to wp_)>
-=item * env.DB_HOST <database host (defaults to localhost)>
-=item * env.DB_PORT <database port (defaults to 3306)>
+=item * env.mysqlopts <ie -uroot -prootpass>
+=item * env.mysqlconnection <defaults to -hlocalhost>
+=item * env.database <ie -Dwordpress>
+=item * env.dbprefix <defaults to wp_>
 
 =back
 
-=head1 VERSION                                                                                                                                                                                                                      
-
-0.1 2016-02-07
+=head1 VERSION																														   
+Version 0.2 (2016-02-07)
 
 =head1 AUTHOR
 
 Jonas Palm <jonaspalm . posteo . de>
 
+=head1 LICENSE
+
+GPLv3 or higher
+
 =cut
 
-# Fill some variables
-DB_USER=${DB_USER}
-DB_PASSWORD=${DB_PASSWORD}
-DB_NAME=${DB_NAME:-wordpress}
-DB_PREFIX=${DB_PREFIX:-wp_}
-DB_HOST=${DB_HOST:-localhost}
-DB_PORT=${DB_PORT:-3306}
+# fill vars
+DB_OPTIONS=${mysqlopts}
+DB_CONNECTION=${mysqlconnection:--hlocalhost}
+DB_NAME=${database}
+DB_PREFIX=${dbprefix:-wp_}
 
-MYSQLOPTS="-h$DB_HOST -P $DB_PORT -p$DB_PASSWORD -u$DB_USER -D $DB_NAME --column-names=0 -s"
+MYSQL_CMD=$(which mysql)
+wp_get() {
+	case $1 in
+		comments) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${2}comments WHERE comment_approved = '1' AND comment_type = '';" ;;
+		ids) QUERY="SELECT blog_id FROM ${DB_PREFIX}blogs;" ;;
+		pingbacks) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${2}comments WHERE comment_approved = '1' AND comment_type = 'pingback';" ;;
+		posts) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}${2}posts WHERE post_status = 'publish' AND post_password = '' AND post_type = 'post';" ;;
+		title) QUERY="SELECT option_value FROM ${DB_PREFIX}${2}options WHERE option_name = 'siteurl';" ;;
+		users) QUERY="SELECT COUNT(*) FROM ${DB_PREFIX}users;"
+	esac
 
+	$MYSQL_CMD $DB_CONNECTION $DB_OPTIONS $DB_NAME --column-names=0 -s --execute="$QUERY"
+}
+
+# whole network
 if [ "$1" = "config" ]; then
-        echo "multigraph wordpress"
-        echo "graph_title Wordpress Mulitsite"
-        echo "graph_order instances users posts comments pingbacks"
-        echo "graph_vlabel Wordpress"
-        echo "graph_category Wordpress"
-        echo "graph_info Some Statistics of Wordpress"
-        echo "instances.label Instances"
-        echo "users.label Users"
-        echo "posts.label Posts"
-        echo "comments.label Comments"
-        echo "pingbacks.label Pingbacks"
+	echo "multigraph wordpress"
+	echo "graph_title Wordpress Mulitsite"
+	echo "graph_order instances users posts comments pingbacks"
+	echo "graph_vlabel Wordpress"
+	echo "graph_category Wordpress"
+	echo "graph_info Some Statistics of Wordpress"
+	echo "instances.label Instances"
+	echo "users.label Users"
+	echo "posts.label Posts"
+	echo "comments.label Comments"
+	echo "pingbacks.label Pingbacks"
 else
-        CNT=0
-        for n in `mysql $MYSQLOPTS --execute="select blog_id from ${DB_PREFIX}blogs"`; do
-                if [ "$n" == "1" ]; then
-                        i=
-                else
-                        i=${n}_
-                fi
+	for n in $(wp_get ids); do
+		i=
+		test "$n" -gt "1" && i=${n}_
 
-                POSTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}posts WHERE post_status = 'publish' AND post_password = '' AND post_type = 'post';"`
-                (( POSTS_ += POSTS ))
+		POSTS=$(expr $POSTS + $(wp_get posts $i))
+		COMMENTS=$(expr $COMMENTS + $(wp_get comments $i))
+		PINGBACKS=$(expr $PINGBACKS + $(wp_get pingbacks $i))
+		CNT=$(expr $CNT + 1)
+	done
 
-                COMMENTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = '';"`
-                (( COMMENTS_ += COMMENTS ))
-
-                PINGBACKS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = 'pingback';"`
-                (( PINGBACKS_ += PINGBACKS ))
-
-                (( CNT += 1 ))
-        done
-
-        # return values
-        echo "multigraph wordpress"
-        echo "posts.value $POSTS_"
-        echo "comments.value $COMMENTS_"
-        echo "pingbacks.value $PINGBACKS_"
-        echo "instances.value $CNT"
-        echo "users.value `mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}users ;"`"
+	echo "multigraph wordpress"
+	echo "posts.value $POSTS"
+	echo "comments.value $COMMENTS"
+	echo "pingbacks.value $PINGBACKS"
+	echo "instances.value $CNT"
+	echo "users.value $(wp_get users)"
 fi
 
 # single blogs
-for n in `mysql $MYSQLOPTS --execute="select blog_id from ${DB_PREFIX}blogs"`; do
-        if [ "${n}" == "1" ]; then
-                i=
-        else
-                i=${n}_
-        fi
+for n in $(wp_get ids); do
+	i=
+	test "$n" -gt "1" && i=${n}_
+	test "$n" -le "9" && n=0${n}
 
-        if [ "$n" -le "9" ]; then
-                n=0${n}
-        fi
-
-        if [ "$1" = "config" ]; then
-                echo "multigraph wordpress.site_${n}"
-                echo "graph_title `mysql $MYSQLOPTS --execute=\"select option_value from ${DB_PREFIX}${i}options where option_name = 'siteurl';\"`"
-                echo "graph_order posts comments pingbacks"
-                echo "graph_vlabel Wordpress ID ${n}"
-                echo "posts.label Posts"
-                echo "comments.label Comments"
-                echo "pingbacks.label Pingbacks"
-        else
-                POSTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}posts WHERE post_status = 'publish' AND post_password = '' AND post_type = 'post';"`
-                COMMENTS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = '';"`
-                PINGBACKS=`mysql $MYSQLOPTS --execute="SELECT COUNT(*) FROM ${DB_PREFIX}${i}comments WHERE comment_approved = '1' AND comment_type = 'pingback';"`
-
-                # return values
-                echo "multigraph wordpress.site_${n}"
-                echo "posts.value $POSTS"
-                echo "comments.value $COMMENTS"
-                echo "pingbacks.value $PINGBACKS"
-        fi
+	if [ "$1" = "config" ]; then
+		echo "multigraph wordpress.site_${n}"
+		echo "graph_title $(wp_get title $i)"
+		echo "graph_order posts comments pingbacks"
+		echo "graph_vlabel Wordpress ID ${n}"
+		echo "posts.label Posts"
+		echo "comments.label Comments"
+		echo "pingbacks.label Pingbacks"
+	else
+		echo "multigraph wordpress.site_${n}"
+		echo "posts.value $(wp_get posts $i)"
+		echo "comments.value $(wp_get comments $i)"
+		echo "pingbacks.value $(wp_get pingbacks $i)"
+	fi
 done


### PR DESCRIPTION
A Munin plugin to monitor posts, comments and pingbacks from every multisite instance.
It uses multigraphs and also shows the combined number of posts, comments, pingbacks, instances and users.

Most database requests came from the wordpress-mu-plugin which was written by Andre Darafarin and Chris Bair
