### PR TITLE
other/sshd_log: use DERIVE datatype and support logs from journald too (using cursors)

### DIFF
--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -23,6 +23,9 @@ The following environment variables are used by this plugin:
                   journalctl to get the sshd logs.
                   default: _COMM=sshd
 
+ type - "GAUGE" or "DERIVE"
+         default: GAUGE
+
 If the "logfile" environment variable is set to "journald" the sshd
 logs are read from journald, filtering on program "sshd". The filtering
 may be changed using "journalctlargs".
@@ -48,6 +51,13 @@ Config example with journald on the sshd.service unit only:
       env.logfile journald
       env.journalctlargs --unit=sshd.service
 
+Config example with journald and type DERIVE:
+
+  [sshd_log]
+      group systemd-journal
+      env.logfile journald
+      env.type DERIVE
+
 =head1 MAGIC MARKERS
 
   #%# family=auto
@@ -71,6 +81,10 @@ Revision 1.0  2009/04/22 22:00:00  zlati
 
 LOG=${logfile:-/var/log/secure}
 JOURNALCTL_ARGS=${journalctlargs:-_COMM=sshd}
+TYPE=${type:-GAUGE}
+if [ "$LOG" = "journald" -a "$TYPE" = "DERIVE" ]; then
+        TYPE=ABSOLUTE
+fi
 
 
 if [ "$1" = "autoconf" ]; then
@@ -92,13 +106,6 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 if [ "$1" = "config" ]; then
-
-        if [ "$LOG" = "journald" ]; then
-                TYPE=ABSOLUTE
-        else
-                TYPE=DERIVE
-        fi
-
         echo 'graph_title SSHD login stats from' "$LOG"
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel logins'
@@ -139,7 +146,7 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
-if [ "$LOG" = "journald" ]; then
+if [ "$LOG" = "journald" -a "$TYPE" = "ABSOLUTE" ]; then
         CURSOR_FILE="$MUNIN_STATEFILE"
         # read cursor
         # format: "journald-cursor <cursor>"
@@ -153,7 +160,11 @@ fi
 
 if [ "$LOG" = "journald" ]; then
         # shellcheck disable=SC2086
-        journalctl --no-pager --quiet --show-cursor ${CURSOR:+"--after-cursor=$CURSOR"} $JOURNALCTL_ARGS
+        if [ "$TYPE" = "ABSOLUTE" ]; then
+                journalctl --no-pager --quiet --show-cursor ${CURSOR:+"--after-cursor=$CURSOR"} $JOURNALCTL_ARGS
+        else
+                journalctl --no-pager --quiet --since=$(date -dlast-sunday +%Y-%m-%d) $JOURNALCTL_ARGS
+        fi
 else
         cat "$LOG"
 fi | \

--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -25,7 +25,7 @@ The following environment variables are used by this plugin:
 
 If the "logfile" environment variable is set to "journald" the sshd
 logs are read from journald, filtering on program "sshd". The filtering
-may be changed using "journalctlarg".
+may be changed using "journalctlargs".
 
 
 Config examples for /etc/munin/plugin-conf.d/munin-node:
@@ -46,7 +46,7 @@ Config example with journald on the sshd.service unit only:
   [sshd_log]
       group systemd-journal
       env.logfile journald
-      env.journalctlarg --unit=sshd.service
+      env.journalctlargs --unit=sshd.service
 
 =head1 MAGIC MARKERS
 
@@ -70,15 +70,16 @@ Revision 1.0  2009/04/22 22:00:00  zlati
 
 
 LOG=${logfile:-/var/log/secure}
-JOURNALCTL_ARG=${journalctlarg:-_COMM=sshd}
+JOURNALCTL_ARGS=${journalctlargs:-_COMM=sshd}
 
 
 if [ "$1" = "autoconf" ]; then
         if [ "$LOG" = "journald" ]; then
-                if journalctl --no-pager --quiet --lines=1 "$JOURNALCTL_ARG" | read -r DUMMY; then
+                # shellcheck disable=SC2086,SC2034
+                if journalctl --no-pager --quiet --lines=1 $JOURNALCTL_ARGS | read -r DUMMY; then
                         echo "yes"
                 else
-                        echo "no (journald empty log for '$JOURNALCTL_ARG' not found)"
+                        echo "no (journald empty log for '$JOURNALCTL_ARGS' not found)"
                 fi
         else
                 if [ -r "$LOG" ]; then
