### PR TITLE
python3 dependency fixed (backport)

### DIFF
--- a/plugins/time/ntp_packets
+++ b/plugins/time/ntp_packets
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- python -*-
 
 # This plugin graphs the rate of sent, received, ignored, and dropped
@@ -31,48 +31,48 @@ import os
 import subprocess
 import sys
 
-if len(sys.argv) == 2 and sys.argv[1] == 'config':
-    print('graph_title NTP packets')
-    print('graph_vlabel Packets/${graph_period} received(-)/sent(+)')
-    print('graph_info This graph shows the packet rates of this ntpd. Ignored and dropped packets are graphed as positive values.')
-    print('graph_category time')
-    print('received.label Received')
-    print('received.type DERIVE')
-    print('received.graph no')
-    print('received.min 0')
-    print('sent.label Rx/Tx')
-    print('sent.type DERIVE')
-    print('sent.negative received')
-    print('sent.min 0')
-    print('dropped.label Dropped')
-    print('dropped.type DERIVE')
-    print('dropped.min 0')
-    print('ignored.label Ignored')
-    print('ignored.type DERIVE')
-    print('ignored.min 0')
+if len(sys.argv) == 2 and sys.argv[1] == u'config':
+    print u'graph_title NTP packets'
+    print u'graph_vlabel Packets/${graph_period} received(-)/sent(+)'
+    print u'graph_info This graph shows the packet rates of this ntpd. Ignored and dropped packets are graphed as positive values.'
+    print u'graph_category time'
+    print u'received.label Received'
+    print u'received.type DERIVE'
+    print u'received.graph no'
+    print u'received.min 0'
+    print u'sent.label Rx/Tx'
+    print u'sent.type DERIVE'
+    print u'sent.negative received'
+    print u'sent.min 0'
+    print u'dropped.label Dropped'
+    print u'dropped.type DERIVE'
+    print u'dropped.min 0'
+    print u'ignored.label Ignored'
+    print u'ignored.type DERIVE'
+    print u'ignored.min 0'
     sys.exit(0)
 
-os.environ['PATH'] = '/usr/local/sbin:/usr/local/bin:' + os.environ['PATH']
+os.environ[u'PATH'] = u'/usr/local/sbin:/usr/local/bin:' + os.environ[u'PATH']
 
 # Assuming that the ntpd version is the same as the ntpq or ntpdc
 # version. This is how a proper install should be.
 
-version = subprocess.check_output(['ntpq', '-c', 'version'], universal_newlines=True).split()[1][0:5].replace('.', '')
+version = subprocess.check_output([u'ntpq', u'-c', u'version'], universal_newlines=True).split()[1][0:5].replace(u'.', u'')
 
 if int(version) >= 427:
-    cmd = 'ntpq'
+    cmd = u'ntpq'
 else:
-    cmd = 'ntpdc'
+    cmd = u'ntpdc'
 
 iostats = dict()
 
-iostats_output = subprocess.check_output([cmd, '-c', 'iostats'], universal_newlines=True).splitlines()
+iostats_output = subprocess.check_output([cmd, u'-c', u'iostats'], universal_newlines=True).splitlines()
 
-for line in iostats_output: iostats[line.split(':')[0]] = int(line.split(':')[1])
+for line in iostats_output: iostats[line.split(u':')[0]] = int(line.split(u':')[1])
 
-print('received.value ' + str(iostats['received packets']))
-print('sent.value ' + str(iostats['packets sent']))
-print('dropped.value ' + str(iostats['dropped packets']))
-print('ignored.value ' + str(iostats['ignored packets']))
+print u'received.value ' + unicode(iostats[u'received packets'])
+print u'sent.value ' + unicode(iostats[u'packets sent'])
+print u'dropped.value ' + unicode(iostats[u'dropped packets'])
+print u'ignored.value ' + unicode(iostats[u'ignored packets'])
 
 sys.exit(0)

--- a/plugins/time/ntp_packets
+++ b/plugins/time/ntp_packets
@@ -32,7 +32,7 @@ import subprocess
 import sys
 
 if len(sys.argv) == 2 and sys.argv[1] == 'config':
-    print('graph_title NTP traffic')
+    print('graph_title NTP packets')
     print('graph_vlabel Packets/${graph_period} received(-)/sent(+)')
     print('graph_info This graph shows the packet rates of this ntpd. Ignored and dropped packets are graphed as positive values.')
     print('graph_category time')

--- a/plugins/time/ntp_packets
+++ b/plugins/time/ntp_packets
@@ -13,7 +13,7 @@
 # Symlink this plugin into the node's plugins directory (like
 # /etc/munin/plugins).
 #
-# Copyright © 2013 Kenyon Ralph <kenyon@kenyonralph.com>
+# Copyright [c] 2013 Kenyon Ralph <kenyon@kenyonralph.com>
 #
 # This program is free software. It comes without any warranty, to the
 # extent permitted by applicable law. You can redistribute it and/or


### PR DESCRIPTION
Works on python 2.7.10 now.

I'm not aware of a single distro which doesn't have python2.x available, however the reverse case is not true:

Some systems have python3.x blacklisted, but since there's nothing about this plugin so complicated it can't work on the more widely deployed python 2.x it took less than 10 minutes to backport.