### PR TITLE
lxd plugins

### DIFF
--- a/plugins/lxd/lxd_disk
+++ b/plugins/lxd/lxd_disk
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+import sys
+from pylxd import api
+
+c=api.API()
+
+if len(sys.argv) == 2:
+    if sys.argv[1]=="autoconf":
+        print("yes")
+        sys.exit(0)
+    elif sys.argv[1]=="config":
+        print("graph_title LXD container disk usage")
+        print("graph_args --base 1000 --lower-limit 0")
+        print("graph_vlabel Bytes")
+        print("graph_category lxd")
+        print("graph_info This shows the disk usage of storage in containers. Make sure to install pylxd in python3.")
+        for name in c.container_list():
+            for disk in c.container_info(name)['disk']:
+                print(name+"-"+disk+".label "+name)
+                print(name+"-"+disk+".draw LINE2")
+        sys.exit(0)
+
+for name in c.container_list():
+    for disk in c.container_info(name)['disk']:
+        print(name+"-"+disk+".value "+str(c.container_info(name)['disk'][disk]['usage']))

--- a/plugins/lxd/lxd_disk
+++ b/plugins/lxd/lxd_disk
@@ -1,25 +1,47 @@
 #!/usr/bin/python3
 
 import sys
-from pylxd import api
 
-c=api.API()
+errors=[]
 
-if len(sys.argv) == 2:
-    if sys.argv[1]=="autoconf":
+HAS_LIB=True
+try:
+    from pylxd import api
+except:
+    HAS_LIB=False
+    errors.append("no pylxd module")
+    
+c=None
+HAS_ACCESS=True
+try:
+    c=api.API()
+    c.container_list()
+except:
+    HAS_ACCESS=False
+    errors.append("no socket access")
+
+if len(sys.argv) == 2 and sys.argv[1]=="autoconf":
+    if HAS_LIB and HAS_ACCESS:
         print("yes")
-        sys.exit(0)
-    elif sys.argv[1]=="config":
-        print("graph_title LXD container disk usage")
-        print("graph_args --base 1000 --lower-limit 0")
-        print("graph_vlabel Bytes")
-        print("graph_category lxd")
-        print("graph_info This shows the disk usage of storage in containers. Make sure to install pylxd in python3.")
-        for name in c.container_list():
-            for disk in c.container_info(name)['disk']:
-                print(name+"-"+disk+".label "+name)
-                print(name+"-"+disk+".draw LINE2")
-        sys.exit(0)
+    else:
+        print("no ("+" and ".join(errors)+")")
+    sys.exit(0)
+
+if not (HAS_LIB and HAS_ACCESS):
+    # pylxd not installed or lxd socket not accessible
+    sys.exit(1)
+
+if len(sys.argv) == 2 and sys.argv[1]=="config":
+    print("graph_title LXD container disk usage")
+    print("graph_args --base 1000 --lower-limit 0")
+    print("graph_vlabel Bytes")
+    print("graph_category lxd")
+    print("graph_info This shows the disk usage of storage in containers. Make sure to install pylxd in python3.")
+    for name in c.container_list():
+        for disk in c.container_info(name)['disk']:
+            print(name+"-"+disk+".label "+name)
+            print(name+"-"+disk+".draw LINE2")
+    sys.exit(0)
 
 for name in c.container_list():
     for disk in c.container_info(name)['disk']:

--- a/plugins/lxd/lxd_mem
+++ b/plugins/lxd/lxd_mem
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+
+import sys
+from pylxd import api
+
+c=api.API()
+
+if len(sys.argv) == 2:
+    if sys.argv[1]=="autoconf":
+        print("yes")
+        sys.exit(0)
+    elif sys.argv[1]=="config":
+        print("graph_title LXD container memory")
+        print("graph_args --base 1024 --lower-limit 0")
+        print("graph_vlabel Bytes")
+        print("graph_category lxd")
+        print("graph_info This shows the memory usage of each container. Make sure to install pylxd in python3.")
+        for name in c.container_list():
+            print(name+".label "+name)
+            print(name+".draw AREASTACK")
+        sys.exit(0)
+
+for name in c.container_list():
+    print(name+".value "+str(c.container_info(name)['memory']['usage']))

--- a/plugins/lxd/lxd_mem
+++ b/plugins/lxd/lxd_mem
@@ -1,24 +1,46 @@
 #!/usr/bin/python3
 
 import sys
-from pylxd import api
 
-c=api.API()
+errors=[]
 
-if len(sys.argv) == 2:
-    if sys.argv[1]=="autoconf":
+HAS_LIB=True
+try:
+    from pylxd import api
+except:
+    HAS_LIB=False
+    errors.append("no pylxd module")
+    
+c=None
+HAS_ACCESS=True
+try:
+    c=api.API()
+    c.container_list()
+except:
+    HAS_ACCESS=False
+    errors.append("no socket access")
+
+if len(sys.argv) == 2 and sys.argv[1]=="autoconf":
+    if HAS_LIB and HAS_ACCESS:
         print("yes")
-        sys.exit(0)
-    elif sys.argv[1]=="config":
-        print("graph_title LXD container memory")
-        print("graph_args --base 1024 --lower-limit 0")
-        print("graph_vlabel Bytes")
-        print("graph_category lxd")
-        print("graph_info This shows the memory usage of each container. Make sure to install pylxd in python3.")
-        for name in c.container_list():
-            print(name+".label "+name)
-            print(name+".draw AREASTACK")
-        sys.exit(0)
+    else:
+        print("no ("+" and ".join(errors)+")")
+    sys.exit(0)
+
+if not (HAS_LIB and HAS_ACCESS):
+    # pylxd not installed or lxd socket not accessible
+    sys.exit(1)
+
+if len(sys.argv) == 2 and sys.argv[1]=="config":
+    print("graph_title LXD container memory")
+    print("graph_args --base 1024 --lower-limit 0")
+    print("graph_vlabel Bytes")
+    print("graph_category lxd")
+    print("graph_info This shows the memory usage of each container. Make sure to install pylxd in python3.")
+    for name in c.container_list():
+        print(name+".label "+name)
+        print(name+".draw AREASTACK")
+    sys.exit(0)
 
 for name in c.container_list():
     print(name+".value "+str(c.container_info(name)['memory']['usage']))


### PR DESCRIPTION
lxd is the abstraction of lxc containers and provides multiple additional services. Through a REST interface and pylxd it provides a lot of metrics about running containers which can be graphed. To run it, the munin user must either be in the lxd group or the plugin must run as root in the `munin-node` config

    [lxd_*]
    user root

Creating a new plugin for another value, such as network traffic, can easily be copied from these ones.