### PR TITLE
travis/CI: remove perl module File::Tail::Multi (cpan failed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ install:
   - cpanm --notest Device::SerialPort
   - cpanm --notest FCGI::Client
   - cpanm --notest File::ReadBackwards
-  - cpanm --notest File::Tail::Multi
   - cpanm --notest Graphics::ColorObject
   - cpanm --notest IPC::Run3
   - cpanm --notest IPC::ShareLite
@@ -55,6 +54,7 @@ install:
   # - Sys::Virt version matching the test system's libvirt-dev
   - cpanm --notest DANBERR/Sys-Virt-0.9.8.tar.gz
   # Modules used by plugins, but missing on cpan
+  # - File::Tail::Multi
   # - Sun::Solaris::Kstat
   # - VMware::VIRuntime
   # - MythTV

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ install:
   - cpanm --notest Device::SerialPort
   - cpanm --notest FCGI::Client
   - cpanm --notest File::ReadBackwards
+  # currently "File::Tail::Multi" is not available - but it is part of "Bundle::Everything"
+  # TODO: switch back to "File::Tail::Multi"
+  - cpanm --notest Bundle::Everything
+  # cpanm --notest File::Tail::Multi
   - cpanm --notest Graphics::ColorObject
   - cpanm --notest IPC::Run3
   - cpanm --notest IPC::ShareLite
@@ -54,7 +58,6 @@ install:
   # - Sys::Virt version matching the test system's libvirt-dev
   - cpanm --notest DANBERR/Sys-Virt-0.9.8.tar.gz
   # Modules used by plugins, but missing on cpan
-  # - File::Tail::Multi
   # - Sun::Solaris::Kstat
   # - VMware::VIRuntime
   # - MythTV


### PR DESCRIPTION
Somehow the module File::Tail::Multi disappeared from cpan within the last days.
A previous travis run succeeded with this module installed:
  https://travis-ci.org/munin-monitoring/contrib/builds/151461171
A later run failed due to this module:
  https://travis-ci.org/munin-monitoring/contrib/builds/168205319