### PR TITLE
Variation of lxc_ plugins which resolve the hostname on Proxmox Hosts

### DIFF
--- a/plugins/lxc/lxc_pct_cpu
+++ b/plugins/lxc/lxc_pct_cpu
@@ -68,7 +68,7 @@ if [ "$1" = "config" ]; then
  for guest_name in $guest_names;
  do 
   guest="$(clean_fieldname $guest_name)"
-  name=`cat /etc/pve/nodes/proxmox/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
+  name=`cat /etc/pve/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
   echo 'cpu_user_'$guest'.label '$name': User'
   echo 'cpu_user_'$guest'.type DERIVE'
   echo 'cpu_user_'$guest'.min 0'

--- a/plugins/lxc/lxc_pct_cpu
+++ b/plugins/lxc/lxc_pct_cpu
@@ -1,0 +1,96 @@
+#!/bin/bash
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+lxc_pct_cpu - Plugin to monitor LXC CPU usage for Proxmox hosts. Based on the lxc_cpu plugin
+
+=head1 CONFIGURATION
+
+  [lxc_*]
+    user root
+
+=head1 INTERPRETATION
+
+This plugin needs root privilege.
+
+=head1 AUTHOR
+
+vajtsz  vajtsz@gmail.com
+mitty   mitty@mitty.jp
+deveth0 amuthmann@dev-eth0.de
+
+=head1 LICENSE
+
+Unknown license
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+guest_names=`lxc-ls | sort -u`
+for guest in $guest_names; do
+ if lxc-info -n $guest 2>&1 | grep -qs RUNNING ; then
+  active="$active $guest"
+ fi
+done
+guest_names="$active"
+               
+
+
+f_comm='lxc-cgroup  '
+
+if [ "$1" = "autoconf" ]; then
+	if [ -r /proc/stat ]; then
+		echo yes
+		exit 0
+	else
+		echo "no (no /proc/stat)"
+		exit 0
+	fi
+fi
+
+if [ "$1" = "config" ]; then
+
+ echo 'graph_title CPU Usage '
+ echo 'graph_args -l 0 --base 1000'
+ echo 'graph_vlabel USER_HZ'
+ echo 'graph_category lxc'
+
+ 
+ for guest_name in $guest_names;
+ do 
+  guest="$(clean_fieldname $guest_name)"
+  name=`cat /etc/pve/nodes/proxmox/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
+  echo 'cpu_user_'$guest'.label '$name': User'
+  echo 'cpu_user_'$guest'.type DERIVE'
+  echo 'cpu_user_'$guest'.min 0'
+  echo 'cpu_system_'$guest'.label '$name': System'
+  echo 'cpu_system_'$guest'.type DERIVE'
+  echo 'cpu_system_'$guest'.min 0'
+ done
+ exit 0
+fi
+
+ for guest_name in $guest_names;
+ do 
+  guest="$(clean_fieldname $guest_name)"
+  
+  tmp_g=`$f_comm -n $guest_name cpuacct.stat | grep user`
+  tmp_v=`echo $tmp_g | awk '{print($2)}'`
+  echo 'cpu_user_'$guest'.value '$tmp_v
+  
+  tmp_g=`$f_comm -n $guest_name cpuacct.stat | grep system`
+  tmp_v=`echo $tmp_g | awk '{print($2)}'`
+  echo 'cpu_system_'$guest'.value '$tmp_v
+
+ done
+
+

--- a/plugins/lxc/lxc_pct_net
+++ b/plugins/lxc/lxc_pct_net
@@ -88,7 +88,7 @@ if [ "$1" = "config" ]; then
     
     for guestname in $actives; do
         guest=$(clean_fieldname $guestname)
-	name=`cat /etc/pve/nodes/proxmox/lxc/$guestname.conf | grep hostname | awk '{print $2}'`
+	name=`cat /etc/pve/lxc/$guestname.conf | grep hostname | awk '{print $2}'`
         device=$(eval 'echo $dev_'$guest)
         bps="U"
         if [ -r /sys/class/net/$device/speed ]; then

--- a/plugins/lxc/lxc_pct_net
+++ b/plugins/lxc/lxc_pct_net
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+: << =cut
+
+=head1 NAME
+
+lxc_pct_net - Munin plugin to graph traffic of active LXC containers for Proxmox Hosts. Based on the lxc_net plugin
+
+=head1 APPLICABLE SYSTEMS
+
+LXC container with "lxc.network.type=veth" and "lxc.network.veth.pair" settings.
+
+=head1 CONFIGURATION
+
+env.lxcpath - Set the path where LXC containers are stored, default: /var/lib/lxc
+env.exclude - Removing containers from graphs, default: empty
+
+  [lxc_net]
+    env.lxcpath /var/lib/lxc
+    env.exclude container1 container2
+
+=head1 INTERPRETATION
+
+This plugin reads a "lxc.network.veth.pair" setting from "config" file of each container,
+because lxc-start command creates a random named veth device without the setting.
+
+If your xen config (/var/lib/lxc/GUEST_NAME/config does not contain this parameter, 
+then you have to fill it, because if every guest restart generate new device name, then the graph will be useless
+( example config : lxc.network.veth.pair = vethsamba )
+
+=head1 AUTHOR
+
+mitty   mitty@mitty.jp
+deveth0 amuthmann@dev-eth0.de
+
+=head1 LICENSE
+
+2-clause BSD License
+
+=head1 MAGIC MARKERS
+
+ #%# familiy=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+lxcpath=${lxcpath:-/var/lib/lxc}
+
+if [ "$1" = "autoconf" ]; then
+    if [ ! -r /proc/net/dev ]; then
+        echo "no (/proc/net/dev cannot be read)"
+        exit 0
+    fi
+    if [ ! -e "$lxcpath" ]; then
+        echo "no ($lxcdir is not present)"
+        exit 0
+    fi
+    
+    echo yes
+fi
+
+actives=""
+for guest in `ls $lxcpath`; do
+    if [ `echo $exclude | grep -c "\b$guest\b"` -eq 1 ]; then
+        continue;
+    fi
+    if [ -f "$lxcpath/$guest/config" ]; then
+        device=`grep '^lxc\.network\.veth\.pair[ \t]*=[ \t]*' $lxcpath/$guest/config | \
+            awk '{ split($0, a, /=/); gsub(/[ \t]/, "", a[2]); print a[2]; }'`
+        if [ -n "$device" ]; then
+            device_re=`echo $device | sed -e 's/\./\\\\./g'`
+            if [ `grep -c "^ *$device_re:" /proc/net/dev` -eq 1 ]; then
+                actives="$actives $guest"
+                eval "dev_$(clean_fieldname $guest)=$device"
+            fi
+        fi
+    fi
+done
+
+if [ "$1" = "config" ]; then
+    echo "graph_title Network traffic"
+    echo "graph_args --base 1000"
+    echo "graph_vlabel bits in (-) / out (+) per ${graph_period}"
+    echo "graph_category lxc"
+    echo "graph_info This graph shows the traffic of active LXC containers."
+    
+    for guestname in $actives; do
+        guest=$(clean_fieldname $guestname)
+	name=`cat /etc/pve/nodes/proxmox/lxc/$guestname.conf | grep hostname | awk '{print $2}'`
+        device=$(eval 'echo $dev_'$guest)
+        bps="U"
+        if [ -r /sys/class/net/$device/speed ]; then
+            bps=$(cat /sys/class/net/$device/speed)
+            bps=$(($bps * 1000 * 1000))
+        fi
+        
+        echo "${guest}_down.label $name"
+        echo "${guest}_down.type DERIVE"
+        echo "${guest}_down.graph no"
+        echo "${guest}_down.cdef ${guest}_down,8,*"
+        echo "${guest}_down.min 0"
+        echo "${guest}_down.max $bps"
+        echo "${guest}_up.label $name"
+        echo "${guest}_up.type DERIVE"
+        echo "${guest}_up.negative ${guest}_down"
+        echo "${guest}_up.cdef ${guest}_up,8,*"
+        echo "${guest}_up.min 0"
+        echo "${guest}_up.max $bps"
+   done
+   exit 0
+fi
+
+
+for guest in $actives; do
+    guest=$(clean_fieldname $guest)
+    device=$(eval 'echo $dev_'$guest)
+    device_re=`echo $device | sed -e 's/\./\\\\./g'`
+    line=`grep "^ *$device_re:" /proc/net/dev`
+    echo -n "${guest}_down.value "
+    echo $line | awk '{
+            split($0, a, /: */); 
+            print  $2;
+    }'
+    echo -n "${guest}_up.value "
+    echo $line | awk '{
+            split($0, a, /: */); 
+            print  $10; 
+        }'
+done

--- a/plugins/lxc/lxc_pct_proc
+++ b/plugins/lxc/lxc_pct_proc
@@ -1,0 +1,125 @@
+#!/bin/bash
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+lxc_pct_proc - Plugin to monitor LXC Processes count for Proxmox Hosts. Based on the lxc_proc Plugin
+
+=head1 CONFIGURATION
+
+env.cgrouppath - Set the path where 'tasks' sysfs files are stored, default: empty
+
+  [lxc_proc]
+    user root
+    env.cgrouppath /sys/fs/cgroup/cpuacct/lxc/
+
+=head1 INTERPRETATION
+
+This plugin needs root privilege.
+
+=head1 AUTHOR
+
+vajtsz  vajtsz@gmail.com
+deveth0 amuthmann@dev-eth0.de
+
+=head1 LICENSE
+
+Unknown license
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+## find proper sysfs and count it
+# Debian 6.0: /sys/fs/cgroup/<container>/tasks
+# Ubuntu 12.04 with fstab: /sys/fs/cgroup/lxc/<container>/tasks
+# Ubuntu 12.04 with cgroup-lite: /sys/fs/cgroup/cpuacct/lxc/<container>/tasks
+# Ubuntu 12.04 with cgroup-bin: /sys/fs/cgroup/cpuacct/sysdefault/lxc/<container>/tasks
+count_processes () {
+    [ -z "$1" ] && return 0
+    
+    if [ -n "$cgrouppath" ]; then
+        SYSFS=$cgrouppath/$1/tasks
+        if [ -e $SYSFS ]; then
+            return `wc -l < $SYSFS`
+        fi
+    fi
+    
+    for SYSFS in \
+        /sys/fs/cgroup/$1/tasks \
+        /sys/fs/cgroup/lxc/$1/tasks \
+        /sys/fs/cgroup/cpuacct/lxc/$1/tasks \
+        /sys/fs/cgroup/cpuacct/sysdefault/lxc/$1/tasks \
+    ; do
+        if [ -e $SYSFS ]; then
+            return `wc -l < $SYSFS`
+        fi
+    done
+    
+    return 0
+}
+
+
+guest_names=`lxc-ls | sort -u`
+for guest in $guest_names; do
+ if lxc-info -n $guest 2>&1 | grep -qs RUNNING ; then
+  active="$active $guest"
+ fi
+done
+guest_names="$active"
+                
+
+
+f_comm='lxc-cgroup  '
+
+if [ "$1" = "autoconf" ]; then
+	if [ -r /proc/stat ]; then
+		echo yes
+		exit 0
+	else
+		echo "no (no /proc/stat)"
+		exit 0
+	fi
+fi
+
+if [ "$1" = "config" ]; then
+
+ echo 'graph_title Processes '
+ echo 'graph_args -l 0 --base 1000'
+ echo 'graph_vlabel Number of processes'
+ echo 'graph_category lxc'
+
+ 
+ for guest_name in $guest_names;
+ do 
+  guest="$(clean_fieldname $guest_name)"
+  name=`cat /etc/pve/nodes/proxmox/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
+  echo 'lxc_proc_'$guest'.label '$name': processes'
+  echo 'lxc_proc_'$guest'.type GAUGE'
+  echo 'lxc_proc_'$guest'.min 0'
+ done
+ exit 0
+fi
+
+ for guest_name in $guest_names;
+ do 
+  guest="$(clean_fieldname $guest_name)"
+  
+  count_processes $guest_name
+  tmp_g=$?
+  if [ $tmp_g -eq 0 ]; then
+    tmp_g=`$f_comm -n $guest_name tasks | wc -l`
+  fi
+  echo 'lxc_proc_'$guest'.value '$tmp_g
+  
+
+ done
+
+

