### PR TITLE
Update boinc_projs

### DIFF
--- a/plugins/boinc/boinc_projs
+++ b/plugins/boinc/boinc_projs
@@ -24,6 +24,10 @@
 #
 # $Log$
 #
+# Revision 1.2  2016/10/04  Paul Saunders
+#   BoincCmd now translates states into words, so consider a "downloaded, scheduled, EXECUTING" task
+#     to be equivalent to a "2, 2, 1" task
+#   Really, this should be ported to use the proper RPC, rather than parsing boinccmd's output.
 # Revision 1.1  2011/03/22  Paul Saunders
 #   Update for BOINC 6.12
 #   Add colours from http://boinc.netsoft-online.com/e107_plugins/forum/forum_viewtopic.php?3
@@ -145,7 +149,8 @@ for my $rslt_info (@rsltInfos) {
   my @acttask = grep /^\s+active_task_state: /,@lines;
   my $acttask = $acttask[0];
   $acttask =~ s/^\s+active_task_state: //;
-  if ( ($schedstat eq "2") && ($state eq "2") && ($acttask eq "1") ) {
+  if (( ($schedstat eq "2") && ($state eq "2") && ($acttask eq "1") ) ||
+      ( ($schedstate eq "scheduled") && ($state eq "downloaded") && ($acttask eq "EXECUTING") )) {
     # This is running task
     $projects{$url}->{prj_running} += 1;
   }


### PR DESCRIPTION
BoincCmd now translates states into words, so consider a "downloaded, scheduled, EXECUTING" task to be equivalent to a "2, 2, 1" task.