@@ -151,7 +152,8 @@ else
 fi
 
 if [ "$LOG" = "journald" ]; then
-        journalctl --no-pager --quiet --show-cursor ${CURSOR:+"--after-cursor=$CURSOR"} "$JOURNALCTL_ARG"
+        # shellcheck disable=SC2086
+        journalctl --no-pager --quiet --show-cursor ${CURSOR:+"--after-cursor=$CURSOR"} $JOURNALCTL_ARGS
 else
         cat "$LOG"
 fi | \

--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -1,44 +1,75 @@
 #!/bin/sh
-#
-# Plugin to monitor auth.log or journald for sshd server events.
-#
-# Require read permitions for $LOG or journald
-#  (set in /etc/munin/plugin-conf.d/munin-node on debian)
-#
-# $Log$
-# Revision 2.0  2016/11/11 15:42:00  Thomas Riccardi
-# Revision 1.2  2010/03/19 15:03:00  pmoranga
-# Revision 1.1  2009/04/26 23:28:00  ckujau
-# Revision 1.0  2009/04/22 22:00:00  zlati
-# Initial revision
-#
-# Parameters:
+
+: <<=cut
+
+=head1 NAME
+
+sshd_log - Munin plugin to monitor auth.log or journald for sshd
+           server events.
+
+=head1 CONFIGURATION
+
+This plugin requires read permission for the logfile or journald.
+
+On busy servers you can change value type to COUNTER and set min to 0
+to avoid minus peaks at logrotate.
+
+The following environment variables are used by this plugin:
+
+ logfile  - path to the auth log file, or "journald" to use journald.
+            default: /var/log/secure
+ category - graph category. default: system
+
+ journalctlargs - space separated list of arguments to pass to
+                  journalctl to get the sshd logs.
+                  default: _COMM=sshd
+
+If the "logfile" environment variable is set to "journald" the sshd
+logs are read from journald, filtering on program "sshd". The filtering
+may be changed using "journalctlarg".
+
+
+Config examples for /etc/munin/plugin-conf.d/munin-node:
+
+  [sshd_log]
+      user root
+      group root
+      env.logfile /var/log/messages
+      env.category users
+
+Config example with journald:
+
+  [sshd_log]
+      group systemd-journal
+      env.logfile journald
+
+Config example with journald on the sshd.service unit only:
+
+  [sshd_log]
+      group systemd-journal
+      env.logfile journald
+      env.journalctlarg --unit=sshd.service
+
+=head1 MAGIC MARKERS
+
+  #%# family=auto
+  #%# capabilities=autoconf
+
+=head1 AUTHOR
+
+Revision 2.0  2016/11/11 15:42:00  Thomas Riccardi
+Revision 1.2  2010/03/19 15:03:00  pmoranga
+Revision 1.1  2009/04/26 23:28:00  ckujau
+Revision 1.0  2009/04/22 22:00:00  zlati
+
+=cut
+
+
+# Script parameters:
 #
 #       config   (required)
 #       autoconf (optional - used by munin-config)
-#
-# Magick markers (optional):
-#%# family=auto
-#%# capabilities=autoconf
 
-# config example for /etc/munin/plugin-conf.d/munin-node
-#[sshd_log]
-#user root
-#group root
-#env.logfile /var/log/messages
-#env.category users
-#
-# config example with journald
-#[sshd_log]
-#group systemd-journal
-#env.logfile journald
-#
-# config example with journald on the sshd.service unit only
-#[sshd_log]
-#group systemd-journal
-#env.logfile journald
-#env.journalctlarg --unit=sshd.service
-#
 
 LOG=${logfile:-/var/log/secure}
 JOURNALCTL_ARG=${journalctlarg:-_COMM=sshd}

--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -18,7 +18,6 @@ The following environment variables are used by this plugin:
 
  logfile  - path to the auth log file, or "journald" to use journald.
             default: /var/log/secure
- category - graph category. default: system
 
  journalctlargs - space separated list of arguments to pass to
                   journalctl to get the sshd logs.
@@ -35,7 +34,6 @@ Config examples for /etc/munin/plugin-conf.d/munin-node:
       user root
       group root
       env.logfile /var/log/messages
-      env.category users
 
 Config example with journald:
 

