### PR TITLE
Skip over comment lines in dhcpd.conf

### DIFF
--- a/plugins/network/dhcp-pool
+++ b/plugins/network/dhcp-pool
@@ -98,6 +98,7 @@ sub determine_pools {
     close (CONFFILE);
 
     foreach $line (@conffile) {
+	next if ($line =~/^\s*($|#)/) ;
 	if ($line =~ /range[\s]+([\d]+\.[\d]+\.[\d]+\.[\d]+)[\s]+([\d]+\.[\d]+\.[\d]+\.[\d]+)/) {
 	    $start = string2ip($1);
 	    $end = string2ip($2);


### PR DESCRIPTION
to avoid finding random subnets in the comments.
Without this comment lines will end up getting captured, and statistics erroneously generated for them.
