### PR TITLE
If a pool is named something like "m" or "ra" or any string that matc…

### DIFF
--- a/plugins/zfs/zpool_iostat
+++ b/plugins/zfs/zpool_iostat
@@ -40,9 +40,9 @@ echo $zlist | tr ' ' '\n' | while read iz; do
 	*) name=`echo $iz | gawk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
 	esac
 	echo -n $name'_read.value '
-	grep '^[ ]*'$zlabel\  $ztmp|gawk '{print $6}'|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
+	gawk '{ if ($1 == "'"$zlabel"'") print $6; }' "$ztmp"|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
 	echo -n $name'_write.value '
-	grep '^[ ]*'$zlabel\  $ztmp|gawk '{print $7}'|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
+	gawk '{ if ($1 == "'"$zlabel"'") print $7; }' "$ztmp"|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
 done
 
 rm $ztmp; touch $ztmp

--- a/plugins/zfs/zpool_iostat
+++ b/plugins/zfs/zpool_iostat
@@ -40,9 +40,9 @@ echo $zlist | tr ' ' '\n' | while read iz; do
 	*) name=`echo $iz | gawk '{ gsub("[^a-zA-Z0-9_]", "_", $1); print $1 }'` ;;
 	esac
 	echo -n $name'_read.value '
-	grep '^[ ]*'$zlabel $ztmp|gawk '{print $6}'|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
+	grep '^[ ]*'$zlabel\  $ztmp|gawk '{print $6}'|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
 	echo -n $name'_write.value '
-	grep '^[ ]*'$zlabel $ztmp|gawk '{print $7}'|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
+	grep '^[ ]*'$zlabel\  $ztmp|gawk '{print $7}'|gawk '/M/ {print strtonum($1)*1000}; /K/ {print strtonum($1)}; /[0-9]$/ {print int($1)/1000}'
 done
 
 rm $ztmp; touch $ztmp


### PR DESCRIPTION
…hes the types of zpool, the grep will match multiple lines.

Adding a space after the zlabel will allow for more exact matching.