--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -1,12 +1,12 @@
 #!/bin/sh
 #
-# Plugin to monitor auth.log for sshd server events.
+# Plugin to monitor auth.log or journald for sshd server events.
 #
-# Require read permitions for $LOG
+# Require read permitions for $LOG or journald
 #  (set in /etc/munin/plugin-conf.d/munin-node on debian)
-# On busy servers you can change value type to COUNTER and set min to 0 to avoid minus peaks at logrotate
 #
 # $Log$
+# Revision 2.0  2016/11/11 15:42:00  Thomas Riccardi
 # Revision 1.2  2010/03/19 15:03:00  pmoranga
 # Revision 1.1  2009/04/26 23:28:00  ckujau
 # Revision 1.0  2009/04/22 22:00:00  zlati
@@ -28,21 +28,49 @@
 #env.logfile /var/log/messages
 #env.category users
 #
+# config example with journald
+#[sshd_log]
+#group systemd-journal
+#env.logfile journald
+#
+# config example with journald on the sshd.service unit only
+#[sshd_log]
+#group systemd-journal
+#env.logfile journald
+#env.journalctlarg --unit=sshd.service
+#
 
 LOG=${logfile:-/var/log/secure}
+JOURNALCTL_ARG=${journalctlarg:-_COMM=sshd}
 
 
 if [ "$1" = "autoconf" ]; then
-        if [ -r "$LOG" ]; then
-                echo yes
-                exit 0
+        if [ "$LOG" = "journald" ]; then
+                if journalctl --no-pager --quiet --lines=1 "$JOURNALCTL_ARG" | read -r DUMMY; then
+                        echo yes
+                        exit 0
+                else
+                        echo no
+                        exit 1
+                fi
         else
-                echo no
-                exit 1
+                if [ -r "$LOG" ]; then
+                        echo yes
+                        exit 0
+                else
+                        echo no
+                        exit 1
+                fi
         fi
 fi
 
 if [ "$1" = "config" ]; then
+
+        if [ "$LOG" = "journald" ]; then
+                TYPE=ABSOLUTE
+        else
+                TYPE=DERIVE
+        fi
 
         echo 'graph_title SSHD login stats from' $LOG
         echo 'graph_args --base 1000 -l 0'
@@ -50,17 +78,58 @@ if [ "$1" = "config" ]; then
         echo 'graph_category' security
 
         echo 'LogPass.label Successful password logins'
+        echo 'LogPass.min 0'
+        echo 'LogPass.type' "$TYPE"
+
         echo 'LogPassPAM.label Successful login via PAM'
+        echo 'LogPassPAM.min 0'
+        echo 'LogPassPAM.type' "$TYPE"
+
         echo 'LogKey.label Successful PublicKey logins'
+        echo 'LogKey.min 0'
+        echo 'LogKey.type' "$TYPE"
+
         echo 'NoID.label No identification from user'
+        echo 'NoID.min 0'
+        echo 'NoID.type' "$TYPE"
+
         echo 'rootAttempt.label Root login attempts'
+        echo 'rootAttempt.min 0'
+        echo 'rootAttempt.type' "$TYPE"
+
         echo 'InvUsr.label Invalid user login attepmts'
+        echo 'InvUsr.min 0'
+        echo 'InvUsr.type' "$TYPE"
+
         echo 'NoRDNS.label No reverse DNS for peer'
+        echo 'NoRDNS.min 0'
+        echo 'NoRDNS.type' "$TYPE"
+
         echo 'Breakin.label Potential Breakin Attempts'
+        echo 'Breakin.min 0'
+        echo 'Breakin.type' "$TYPE"
+
         exit 0
 fi
 
