### PR TITLE
backuppc: Split age graph into last backup / last full backup

### DIFF
--- a/plugins/backuppc/backuppc
+++ b/plugins/backuppc/backuppc
@@ -44,19 +44,29 @@ if [ "$1" = "config" ]; then
 
 	for h in ${HOSTS}
 	do
-		echo "$(clean_fieldname ${h})_full.label $(clean_fieldname ${h}) Full"
-		echo "$(clean_fieldname ${h})_incr.label $(clean_fieldname ${h}) Incr"
-		if [ -n "$full_warning" ]; then
-			echo "$(clean_fieldname ${h})_full.warning $full_warning"
-		fi
+		echo "$(clean_fieldname ${h})_incr.label $(clean_fieldname ${h})"
 		if [ -n "$incr_warning" ]; then
 			echo "$(clean_fieldname ${h})_incr.warning $incr_warning"
 		fi
-		if [ -n "$full_critical" ]; then
-			echo "$(clean_fieldname ${h})_full.critical $full_critical"
-		fi
 		if [ -n "$incr_critical" ]; then
 			echo "$(clean_fieldname ${h})_incr.critical $incr_critical"
+		fi
+	done
+
+	echo "multigraph backuppc_ages_full"
+	echo "graph_title BackupPC - Last Full Backup Age"
+	echo "graph_args -l 0"
+	echo "graph_vlabel days"
+	echo "graph_category Backuppc"
+
+	for h in ${HOSTS}
+	do
+		echo "$(clean_fieldname ${h})_full.label $(clean_fieldname ${h})"
+		if [ -n "$full_warning" ]; then
+			echo "$(clean_fieldname ${h})_full.warning $full_warning"
+		fi
+		if [ -n "$full_critical" ]; then
+			echo "$(clean_fieldname ${h})_full.critical $full_critical"
 		fi
 	done
 
@@ -75,10 +85,15 @@ done
 echo "multigraph backuppc_ages"
 for h in $HOSTS
 do
+	SIZE=$(awk '{ age = systime() - $3 } END { print age / 3600 / 24; }' ${PCDIR}/${h}/backups)
+	echo "$(clean_fieldname ${h})_incr.value $SIZE"
+done
+
+echo "multigraph backuppc_ages_full"
+for h in $HOSTS
+do
 	SIZE=$(awk '/full/ { age = systime() - $3 } END { print age / 3600 / 24; }' ${PCDIR}/${h}/backups)
 	echo "$(clean_fieldname ${h})_full.value $SIZE"
-	SIZE=$(awk '/incr/ { age = systime() - $3 } END { print age / 3600 / 24; }' ${PCDIR}/${h}/backups)
-	echo "$(clean_fieldname ${h})_incr.value $SIZE"
 done
 
 <<'__END__'


### PR DESCRIPTION
With this change there are two separate graphs:
* one for the age of the last backup (either incr/full)
* one for the age of the last full backup

If you update your backuppc plugin to the new version, the lines showing the last full backup age will be removed from the "last backup" graph, the new "last full backup" graph will be empty and start a-new.