--- a/plugins/lxc/lxc_pct_proc
+++ b/plugins/lxc/lxc_pct_proc
@@ -100,7 +100,7 @@ if [ "$1" = "config" ]; then
  for guest_name in $guest_names;
  do 
   guest="$(clean_fieldname $guest_name)"
-  name=`cat /etc/pve/nodes/proxmox/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
+  name=`cat /etc/pve/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
   echo 'lxc_proc_'$guest'.label '$name': processes'
   echo 'lxc_proc_'$guest'.type GAUGE'
   echo 'lxc_proc_'$guest'.min 0'

--- a/plugins/lxc/lxc_pct_ram
+++ b/plugins/lxc/lxc_pct_ram
@@ -1,0 +1,105 @@
+#!/bin/bash
+# -*- sh -*-
+
+: << =cut
+
+=head1 NAME
+
+lxc_ram - Plugin to monitor LXC memory usage for Proxmox hosts. Based on the lxc_ram plugin
+
+=head1 CONFIGURATION
+
+  [lxc_*]
+    user root
+
+=head1 INTERPRETATION
+
+This plugin needs root privilege.
+
+=head1 AUTHOR
+
+vajtsz vajtsz@gmail.com
+mitty   mitty@mitty.jp
+deveth0 amuthmann@dev-eth0.de
+
+=head1 LICENSE
+
+Unknown license
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+. $MUNIN_LIBDIR/plugins/plugin.sh
+
+guest_names=`lxc-ls | sort -u`
+for guest in $guest_names; do
+ if lxc-info -n $guest 2>&1 | grep -qs RUNNING ; then
+  active="$active $guest"
+ fi
+done
+guest_names="$active"
+                
+
+f_comm='lxc-cgroup  '
+
+if [ "$1" = "autoconf" ]; then
+	if [ -r /proc/stat ]; then
+		echo yes
+		exit 0
+	else
+		echo "no (no /proc/stat)"
+		exit 0
+	fi
+fi
+
+if [ "$1" = "config" ]; then
+
+ echo 'graph_title Memory '
+ echo 'graph_args -l 0 --base 1024'
+ echo 'graph_vlabel byte'
+ echo 'graph_category lxc'
+
+
+ for guest_name in $guest_names;
+  do
+   guest="$(clean_fieldname $guest_name)"
+   name=`cat /etc/pve/nodes/proxmox/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
+   echo 'mem_usage_'$guest'.label '$name': Mem usage'
+   echo 'mem_usage_'$guest'.type GAUGE'
+   echo 'mem_cache_'$guest'.label '$name': Cache'
+   echo 'mem_cache_'$guest'.type GAUGE'
+   echo 'mem_active_'$guest'.label '$name': Active'
+   echo 'mem_active_'$guest'.type GAUGE'
+   echo 'mem_inactive_'$guest'.label '$name': Inactive'
+   echo 'mem_inactive_'$guest'.type GAUGE'
+
+  done
+ 
+ exit 0
+fi
+
+
+ for guest_name in $guest_names;
+  do
+   guest="$(clean_fieldname $guest_name)"
+
+   tmp_v=`$f_comm -n $guest_name memory.usage_in_bytes`
+   echo 'mem_usage_'$guest'.value '$tmp_v
+   
+   tmp_g=`$f_comm -n $guest_name memory.stat | grep total_cache`
+   tmp_v=`echo $tmp_g | awk '{print($2)}'`
+   echo  'mem_cache_'$guest'.value '$tmp_v
+   
+   tmp_g=`$f_comm -n $guest_name memory.stat | grep total_active_anon`
+   tmp_v=`echo $tmp_g | awk '{print($2)}'`
+   echo  'mem_active_'$guest'.value '$tmp_v
+   
+   tmp_g=`$f_comm -n $guest_name memory.stat | grep total_inactive_anon`
+   tmp_v=`echo $tmp_g | awk '{print($2)}'`
+   echo  'mem_inactive_'$guest'.value '$tmp_v
+
+  done

--- a/plugins/lxc/lxc_pct_ram
+++ b/plugins/lxc/lxc_pct_ram
@@ -67,7 +67,7 @@ if [ "$1" = "config" ]; then
  for guest_name in $guest_names;
   do
    guest="$(clean_fieldname $guest_name)"
-   name=`cat /etc/pve/nodes/proxmox/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
+   name=`cat /etc/pve/lxc/$guest_name.conf | grep hostname | awk '{print $2}'`
    echo 'mem_usage_'$guest'.label '$name': Mem usage'
    echo 'mem_usage_'$guest'.type GAUGE'
    echo 'mem_cache_'$guest'.label '$name': Cache'


### PR DESCRIPTION
The original lxc_ plugins work fine for all kinds of LXC hosts. But as the amount of containers grows, it becomes quite annoying that the plugins only list the id of the containers.
Those 4 modified versions only work for Proxmox hosts and use the config-files to determine the hostname of the containers.
