### PR TITLE
add wildcard version of rabbitmq messages and consumer plugins

### DIFF
--- a/plugins/rabbitmq/rabbitmq.inc
+++ b/plugins/rabbitmq/rabbitmq.inc
@@ -1,0 +1,33 @@
+CMD=$(which rabbitmqctl)
+
+if [ "$1" = "autoconf" ]; then
+    test -x "$CMD" && echo yes || echo "no ('$CMD' not executable)"
+	exit 0
+fi
+
+if [ "$1" = "suggest" ]; then
+    for h in $(HOME=$HOME sudo $CMD list_vhosts -q); do 
+        vhost=$(echo $h | sed -e 's#/##')
+        if [ -z "$vhost" ] ; then
+            vhost="_root"
+        fi
+        echo $vhost
+    done
+    exit 0
+fi
+
+# If run with the "config"-parameter, give out information on how the
+# graphs should look. 
+
+HOME=/tmp/
+SELF=$(basename $0)
+PREFIX=$(basename $(readlink -f "$0"))
+VHOST=${SELF##$PREFIX}
+
+if [ "$VHOST" = "_root" ] ; then
+    VHOST="/"
+fi
+
+VHOST=${vhost:-$VHOST}
+IGNORE=${ignore:-'\A(?!x)x'}
+

--- a/plugins/rabbitmq/rabbitmq_consumers_
+++ b/plugins/rabbitmq/rabbitmq_consumers_
@@ -1,0 +1,66 @@
+#!/bin/sh
+# 
+# Plugin to monitor the queues of a virtual_host in RabbitMQ
+#
+# Usage: Link or copy into /etc/munin/node.d/
+#
+# Parameters
+#     env.vhost <AMQ virtual host>
+#     env.queue_warn <warning queuesize>
+#     env.queue_crit <critical queuesize>
+#     env.ignore <regex to ignore queues>
+#
+# Magic markers (optional - only used by munin-config and some
+# installation scripts):
+#
+#%# family=auto
+#%# capabilities=autoconf suggest
+
+# If run with the "autoconf"-parameter, give our opinion on wether we
+# should be run on this system or not. This is optinal, and only used by
+# munin-config. In the case of this plugin, we should most probably
+# always be included.
+
+. $(dirname $(readlink -f "$0"))/rabbitmq.inc
+
+QUEUES=$(HOME=$HOME sudo $CMD list_queues -p $VHOST name | \
+		grep -v '^Listing' | egrep -v "$IGNORE" | \
+		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
+ 
+if [ "$1" = "config" ]; then
+        QUEUE_WARN=${queue_warn:-100}
+        QUEUE_CRIT=${queue_crit:-500}
+
+	# The host name this plugin is for. (Can be overridden to have
+	# one machine answer for several)
+
+	# The title of the graph
+	echo "graph_title RabbitMQ $VHOST consumers"
+	# Arguments to "rrdtool graph". In this case, tell it that the
+	# lower limit of the graph is '0', and that 1k=1000 (not 1024)
+	echo 'graph_args --base 1000 -l 0'
+	# The Y-axis label
+	echo 'graph_vlabel consumers'
+	# We want Cur/Min/Avg/Max unscaled (i.e. 0.42 load instead of
+	# 420 milliload)
+	#echo 'graph_scale no'
+	echo 'graph_category RabbitMQ'
+
+	for queue in $QUEUES; do
+		echo "$queue.label $queue"
+		echo "$queue.warning $QUEUE_WARN"
+		echo "$queue.critical $QUEUE_CRIT"
+		echo "$queue.info Active consumers for $queue"
+	done
+
+	echo 'graph_info Lists active consumers for a queue.'
+	# Last, if run with the "config"-parameter, quit here (don't
+	# display any data)
+	exit 0
+fi
+
+# If not run with any parameters at all (or only unknown ones), do the
+# real work - i.e. display the data. Almost always this will be
+# "value" subfield for every data field.
+
+HOME=$HOME sudo $CMD list_queues -p $VHOST name consumers| grep -v "^Listing" | grep -v "done.$" | grep -v "\.\.\." | egrep -v "$IGNORE" | sed "s/[\t]/.value /g"

--- a/plugins/rabbitmq/rabbitmq_messages_
+++ b/plugins/rabbitmq/rabbitmq_messages_
@@ -1,0 +1,65 @@
+#!/bin/sh
+# 
+# Plugin to monitor the queues of a virtual_host in RabbitMQ
+#
+# Usage: Link or copy into /etc/munin/node.d/
+#
+# Parameters
+#     env.vhost <AMQ virtual host>
+#     env.queue_warn <warning queuesize>
+#     env.queue_crit <critical queuesize>
+#     env.ignore <regex to ignore queues>
+#
+# Magic markers (optional - only used by munin-config and some
+# installation scripts):
+#
+#%# family=auto
+#%# capabilities=autoconf suggest
+
+# If run with the "autoconf"-parameter, give our opinion on wether we
+# should be run on this system or not. This is optinal, and only used by
+# munin-config.
+
+. $(dirname $(readlink -f "$0"))/rabbitmq.inc
+
+QUEUES=$(HOME=$HOME sudo $CMD list_queues -p $VHOST name | \
+		grep -v '^Listing' | egrep -v "$IGNORE" | \
+		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
+ 
+if [ "$1" = "config" ]; then
+        QUEUE_WARN=${queue_warn:-10000}
+        QUEUE_CRIT=${queue_crit:-20000}
+
+	# The host name this plugin is for. (Can be overridden to have
+	# one machine answer for several)
+
+	# The title of the graph
+	echo "graph_title RabbitMQ $VHOST list_queues"
+	# Arguments to "rrdtool graph". In this case, tell it that the
+	# lower limit of the graph is '0', and that 1k=1000 (not 1024)
+	echo 'graph_args --base 1000 -l 0'
+	# The Y-axis label
+	echo 'graph_vlabel queue_size'
+	# We want Cur/Min/Avg/Max unscaled (i.e. 0.42 load instead of
+	# 420 milliload)
+	#echo 'graph_scale no'
+	echo 'graph_category RabbitMQ'
+
+	for queue in $QUEUES; do
+		echo "$queue.label $queue"
+		echo "$queue.warning $QUEUE_WARN"
+		echo "$queue.critical $QUEUE_CRIT"
+		echo "$queue.info Queue size for $queue"
+	done
+
+	echo 'graph_info Lists how many messages are in each queue.'
+	# Last, if run with the "config"-parameter, quit here (don't
+	# display any data)
+	exit 0
+fi
+
+# If not run with any parameters at all (or only unknown ones), do the
+# real work - i.e. display the data. Almost always this will be
+# "value" subfield for every data field.
+
+HOME=$HOME sudo $CMD list_queues -p $VHOST | grep -v "^Listing" | grep -v "done.$" | grep -v "\.\.\." | egrep -v "$IGNORE" | sed "s/[\t]/.value /g"


### PR DESCRIPTION
Based on the existing rabbitmq plugins here are two new wildcard plugins which run for each virtual host present.

Additional options:
- `ignore`: a regex to ignore certain queues