-awk 'BEGIN{c["LogPass"]=0;c["LogKey"]=0;c["NoID"]=0;c["rootAttempt"]=0;c["InvUsr"]=0;c["LogPassPAM"]=0;c["Breakin"]=0;c["NoRDNS"]=0; }
+if [ "$LOG" = "journald" ]; then
+        CURSOR_FILE="$MUNIN_STATEFILE"
+        # read cursor
+        # format: "journald-cursor <cursor>"
+        CURSOR=
+        if [ -f "$CURSOR_FILE" ]; then
+                CURSOR=$(awk '/^journald-cursor / {print $2}' "$CURSOR_FILE")
+        fi
+else
+        CURSOR_FILE=
+fi
+
+if [ "$LOG" = "journald" ]; then
+        journalctl --no-pager --quiet --show-cursor ${CURSOR:+"--after-cursor=$CURSOR"} "$JOURNALCTL_ARG"
+else
+        cat $LOG
+fi | \
+    awk -v cursor_file="$CURSOR_FILE" 'BEGIN{c["LogPass"]=0;c["LogKey"]=0;c["NoID"]=0;c["rootAttempt"]=0;c["InvUsr"]=0;c["LogPassPAM"]=0;c["Breakin"]=0;c["NoRDNS"]=0; }
      /sshd\[.*Accepted password for/{c["LogPass"]++}
      /sshd\[.*Accepted publickey for/{c["LogKey"]++}
      /sshd\[.*Did not receive identification string/{c["NoID"]++}
@@ -69,4 +138,4 @@ awk 'BEGIN{c["LogPass"]=0;c["LogKey"]=0;c["NoID"]=0;c["rootAttempt"]=0;c["InvUsr
      /sshd\[.*POSSIBLE BREAK-IN ATTEMPT!/{c["Breakin"]++}
      /sshd\[.*keyboard-interactive\/pam/{c["LogPassPAM"]++}
      /sshd\[.*reverse mapping checking getaddrinfo/{c["NoRDNS"]++}a
-     END{for(i in c){print i".value " c[i]} }' < $LOG
+     END{if (cursor_file != "") { print "journald-cursor " $3 > cursor_file };for(i in c){print i".value " c[i]} }'

--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -47,21 +47,18 @@ JOURNALCTL_ARG=${journalctlarg:-_COMM=sshd}
 if [ "$1" = "autoconf" ]; then
         if [ "$LOG" = "journald" ]; then
                 if journalctl --no-pager --quiet --lines=1 "$JOURNALCTL_ARG" | read -r DUMMY; then
-                        echo yes
-                        exit 0
+                        echo "yes"
                 else
-                        echo no
-                        exit 1
+                        echo "no (journald empty log for '$JOURNALCTL_ARG' not found)"
                 fi
         else
                 if [ -r "$LOG" ]; then
-                        echo yes
-                        exit 0
+                        echo "yes"
                 else
-                        echo no
-                        exit 1
+                        echo "no (logfile '$LOG' not readable)"
                 fi
         fi
+        exit 0
 fi
 
 if [ "$1" = "config" ]; then

--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -72,7 +72,7 @@ if [ "$1" = "config" ]; then
                 TYPE=DERIVE
         fi
 
-        echo 'graph_title SSHD login stats from' $LOG
+        echo 'graph_title SSHD login stats from' "$LOG"
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel logins'
         echo 'graph_category' security
@@ -127,7 +127,7 @@ fi
 if [ "$LOG" = "journald" ]; then
         journalctl --no-pager --quiet --show-cursor ${CURSOR:+"--after-cursor=$CURSOR"} "$JOURNALCTL_ARG"
 else
-        cat $LOG
+        cat "$LOG"
 fi | \
     awk -v cursor_file="$CURSOR_FILE" 'BEGIN{c["LogPass"]=0;c["LogKey"]=0;c["NoID"]=0;c["rootAttempt"]=0;c["InvUsr"]=0;c["LogPassPAM"]=0;c["Breakin"]=0;c["NoRDNS"]=0; }
      /sshd\[.*Accepted password for/{c["LogPass"]++}

--- a/plugins/ssh/sshd_log
+++ b/plugins/ssh/sshd_log
@@ -123,7 +123,7 @@ if [ "$1" = "config" ]; then
         echo 'rootAttempt.min 0'
         echo 'rootAttempt.type' "$TYPE"
 
-        echo 'InvUsr.label Invalid user login attepmts'
+        echo 'InvUsr.label Invalid user login attempts'
         echo 'InvUsr.min 0'
         echo 'InvUsr.type' "$TYPE"
 


### PR DESCRIPTION
Now shows the number of events per time unit, instead of a counter
always increasing until logrotate.

To use journald, set env.logfile to special value 'journald': It will
read the sshd logs from journalctl _COMM=sshd.
To configure the source of journald, set env.journalctlarg:
Example: "env.journalctlarg --unit=sshd.service"

Previous discussion: #770.
This version uses journald cursor to only parse new logs on each run.