### PR TITLE
Plugin for monitoring EMC VNX5300 Block statistics

### DIFF
--- a/plugins/emc/emc_vnx_block_lun_perfdata
+++ b/plugins/emc/emc_vnx_block_lun_perfdata
@@ -158,28 +158,24 @@ echo -n "graph_order "
 	while read -r LUN ; do
 		echo "${LUN}_busyticks_spa.label $LUN Busy Ticks SPA
 ${LUN}_busyticks_spa.type DERIVE
-${LUN}_busyticks_spa.min 0
 ${LUN}_busyticks_spa.draw AREA
 ${LUN}_busyticks_spa.graph no
 ${LUN}_bta.label $LUN Busy Ticks SPA
 ${LUN}_bta.graph 0
 ${LUN}_idleticks_spa.label $LUN Idle Ticks SPA
 ${LUN}_idleticks_spa.type DERIVE
-${LUN}_idleticks_spa.min 0
 ${LUN}_idleticks_spa.draw AREA
 ${LUN}_idleticks_spa.graph no
 ${LUN}_busyticks_spb.label $LUN Busy Ticks SPB
 ${LUN}_busyticks_spb.type DERIVE
-${LUN}_busyticks_spb.min 0
 ${LUN}_busyticks_spb.draw AREA
-${LUN}_busyticks_spb.graph 0
+${LUN}_busyticks_spb.graph no
 ${LUN}_btb.label $LUN Busy Ticks SPB
 ${LUN}_btb.graph 0
 ${LUN}_idleticks_spb.label $LUN Idle Ticks SPB
 ${LUN}_idleticks_spb.type DERIVE
-${LUN}_idleticks_spb.min 0
 ${LUN}_idleticks_spb.draw AREA
-${LUN}_idleticks_spb.graph 0"
+${LUN}_idleticks_spb.graph no"
 
 echo "${LUN}_load_spa.label $LUN load SPA 
 ${LUN}_load_spa.draw AREASTACK
@@ -226,11 +222,11 @@ ${LUN}_explic_tr.label ${LUN} Explicit Trespasses"
 graph_category disk
 graph_title EMC VNX 5300 Queue Length
 graph_vlabel Length"
-echo -n "graph_order "
-while read -r LUN ; do
-		echo -n "${LUN}_bta=${LUN}_btspa ${LUN}_btb=${LUN}_btspb "
-	done <<< $LUNLIST
-echo ""
+#echo -n "graph_order "
+#while read -r LUN ; do
+#		echo -n "${LUN}_bta=${LUN}_btspa ${LUN}_btb=${LUN}_btspb "
+#	done <<< $LUNLIST
+#echo ""
 	while read -r LUN ; do
 		echo "${LUN}_btspa.label ${LUN}"
 		echo "${LUN}_btspa.graph no"
@@ -268,8 +264,8 @@ echo ""
 		echo "${LUN}_ql_l_a.label ${LUN} Queue Length SPA"
 #		echo "${LUN}_ql_l.cdef ${LUN}_bta,${LUN}_oss,${LUN}_nzr,2,${LUN}_wr,${LUN}_rr,+,/,-,/,*,${LUN}_btspa,${LUN}_idspa,+,/"
 		echo "${LUN}_ql_l_a.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,${LUN}_btspa,*,${LUN}_btspa,${LUN}_idspa,+,/"
-#		echo "${LUN}_ql_l_b.label ${LUN} Queue Length SPB"
-#		echo "${LUN}_ql_l_b.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,${LUN}_btspb,*,${LUN}_btspb,${LUN}_idspb,+,/"
+		echo "${LUN}_ql_l_b.label ${LUN} Queue Length SPB"
+		echo "${LUN}_ql_l_b.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,${LUN}_btspb,*,${LUN}_btspb,${LUN}_idspb,+,/"
 #		echo "${LUN}_ql_l.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,5000,*"
 	done <<< $LUNLIST
 

--- a/plugins/emc/emc_vnx_block_lun_perfdata
+++ b/plugins/emc/emc_vnx_block_lun_perfdata
@@ -1,0 +1,351 @@
+#!/bin/bash
+
+
+
+# Need bc 
+# Some parts are rudimental..
+# sudo vim ./share/perl5/Munin/Master/GraphOld.pm
+# http://munin-monitoring.org/ticket/1352
+# http://munin-monitoring.org/ticket/1017
+
+######################################################################################################################
+#                  Plugin to monitor basic statistics of EMC VNX 5300 Unified Datamovers                             #
+######################################################################################################################
+
+# Author: Evgeny Beysembaev <megabotva@gmail.com>
+
+#####################################
+#         Description               #
+#####################################
+
+# The plugin monitors basic statistics of EMC Unified Storage system Datamovers. Probably it can also be compatible with 
+# other Isilon or Celerra systems. It uses SSH to connect to Control Stations, then remotely executes 
+# /nas/sbin/server_stats and fetches and parses data from it. It supports gathering data both from active/active 
+# and active/passive Datamover configurations, ignoring offline or standby Datamovers. If all Datamovers are 
+# offline or absent, the plugin returns error.
+# This plugin also automatically chooses Primary Control Station from the list by calling /nasmcd/sbin/getreason and 
+# /nasmcd/sbin/t2slot.
+# 
+# Data is gathered from basic-std Statistics Group
+# 
+# It's quite easy to comment out unneeded data to make graphs less overloaded or to add new statistics sources.
+ 
+#####################################
+#        Configuration              #
+#####################################
+
+# The plugin uses SSH to connect to Control Stations. It's possible to use 'nasadmin' user, but it would be better
+# if you create read-only global user by Unisphere Client. The user should have only Operator role.
+# I created "operator" user but due to the fact that Control Stations already had one internal "operator" user,
+# the new one was called "operator1". So be careful.
+# 
+# On munin-node side choose a user which will be used to connect through SSH. Generally user "munin" is ok. Then,
+# execute "sudo su munin -s /bin/bash", "ssh-keygen" and "ssh-copy-id" to both Control Stations with newly created 
+# user.
+# 
+# Make a link from /usr/share/munin/plugins/emc_vnx_dm_basic_stats to /etc/munin/plugins/emc_vnx_dm_basic_stats_<NAME>,
+# where <NAME> is any arbitrary name of your storage system. The plugin will return <NAME> in its answer 
+# as "host_name" field.
+# Assume your storage system is called "VNX5300".
+# 
+# Make a configuration file at /etc/munin/plugin-conf.d/emc_vnx_dm_basic_stats_VNX5300
+# 
+# [emc_vnx_dm_basic_stats_VNX5300]
+# user munin							# SSH Client local user
+# env.username operator1					# Remote user with Operator role
+# env.cs_addr 192.168.1.1 192.168.1.2				# Control Stations addresses
+# env.nas_servers server_2 server_3				# This is the default value and can be omitted
+
+#####################################
+#           History                 #
+#####################################
+
+# 09.11.2016 - First Release
+
+######################################################################################################################
+
+export LANG=C
+TARGET=$(echo "${0##*/}" | cut -d _ -f 6)
+#: ${nas_servers:="server_2 server_3"}
+SSH_CHECK='ssh -q $username@$CS "/nasmcd/sbin/getreason | grep -w slot_\`/nasmcd/sbin/t2slot\` | cut -d- -f1"'
+
+if [ "$1" = "autoconf" ]; then
+	echo "yes"
+	exit 0
+fi
+
+if [ -z "$username" ]; then
+	echo "No username!"
+	exit 1
+fi
+
+if [ -z "$cs_addr" ]; then
+	echo "No control station addresses!"
+	exit 1
+fi
+
+#Choosing Cotrol Station. Code have to be "10"
+for CS in $cs_addr; do
+	if [ "`eval $SSH_CHECK`" -eq "10" ]; then
+#		echo "$CS is Primary"
+		PRIMARY_CS=$CS
+		break
+	fi
+done
+
+if [ -z "$PRIMARY_CS" ]; then
+	echo "No alive primary Control Station from list \"$cs_addr\"";
+	exit 1;
+fi
+
+SP="SPA" #TODO
+SPALL="SPA SPB" #TODO
+SSH="ssh -q $username@$PRIMARY_CS "
+NAVICLI="/nas/sbin/navicli -h $SP"
+
+# Get Lun List
+LUNLIST="$($SSH $NAVICLI lun -list -drivetype | grep Name | sed -ne 's/^Name:\ *//p')"
+
+echo "host_name ${TARGET}
+"
+
+if [ "$1" = "config" ] ; then
+
+	echo "multigraph emc_vnx_block_blocks
+graph_category disk
+graph_title EMC VNX 5300 LUN Blocks
+graph_vlabel Blocks Read (-) / Written (+)
+graph_args --base 1000"
+	while read -r LUN ; do
+		echo "${LUN}_read.label none
+${LUN}_read.graph no
+${LUN}_read.min 0
+${LUN}_read.draw AREA
+${LUN}_read.type DERIVE
+${LUN}_write.label $LUN Blocks
+${LUN}_write.negative ${LUN}_read
+${LUN}_write.type DERIVE
+${LUN}_write.min 0
+${LUN}_write.draw STACK"
+	done <<< $LUNLIST
+
+	echo -e "\nmultigraph emc_vnx_block_req
+graph_category disk
+graph_title EMC VNX 5300 LUN Requests
+graph_vlabel Requests: Read (-) / Write (+)
+graph_args --base 1000"
+	while read -r LUN ; do
+		echo "${LUN}_readreq.label none
+${LUN}_readreq.graph no
+${LUN}_readreq.min 0
+${LUN}_readreq.type DERIVE
+${LUN}_writereq.label $LUN Requests
+${LUN}_writereq.negative ${LUN}_readreq
+${LUN}_writereq.type DERIVE
+${LUN}_writereq.min 0"
+	done <<< $LUNLIST
+
+	echo -e "\nmultigraph emc_vnx_block_ticks
+graph_category disk
+graph_title EMC VNX 5300 Counted Load per LUN
+graph_vlabel Load, % * Number of LUNs 
+graph_args --base 1000 -l 0 -r "
+echo -n "graph_order "
+	while read -r LUN ; do
+                echo -n "${LUN}_busyticks ${LUN}_idleticks ${LUN}_bta=${LUN}_busyticks_spa ${LUN}_idleticks_spa ${LUN}_btb=${LUN}_busyticks_spb ${LUN}_idleticks_spb "
+	done <<< $LUNLIST
+	echo ""
+	while read -r LUN ; do
+		echo "${LUN}_busyticks_spa.label $LUN Busy Ticks SPA
+${LUN}_busyticks_spa.type DERIVE
+${LUN}_busyticks_spa.min 0
+${LUN}_busyticks_spa.draw AREA
+${LUN}_busyticks_spa.graph no
+${LUN}_bta.label $LUN Busy Ticks SPA
+${LUN}_bta.graph 0
+${LUN}_idleticks_spa.label $LUN Idle Ticks SPA
+${LUN}_idleticks_spa.type DERIVE
+${LUN}_idleticks_spa.min 0
+${LUN}_idleticks_spa.draw AREA
+${LUN}_idleticks_spa.graph no
+${LUN}_busyticks_spb.label $LUN Busy Ticks SPB
+${LUN}_busyticks_spb.type DERIVE
+${LUN}_busyticks_spb.min 0
+${LUN}_busyticks_spb.draw AREA
+${LUN}_busyticks_spb.graph 0
+${LUN}_btb.label $LUN Busy Ticks SPB
+${LUN}_btb.graph 0
+${LUN}_idleticks_spb.label $LUN Idle Ticks SPB
+${LUN}_idleticks_spb.type DERIVE
+${LUN}_idleticks_spb.min 0
+${LUN}_idleticks_spb.draw AREA
+${LUN}_idleticks_spb.graph 0"
+
+echo "${LUN}_load_spa.label $LUN load SPA 
+${LUN}_load_spa.draw AREASTACK
+${LUN}_load_spb.label $LUN load SPB
+${LUN}_load_spb.draw AREASTACK
+${LUN}_load_spa.cdef 100,${LUN}_bta,${LUN}_busyticks_spa,${LUN}_idleticks_spa,+,/,*
+${LUN}_load_spb.cdef 100,${LUN}_btb,${LUN}_busyticks_spa,${LUN}_idleticks_spa,+,/,*
+"
+	done <<< $LUNLIST
+
+	echo -e "\nmultigraph emc_vnx_block_outstanding
+graph_category disk
+graph_title EMC VNX 5300 Sum of Outstanding Requests
+graph_vlabel Requests
+graph_args --base 1000"
+	while read -r LUN ; do
+		echo "${LUN}_outstandsum.label $LUN
+${LUN}_outstandsum.type DERIVE"
+	done <<< $LUNLIST
+
+	echo -e "\nmultigraph emc_vnx_block_nonzeroreq
+graph_category disk
+graph_title EMC VNX 5300 Non-Zero Request Count Arrivals
+graph_vlabel Count Arrivals
+graph_args --base 1000"
+	while read -r LUN ; do
+		echo "${LUN}_nonzeroreq.label $LUN
+${LUN}_nonzeroreq.type DERIVE"
+	done <<< $LUNLIST
+
+	echo -e "\nmultigraph emc_vnx_block_trespasses
+graph_category disk
+graph_title EMC VNX 5300 Trespasses
+graph_vlabel Trespasses"
+	while read -r LUN ; do
+		echo "${LUN}_implic_tr.label ${LUN} Implicit Trespasses
+${LUN}_explic_tr.label ${LUN} Explicit Trespasses"
+	done <<< $LUNLIST
+
+
+
+
+	echo -e "\nmultigraph emc_vnx_block_queue
+graph_category disk
+graph_title EMC VNX 5300 Queue Length
+graph_vlabel Length"
+echo -n "graph_order "
+while read -r LUN ; do
+		echo -n "${LUN}_bta=${LUN}_btspa ${LUN}_btb=${LUN}_btspb "
+	done <<< $LUNLIST
+echo ""
+	while read -r LUN ; do
+		echo "${LUN}_btspa.label ${LUN}"
+		echo "${LUN}_btspa.graph no"
+		echo "${LUN}_btspa.type DERIVE"
+#		echo "${LUN}_bta.label ${LUN}"
+#		echo "${LUN}_bta.graph no"
+#		echo "${LUN}_bta.type DERIVE"
+		echo "${LUN}_idspa.label ${LUN}"
+		echo "${LUN}_idspa.graph no"
+		echo "${LUN}_idspa.type DERIVE"
+		echo "${LUN}_btspb.label ${LUN}"
+		echo "${LUN}_btspb.graph no"
+		echo "${LUN}_btspb.type DERIVE"
+#		echo "${LUN}_btb.label ${LUN}"
+#		echo "${LUN}_btb.graph no"
+#		echo "${LUN}_btb.type DERIVE"
+		echo "${LUN}_idspb.label ${LUN}"
+		echo "${LUN}_idspb.graph no"
+		echo "${LUN}_idspb.type DERIVE"
+		echo "${LUN}_oss.label ${LUN}"
+		echo "${LUN}_oss.graph no"
+		echo "${LUN}_oss.type DERIVE"
+		echo "${LUN}_nzr.label ${LUN}"
+		echo "${LUN}_nzr.graph no"
+		echo "${LUN}_nzr.type DERIVE"
+		echo "${LUN}_rr.label ${LUN}"
+		echo "${LUN}_rr.graph no"
+		echo "${LUN}_rr.type DERIVE"
+		echo "${LUN}_wr.label ${LUN}"
+		echo "${LUN}_wr.graph no"
+		echo "${LUN}_wr.type DERIVE"
+#		echo "${LUN}_w_p_r.label ${LUN}"
+#		echo "${LUN}_w_p_r.graph no"
+#		echo "${LUN}_w_p_r.cdef ${LUN}_writereq,${LUN}_readreq,+"
+		echo "${LUN}_ql_l_a.label ${LUN} Queue Length SPA"
+#		echo "${LUN}_ql_l.cdef ${LUN}_bta,${LUN}_oss,${LUN}_nzr,2,${LUN}_wr,${LUN}_rr,+,/,-,/,*,${LUN}_btspa,${LUN}_idspa,+,/"
+		echo "${LUN}_ql_l_a.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,${LUN}_btspa,*,${LUN}_btspa,${LUN}_idspa,+,/"
+#		echo "${LUN}_ql_l_b.label ${LUN} Queue Length SPB"
+#		echo "${LUN}_ql_l_b.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,${LUN}_btspb,*,${LUN}_btspb,${LUN}_idspb,+,/"
+#		echo "${LUN}_ql_l.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,5000,*"
+	done <<< $LUNLIST
+
+
+
+exit 0
+fi
+# -list -perfData
+BIGSSHCMD="$SSH"
+while read -r LUN ; do
+	BIGSSHCMD+="$NAVICLI lun -list -name $LUN -perfData | 
+		sed -ne 's/^Blocks Read\:\ */${LUN}_read.value /p; 
+		s/^Blocks Written\:\ */${LUN}_write.value /p;
+		s/Read Requests\:\ */${LUN}_readreq.value /p;
+		s/Write Requests\:\ */${LUN}_writereq.value /p;
+		s/Busy Ticks SP A\:\ */${LUN}_busyticks_spa.value /p;
+		s/Idle Ticks SP A\:\ */${LUN}_idleticks_spa.value /p;
+		s/Busy Ticks SP B\:\ */${LUN}_busyticks_spb.value /p;
+		s/Idle Ticks SP B\:\ */${LUN}_idleticks_spb.value /p;
+		s/Sum of Outstanding Requests\:\ */${LUN}_outstandsum.value /p;
+		s/Non-Zero Request Count Arrivals\:\ */${LUN}_nonzeroreq.value /p;
+		s/Implicit Trespasses\:\ */${LUN}_implic_tr.value /p;
+		s/Explicit Trespasses\:\ */${LUN}_explic_tr.value /p;
+		' ;"
+done <<< $LUNLIST
+ANSWER="$($BIGSSHCMD)"
+echo "multigraph emc_vnx_block_blocks"
+echo "$ANSWER" | grep "read\.\|write\."
+echo -e "\nmultigraph emc_vnx_block_req"
+echo "$ANSWER" | grep "readreq\.\|writereq\."
+
+echo -e "\nmultigraph emc_vnx_block_ticks"
+while read -r LUN ; do
+	LBTSPA=$(echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spa\.value //p")
+	LIDSPA=$(echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spa\.value //p")
+	LBTSPB=$(echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spb\.value //p")
+	LIDSPB=$(echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spb\.value //p")
+#	echo "${LUN}_load_spa.value" "$(( $LBTSPA*100 / ($LBTSPA+$LIDSPA) ))"
+#	echo "${LUN}_load_spb.value" "$(( $LBTSPB*100 / ($LBTSPB+$LIDSPB) ))"
+	echo "${LUN}_load_spa.value 0"
+	echo "${LUN}_load_spb.value 0"
+done <<< $LUNLIST
+echo "$ANSWER" | grep "busyticks_spa\.\|idleticks_spa\."
+echo "$ANSWER" | grep "busyticks_spb\.\|idleticks_spb\."
+
+echo -e "\nmultigraph emc_vnx_block_outstanding"
+echo "$ANSWER" | grep "outstandsum\."
+echo -e "\nmultigraph emc_vnx_block_nonzeroreq"
+echo "$ANSWER" | grep "nonzeroreq\."
+echo -e "\nmultigraph emc_vnx_block_trespasses"
+echo "$ANSWER" | grep "implic_tr\.\|explic_tr\."
+
+echo -e "\nmultigraph emc_vnx_block_queue"
+# Queue Length
+while read -r LUN ; do
+# Queue Length SPA = ((Sum of Outstanding Requests SPA - NonZero Request Count Arrivals SPA / 2)/(Host Read Requests SPA + Host Write Requests SPA))*
+# (Busy Ticks SPA/(Busy Ticks SPA + Idle Ticks SPA)
+
+# We count together SPA and SPB, although it is not fully corrext
+
+	SOR=$(echo "$ANSWER" | sed -ne "s/^${LUN}_outstandsum\.value //p")
+	NZRCA=$(echo "$ANSWER" | sed -ne "s/^${LUN}_nonzeroreq\.value //p")
+	RR=$(echo "$ANSWER" | sed -ne "s/^${LUN}_readreq\.value //p")
+	WR=$(echo "$ANSWER" | sed -ne "s/^${LUN}_writereq\.value //p")
+	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spa\./${LUN}_btspa\./p"
+	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spa\./${LUN}_idspa\./p"
+	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spb\./${LUN}_btspb\./p"
+	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spb\./${LUN}_idspb\./p"
+	echo "$ANSWER" | grep "${LUN}_busyticks_spa\.\|${LUN}_idleticks_spa\."
+	echo "$ANSWER" | grep "${LUN}_busyticks_spb\.\|${LUN}_idleticks_spb\."
+	echo "$ANSWER" | sed -ne "s/^${LUN}_outstandsum\./${LUN}_oss\./p"
+	echo "$ANSWER" | sed -ne "s/^${LUN}_nonzeroreq\./${LUN}_nzr\./p"
+	echo "${LUN}_writereq_plus_readreq.value 0"
+	echo "$ANSWER" | sed -ne "s/^${LUN}_readreq\./${LUN}_rr\./p"
+	echo "$ANSWER" | sed -ne "s/^${LUN}_writereq\./${LUN}_wr\./p"
+	echo "${LUN}_ql_l_a.value 0 "
+	echo "${LUN}_ql_l_b.value 0 "
+done <<< $LUNLIST
+exit 0

--- a/plugins/emc/emc_vnx_block_lun_perfdata
+++ b/plugins/emc/emc_vnx_block_lun_perfdata
@@ -1,13 +1,4 @@
 #!/bin/bash
-
-
-
-# Need bc 
-# Some parts are rudimental..
-# sudo vim ./share/perl5/Munin/Master/GraphOld.pm
-# http://munin-monitoring.org/ticket/1352
-# http://munin-monitoring.org/ticket/1017
-
 ######################################################################################################################
 #                  Plugin to monitor basic statistics of EMC VNX 5300 Unified Datamovers                             #
 ######################################################################################################################
@@ -18,21 +9,34 @@
 #         Description               #
 #####################################
 
-# The plugin monitors basic statistics of EMC Unified Storage system Datamovers. Probably it can also be compatible with 
-# other Isilon or Celerra systems. It uses SSH to connect to Control Stations, then remotely executes 
-# /nas/sbin/server_stats and fetches and parses data from it. It supports gathering data both from active/active 
-# and active/passive Datamover configurations, ignoring offline or standby Datamovers. If all Datamovers are 
-# offline or absent, the plugin returns error.
+# The plugin monitors LUN of EMC Unified Storage FLARE SP's. Probably it can also be compatible with 
+# other Clariion systems. It uses SSH to connect to Control Stations, then remotely executes 
+# /nas/sbin/navicli and fetches and parses data from it. Obviously, it's easy to reconfigure plugin not to use 
+# Control Stations' navicli in favor of using locally installed /opt/Navisphere's cli. There is no difference which
+# Storage Processor to use to gather data, so this plugin tries both of them and uses the first active one.
 # This plugin also automatically chooses Primary Control Station from the list by calling /nasmcd/sbin/getreason and 
 # /nasmcd/sbin/t2slot.
 # 
-# Data is gathered from basic-std Statistics Group
-# 
-# It's quite easy to comment out unneeded data to make graphs less overloaded or to add new statistics sources.
+# I left some parts of this plugin as rudimental to make easy to reconfigure it to draw more (or less) data.
  
 #####################################
 #        Configuration              #
 #####################################
+
+######### Prerequisites #########
+
+# First of all, be sure that statistics collection is turned on. You can do this by typing:
+# navicli -h spa setstats -on
+# on your Control Station or locally through /opt/Navisphere 
+
+# Also, the plugin actively uses buggy "cdef" feature of Munin, and here we can be hit by the following bugs:
+# http://munin-monitoring.org/ticket/1017 - Here I have some workarounds in plugin, be sure that they are working.
+# http://munin-monitoring.org/ticket/1352 - 
+# Metrics in my plugin can be much longer than 15 characters, so you have to edit the following file:
+# /usr/share/perl5/Munin/Master/GraphOld.pm
+# Find get_field_name() function and change "15" to "255".
+
+######### Installation #########
 
 # The plugin uses SSH to connect to Control Stations. It's possible to use 'nasadmin' user, but it would be better
 # if you create read-only global user by Unisphere Client. The user should have only Operator role.
@@ -48,13 +52,19 @@
 # as "host_name" field.
 # Assume your storage system is called "VNX5300".
 # 
-# Make a configuration file at /etc/munin/plugin-conf.d/emc_vnx_dm_basic_stats_VNX5300
+# Make a configuration file at /etc/munin/plugin-conf.d/emc_vnx_block_lun_perfdata_VNX5300
 # 
-# [emc_vnx_dm_basic_stats_VNX5300]
+# [emc_vnx_block_lun_perfdata_VNX5300]
 # user munin							# SSH Client local user
 # env.username operator1					# Remote user with Operator role
 # env.cs_addr 192.168.1.1 192.168.1.2				# Control Stations addresses
-# env.nas_servers server_2 server_3				# This is the default value and can be omitted
+
+#####################################
+#           Errata                  #
+#####################################
+# It counts Queue Length in not fully correct way. We take parameters totally from both SP's, but after we divide them
+# independently by load of SPA and SPB. Anyway, in most AAA / ALUA cases the formula is correct.
+
 
 #####################################
 #           History                 #
@@ -66,7 +76,8 @@
 
 export LANG=C
 TARGET=$(echo "${0##*/}" | cut -d _ -f 6)
-#: ${nas_servers:="server_2 server_3"}
+SPALL="SPA SPB"
+NAVICLI="/nas/sbin/navicli"
 SSH_CHECK='ssh -q $username@$CS "/nasmcd/sbin/getreason | grep -w slot_\`/nasmcd/sbin/t2slot\` | cut -d- -f1"'
 
 if [ "$1" = "autoconf" ]; then
@@ -86,7 +97,7 @@ fi
 
 #Choosing Cotrol Station. Code have to be "10"
 for CS in $cs_addr; do
-	if [ "`eval $SSH_CHECK`" -eq "10" ]; then
+	if [ "$(eval $SSH_CHECK)" -eq "10" ]; then
 #		echo "$CS is Primary"
 		PRIMARY_CS=$CS
 		break
@@ -98,19 +109,24 @@ if [ -z "$PRIMARY_CS" ]; then
 	exit 1;
 fi
 
-SP="SPA" #TODO
-SPALL="SPA SPB" #TODO
 SSH="ssh -q $username@$PRIMARY_CS "
+for PROBESP in $SPALL; do
+	$SSH $NAVICLI -h $PROBESP  > /dev/null 2>&1
+	if [ 0 == "$?" ]; then SP="$PROBESP"; break; fi
+done
+
+if [ -z "$SP" ]; then
+	echo "No active Storage Processor found!";
+	exit 1;
+fi
 NAVICLI="/nas/sbin/navicli -h $SP"
 
 # Get Lun List
 LUNLIST="$($SSH $NAVICLI lun -list -drivetype | grep Name | sed -ne 's/^Name:\ *//p')"
 
-echo "host_name ${TARGET}
-"
+echo -e "host_name ${TARGET}\n"
 
 if [ "$1" = "config" ] ; then
-
 	echo "multigraph emc_vnx_block_blocks
 graph_category disk
 graph_title EMC VNX 5300 LUN Blocks
@@ -158,23 +174,19 @@ echo -n "graph_order "
 	while read -r LUN ; do
 		echo "${LUN}_busyticks_spa.label $LUN Busy Ticks SPA
 ${LUN}_busyticks_spa.type DERIVE
-${LUN}_busyticks_spa.draw AREA
 ${LUN}_busyticks_spa.graph no
 ${LUN}_bta.label $LUN Busy Ticks SPA
-${LUN}_bta.graph 0
+${LUN}_bta.graph no
 ${LUN}_idleticks_spa.label $LUN Idle Ticks SPA
 ${LUN}_idleticks_spa.type DERIVE
-${LUN}_idleticks_spa.draw AREA
 ${LUN}_idleticks_spa.graph no
 ${LUN}_busyticks_spb.label $LUN Busy Ticks SPB
 ${LUN}_busyticks_spb.type DERIVE
-${LUN}_busyticks_spb.draw AREA
 ${LUN}_busyticks_spb.graph no
 ${LUN}_btb.label $LUN Busy Ticks SPB
-${LUN}_btb.graph 0
+${LUN}_btb.graph no
 ${LUN}_idleticks_spb.label $LUN Idle Ticks SPB
 ${LUN}_idleticks_spb.type DERIVE
-${LUN}_idleticks_spb.draw AREA
 ${LUN}_idleticks_spb.graph no"
 
 echo "${LUN}_load_spa.label $LUN load SPA 
@@ -215,65 +227,45 @@ graph_vlabel Trespasses"
 ${LUN}_explic_tr.label ${LUN} Explicit Trespasses"
 	done <<< $LUNLIST
 
-
-
-
 	echo -e "\nmultigraph emc_vnx_block_queue
 graph_category disk
 graph_title EMC VNX 5300 Queue Length
 graph_vlabel Length"
-#echo -n "graph_order "
-#while read -r LUN ; do
-#		echo -n "${LUN}_bta=${LUN}_btspa ${LUN}_btb=${LUN}_btspb "
-#	done <<< $LUNLIST
-#echo ""
 	while read -r LUN ; do
-		echo "${LUN}_btspa.label ${LUN}"
-		echo "${LUN}_btspa.graph no"
-		echo "${LUN}_btspa.type DERIVE"
-#		echo "${LUN}_bta.label ${LUN}"
-#		echo "${LUN}_bta.graph no"
-#		echo "${LUN}_bta.type DERIVE"
-		echo "${LUN}_idspa.label ${LUN}"
-		echo "${LUN}_idspa.graph no"
-		echo "${LUN}_idspa.type DERIVE"
-		echo "${LUN}_btspb.label ${LUN}"
-		echo "${LUN}_btspb.graph no"
-		echo "${LUN}_btspb.type DERIVE"
-#		echo "${LUN}_btb.label ${LUN}"
-#		echo "${LUN}_btb.graph no"
-#		echo "${LUN}_btb.type DERIVE"
-		echo "${LUN}_idspb.label ${LUN}"
-		echo "${LUN}_idspb.graph no"
-		echo "${LUN}_idspb.type DERIVE"
-		echo "${LUN}_oss.label ${LUN}"
-		echo "${LUN}_oss.graph no"
-		echo "${LUN}_oss.type DERIVE"
-		echo "${LUN}_nzr.label ${LUN}"
-		echo "${LUN}_nzr.graph no"
-		echo "${LUN}_nzr.type DERIVE"
-		echo "${LUN}_rr.label ${LUN}"
-		echo "${LUN}_rr.graph no"
-		echo "${LUN}_rr.type DERIVE"
-		echo "${LUN}_wr.label ${LUN}"
-		echo "${LUN}_wr.graph no"
-		echo "${LUN}_wr.type DERIVE"
-#		echo "${LUN}_w_p_r.label ${LUN}"
-#		echo "${LUN}_w_p_r.graph no"
-#		echo "${LUN}_w_p_r.cdef ${LUN}_writereq,${LUN}_readreq,+"
+		echo "${LUN}_busyticks_spa.label ${LUN}"
+		echo "${LUN}_busyticks_spa.graph no"
+		echo "${LUN}_busyticks_spa.type DERIVE"
+		echo "${LUN}_idleticks_spa.label ${LUN}"
+		echo "${LUN}_idleticks_spa.graph no"
+		echo "${LUN}_idleticks_spa.type DERIVE"
+		echo "${LUN}_busyticks_spb.label ${LUN}"
+		echo "${LUN}_busyticks_spb.graph no"
+		echo "${LUN}_busyticks_spb.type DERIVE"
+		echo "${LUN}_idleticks_spb.label ${LUN}"
+		echo "${LUN}_idleticks_spb.graph no"
+		echo "${LUN}_idleticks_spb.type DERIVE"
+		echo "${LUN}_outstandsum.label ${LUN}"
+		echo "${LUN}_outstandsum.graph no"
+		echo "${LUN}_outstandsum.type DERIVE"
+		echo "${LUN}_nonzeroreq.label ${LUN}"
+		echo "${LUN}_nonzeroreq.graph no"
+		echo "${LUN}_nonzeroreq.type DERIVE"
+		echo "${LUN}_readreq.label ${LUN}"
+		echo "${LUN}_readreq.graph no"
+		echo "${LUN}_readreq.type DERIVE"
+		echo "${LUN}_writereq.label ${LUN}"
+		echo "${LUN}_writereq.graph no"
+		echo "${LUN}_writereq.type DERIVE"
 		echo "${LUN}_ql_l_a.label ${LUN} Queue Length SPA"
-#		echo "${LUN}_ql_l.cdef ${LUN}_bta,${LUN}_oss,${LUN}_nzr,2,${LUN}_wr,${LUN}_rr,+,/,-,/,*,${LUN}_btspa,${LUN}_idspa,+,/"
-		echo "${LUN}_ql_l_a.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,${LUN}_btspa,*,${LUN}_btspa,${LUN}_idspa,+,/"
+		echo "${LUN}_ql_l_a.cdef ${LUN}_outstandsum,${LUN}_nonzeroreq,2,/,-,${LUN}_readreq,${LUN}_writereq,+,/,${LUN}_busyticks_spa,*,${LUN}_busyticks_spa,${LUN}_idleticks_spa,+,/"
 		echo "${LUN}_ql_l_b.label ${LUN} Queue Length SPB"
-		echo "${LUN}_ql_l_b.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,${LUN}_btspb,*,${LUN}_btspb,${LUN}_idspb,+,/"
-#		echo "${LUN}_ql_l.cdef ${LUN}_oss,${LUN}_nzr,2,/,-,${LUN}_rr,${LUN}_wr,+,/,5000,*"
+		echo "${LUN}_ql_l_b.cdef ${LUN}_outstandsum,${LUN}_nonzeroreq,2,/,-,${LUN}_readreq,${LUN}_writereq,+,/,${LUN}_busyticks_spb,*,${LUN}_busyticks_spb,${LUN}_idleticks_spb,+,/"
 	done <<< $LUNLIST
 
 
 
 exit 0
 fi
-# -list -perfData
 BIGSSHCMD="$SSH"
 while read -r LUN ; do
 	BIGSSHCMD+="$NAVICLI lun -list -name $LUN -perfData | 
@@ -299,12 +291,6 @@ echo "$ANSWER" | grep "readreq\.\|writereq\."
 
 echo -e "\nmultigraph emc_vnx_block_ticks"
 while read -r LUN ; do
-	LBTSPA=$(echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spa\.value //p")
-	LIDSPA=$(echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spa\.value //p")
-	LBTSPB=$(echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spb\.value //p")
-	LIDSPB=$(echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spb\.value //p")
-#	echo "${LUN}_load_spa.value" "$(( $LBTSPA*100 / ($LBTSPA+$LIDSPA) ))"
-#	echo "${LUN}_load_spb.value" "$(( $LBTSPB*100 / ($LBTSPB+$LIDSPB) ))"
 	echo "${LUN}_load_spa.value 0"
 	echo "${LUN}_load_spb.value 0"
 done <<< $LUNLIST
@@ -313,8 +299,10 @@ echo "$ANSWER" | grep "busyticks_spb\.\|idleticks_spb\."
 
 echo -e "\nmultigraph emc_vnx_block_outstanding"
 echo "$ANSWER" | grep "outstandsum\."
+
 echo -e "\nmultigraph emc_vnx_block_nonzeroreq"
 echo "$ANSWER" | grep "nonzeroreq\."
+
 echo -e "\nmultigraph emc_vnx_block_trespasses"
 echo "$ANSWER" | grep "implic_tr\.\|explic_tr\."
 
@@ -326,21 +314,22 @@ while read -r LUN ; do
 
 # We count together SPA and SPB, although it is not fully corrext
 
-	SOR=$(echo "$ANSWER" | sed -ne "s/^${LUN}_outstandsum\.value //p")
-	NZRCA=$(echo "$ANSWER" | sed -ne "s/^${LUN}_nonzeroreq\.value //p")
-	RR=$(echo "$ANSWER" | sed -ne "s/^${LUN}_readreq\.value //p")
-	WR=$(echo "$ANSWER" | sed -ne "s/^${LUN}_writereq\.value //p")
-	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spa\./${LUN}_btspa\./p"
-	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spa\./${LUN}_idspa\./p"
-	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spb\./${LUN}_btspb\./p"
-	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spb\./${LUN}_idspb\./p"
-	echo "$ANSWER" | grep "${LUN}_busyticks_spa\.\|${LUN}_idleticks_spa\."
-	echo "$ANSWER" | grep "${LUN}_busyticks_spb\.\|${LUN}_idleticks_spb\."
-	echo "$ANSWER" | sed -ne "s/^${LUN}_outstandsum\./${LUN}_oss\./p"
-	echo "$ANSWER" | sed -ne "s/^${LUN}_nonzeroreq\./${LUN}_nzr\./p"
-	echo "${LUN}_writereq_plus_readreq.value 0"
-	echo "$ANSWER" | sed -ne "s/^${LUN}_readreq\./${LUN}_rr\./p"
-	echo "$ANSWER" | sed -ne "s/^${LUN}_writereq\./${LUN}_wr\./p"
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spa\./${LUN}_btspa\./p"
+	echo "$ANSWER" | grep "${LUN}_busyticks"
+	echo "$ANSWER" | grep "${LUN}_idleticks"
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spa\./${LUN}_idspa\./p"
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spb\./${LUN}_btspb\./p"
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spb\./${LUN}_idspb\./p"
+#	echo "$ANSWER" | grep "${LUN}_busyticks_spa\.\|${LUN}_idleticks_spa\."
+#	echo "$ANSWER" | grep "${LUN}_busyticks_spb\.\|${LUN}_idleticks_spb\."
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_outstandsum\./${LUN}_oss\./p"
+	echo "$ANSWER" | grep "${LUN}_outstandsum"
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_nonzeroreq\./${LUN}_nzr\./p"
+	echo "$ANSWER" | grep "${LUN}_nonzeroreq"
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_readreq\./${LUN}_rr\./p"
+	echo "$ANSWER" | grep "${LUN}_readreq"
+#	echo "$ANSWER" | sed -ne "s/^${LUN}_writereq\./${LUN}_wr\./p"
+	echo "$ANSWER" | grep "${LUN}_writereq"
 	echo "${LUN}_ql_l_a.value 0 "
 	echo "${LUN}_ql_l_b.value 0 "
 done <<< $LUNLIST

--- a/plugins/emc/emc_vnx_block_lun_perfdata
+++ b/plugins/emc/emc_vnx_block_lun_perfdata
@@ -229,41 +229,41 @@ ${LUN}_explic_tr.label ${LUN} Explicit Trespasses"
 
 	echo -e "\nmultigraph emc_vnx_block_queue
 graph_category disk
-graph_title EMC VNX 5300 Queue Length
+graph_title EMC VNX 5300 Counted Block Queue Length
 graph_vlabel Length"
 	while read -r LUN ; do
-		echo "${LUN}_busyticks_spa.label ${LUN}"
-		echo "${LUN}_busyticks_spa.graph no"
-		echo "${LUN}_busyticks_spa.type DERIVE"
-		echo "${LUN}_idleticks_spa.label ${LUN}"
-		echo "${LUN}_idleticks_spa.graph no"
-		echo "${LUN}_idleticks_spa.type DERIVE"
-		echo "${LUN}_busyticks_spb.label ${LUN}"
-		echo "${LUN}_busyticks_spb.graph no"
-		echo "${LUN}_busyticks_spb.type DERIVE"
-		echo "${LUN}_idleticks_spb.label ${LUN}"
-		echo "${LUN}_idleticks_spb.graph no"
-		echo "${LUN}_idleticks_spb.type DERIVE"
-		echo "${LUN}_outstandsum.label ${LUN}"
-		echo "${LUN}_outstandsum.graph no"
-		echo "${LUN}_outstandsum.type DERIVE"
-		echo "${LUN}_nonzeroreq.label ${LUN}"
-		echo "${LUN}_nonzeroreq.graph no"
-		echo "${LUN}_nonzeroreq.type DERIVE"
-		echo "${LUN}_readreq.label ${LUN}"
-		echo "${LUN}_readreq.graph no"
-		echo "${LUN}_readreq.type DERIVE"
-		echo "${LUN}_writereq.label ${LUN}"
-		echo "${LUN}_writereq.graph no"
-		echo "${LUN}_writereq.type DERIVE"
-		echo "${LUN}_ql_l_a.label ${LUN} Queue Length SPA"
-		echo "${LUN}_ql_l_a.cdef ${LUN}_outstandsum,${LUN}_nonzeroreq,2,/,-,${LUN}_readreq,${LUN}_writereq,+,/,${LUN}_busyticks_spa,*,${LUN}_busyticks_spa,${LUN}_idleticks_spa,+,/"
-		echo "${LUN}_ql_l_b.label ${LUN} Queue Length SPB"
-		echo "${LUN}_ql_l_b.cdef ${LUN}_outstandsum,${LUN}_nonzeroreq,2,/,-,${LUN}_readreq,${LUN}_writereq,+,/,${LUN}_busyticks_spb,*,${LUN}_busyticks_spb,${LUN}_idleticks_spb,+,/"
+		echo "${LUN}_busyticks_spa.label ${LUN}
+${LUN}_busyticks_spa.graph no
+${LUN}_busyticks_spa.type DERIVE
+${LUN}_idleticks_spa.label ${LUN}
+${LUN}_idleticks_spa.graph no
+${LUN}_idleticks_spa.type DERIVE
+${LUN}_busyticks_spb.label ${LUN}
+${LUN}_busyticks_spb.graph no
+${LUN}_busyticks_spb.type DERIVE
+${LUN}_idleticks_spb.label ${LUN}
+${LUN}_idleticks_spb.graph no
+${LUN}_idleticks_spb.type DERIVE
+${LUN}_outstandsum.label ${LUN}
+${LUN}_outstandsum.graph no
+${LUN}_outstandsum.type DERIVE
+${LUN}_nonzeroreq.label ${LUN}
+${LUN}_nonzeroreq.graph no
+${LUN}_nonzeroreq.type DERIVE
+${LUN}_readreq.label ${LUN}
+${LUN}_readreq.graph no
+${LUN}_readreq.type DERIVE
+${LUN}_writereq.label ${LUN}
+${LUN}_writereq.graph no
+${LUN}_writereq.type DERIVE"
+# Queue Length SPA = ((Sum of Outstanding Requests SPA - NonZero Request Count Arrivals SPA / 2)/(Host Read Requests SPA + Host Write Requests SPA))*
+# (Busy Ticks SPA/(Busy Ticks SPA + Idle Ticks SPA)
+# We count together SPA and SPB, although it is not fully corrext
+		echo "${LUN}_ql_l_a.label ${LUN} Queue Length SPA
+${LUN}_ql_l_a.cdef ${LUN}_outstandsum,${LUN}_nonzeroreq,2,/,-,${LUN}_readreq,${LUN}_writereq,+,/,${LUN}_busyticks_spa,*,${LUN}_busyticks_spa,${LUN}_idleticks_spa,+,/
+${LUN}_ql_l_b.label ${LUN} Queue Length SPB
+${LUN}_ql_l_b.cdef ${LUN}_outstandsum,${LUN}_nonzeroreq,2,/,-,${LUN}_readreq,${LUN}_writereq,+,/,${LUN}_busyticks_spb,*,${LUN}_busyticks_spb,${LUN}_idleticks_spb,+,/"
 	done <<< $LUNLIST
-
-
-
 exit 0
 fi
 BIGSSHCMD="$SSH"
@@ -308,28 +308,13 @@ echo "$ANSWER" | grep "implic_tr\.\|explic_tr\."
 
 echo -e "\nmultigraph emc_vnx_block_queue"
 # Queue Length
+	echo "$ANSWER" | grep "busyticks"
+	echo "$ANSWER" | grep "idleticks."
+	echo "$ANSWER" | grep "outstandsum\."
+	echo "$ANSWER" | grep "nonzeroreq\."
+	echo "$ANSWER" | grep "readreq\."
+	echo "$ANSWER" | grep "writereq\."
 while read -r LUN ; do
-# Queue Length SPA = ((Sum of Outstanding Requests SPA - NonZero Request Count Arrivals SPA / 2)/(Host Read Requests SPA + Host Write Requests SPA))*
-# (Busy Ticks SPA/(Busy Ticks SPA + Idle Ticks SPA)
-
-# We count together SPA and SPB, although it is not fully corrext
-
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spa\./${LUN}_btspa\./p"
-	echo "$ANSWER" | grep "${LUN}_busyticks"
-	echo "$ANSWER" | grep "${LUN}_idleticks"
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spa\./${LUN}_idspa\./p"
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_busyticks_spb\./${LUN}_btspb\./p"
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_idleticks_spb\./${LUN}_idspb\./p"
-#	echo "$ANSWER" | grep "${LUN}_busyticks_spa\.\|${LUN}_idleticks_spa\."
-#	echo "$ANSWER" | grep "${LUN}_busyticks_spb\.\|${LUN}_idleticks_spb\."
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_outstandsum\./${LUN}_oss\./p"
-	echo "$ANSWER" | grep "${LUN}_outstandsum"
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_nonzeroreq\./${LUN}_nzr\./p"
-	echo "$ANSWER" | grep "${LUN}_nonzeroreq"
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_readreq\./${LUN}_rr\./p"
-	echo "$ANSWER" | grep "${LUN}_readreq"
-#	echo "$ANSWER" | sed -ne "s/^${LUN}_writereq\./${LUN}_wr\./p"
-	echo "$ANSWER" | grep "${LUN}_writereq"
 	echo "${LUN}_ql_l_a.value 0 "
 	echo "${LUN}_ql_l_b.value 0 "
 done <<< $LUNLIST

--- a/plugins/emc/emc_vnx_dm_basic_stats
+++ b/plugins/emc/emc_vnx_dm_basic_stats
@@ -1,0 +1,169 @@
+#!/bin/bash
+######################################################################################################################
+#                  Plugin to monitor basic statistics of EMC VNX 5300 Unified Datamovers                             #
+######################################################################################################################
+
+# Author: Evgeny Beysembaev <megabotva@gmail.com>
+
+#####################################
+#         Description               #
+#####################################
+
+# The plugin monitors basic statistics of EMC Unified Storage system Datamovers. Probably it can also be compatible with 
+# other Isilon or Celerra systems. It uses SSH to connect to Control Stations, then remotely executes 
+# /nas/sbin/server_stats and fetches and parses data from it. It supports gathering data both from active/active 
+# and active/passive Datamover configurations, ignoring offline or standby Datamovers. If all Datamovers are 
+# offline or absent, the plugin returns error.
+# This plugin also automatically chooses Primary Control Station from the list by calling /nasmcd/sbin/getreason and 
+# /nasmcd/sbin/t2slot.
+# 
+# Data is gathered from basic-std Statistics Group
+# 
+# It's quite easy to comment out unneeded data to make graphs less overloaded or to add new statistics sources.
+ 
+#####################################
+#        Configuration              #
+#####################################
+
+# The plugin uses SSH to connect to Control Stations. It's possible to use 'nasadmin' user, but it would be better
+# if you create read-only global user by Unisphere Client. The user should have only Operator role.
+# I created "operator" user but due to the fact that Control Stations already had one internal "operator" user,
+# the new one was called "operator1". So be careful.
+# 
+# On munin-node side choose a user which will be used to connect through SSH. Generally user "munin" is ok. Then,
+# execute "sudo su munin -s /bin/bash", "ssh-keygen" and "ssh-copy-id" to both Control Stations with newly created 
+# user.
+# 
+# Make a link from /usr/share/munin/plugins/emc_vnx_dm_basic_stats to /etc/munin/plugins/emc_vnx_dm_basic_stats_<NAME>,
+# where <NAME> is any arbitrary name of your storage system. The plugin will return <NAME> in its answer 
+# as "host_name" field.
+# Assume your storage system is called "VNX5300".
+# 
+# Make a configuration file at /etc/munin/plugin-conf.d/emc_vnx_dm_basic_stats_VNX5300
+# 
+# [emc_vnx_dm_basic_stats_vnx5300]
+# user munin							# SSH Client local user
+# env.username operator1					# Remote user with Operator role
+# env.cs_addr 192.168.1.1 192.168.1.2				# Control Stations addresses
+# env.nas_servers server_2 server_3				# This is the default value and can be omitted
+
+#####################################
+#           History                 #
+#####################################
+
+# 08.11.2016 - First Release
+
+######################################################################################################################
+
+export LANG=C
+
+TARGET=$(echo "${0##*/}" | cut -d _ -f 6)
+: ${nas_servers:="server_2 server_3"}
+SSH_CHECK='ssh -q $username@$CS "/nasmcd/sbin/getreason | grep -w slot_\`/nasmcd/sbin/t2slot\` | cut -d- -f1"'
+
+if [ "$1" = "autoconf" ]; then
+	echo "yes"
+	exit 0
+fi
+
+if [ -z "$username" ]; then
+	echo "No username!"
+	exit 1
+fi
+
+if [ -z "$cs_addr" ]; then
+	echo "No control station addresses!"
+	exit 1
+fi
+
+#Choosing Cotrol Station. Code have to be "10"
+for CS in $cs_addr; do
+	if [ "`eval $SSH_CHECK`" -eq "10" ]; then
+#		echo "$CS is Primary"
+		PRIMARY_CS=$CS
+		break
+	fi
+done
+
+if [ -z "$PRIMARY_CS" ]; then
+	echo "No alive primary Control Station from list \"$cs_addr\"";
+	exit 1;
+fi
+
+SSH="ssh -q $username@$PRIMARY_CS . /home/operator1/.bash_profile; "
+
+echo "host_name ${TARGET}"
+
+if [ "$1" = "config" ] ; then
+	for server in $nas_servers; do
+		$SSH nas_server -i $server | grep -q 'type *= nas'
+		if [ "$?" != 0 ]  ; then continue; fi
+		nas_server_ok=TRUE
+		echo "multigraph emc_vnx_cpu_percent
+graph_title EMC VNX 5300 Datamover CPU Util %
+graph_vlabel %
+graph_category cpu
+${server}_cpuutil.min 0
+${server}_cpuutil.label $server CPU util. in % in this interval."
+		echo "
+multigraph emc_vnx_network_kib
+graph_title EMC VNX 5300 Datamover Network bytes over all interfaces
+graph_vlabel B/s sent (+)/ recv. (-)
+graph_category network
+graph_args --base 1000
+${server}_net_in.graph no
+${server}_net_in.label none
+${server}_net_in.cdef ${server}_net_in,1000,*
+${server}_net_out.label $server B/s
+${server}_net_out.cdef ${server}_net_out,1000,*
+${server}_net_out.negative ${server}_net_in
+${server}_net_out.draw AREA"
+		echo "
+multigraph emc_vnx_storage_kib
+graph_title EMC VNX 5300 Datamover Storage bytes over all interfaces
+graph_vlabel B/s sent (+)/ recv. (-)
+graph_category network
+graph_args --base 1000
+${server}_stor_read.graph no
+${server}_stor_read.label none
+${server}_stor_read.cdef ${server}_stor_read,1000,*
+${server}_stor_write.label $server B/s
+${server}_stor_write.cdef ${server}_stor_write,1000,*
+${server}_stor_write.negative ${server}_stor_read
+${server}_stor_write.draw AREA"
+	done
+	if [ -z $nas_server_ok ]; then
+		echo "No active data movers!"
+		exit 1
+	fi
+exit 0
+fi
+
+for server in $nas_servers; do
+	$SSH nas_server -i $server | grep -q 'type *= nas'
+	if [ "$?" != 0 ]  ; then continue; fi
+	nas_server_ok=TRUE
+	member_elements=`$SSH server_stats $server -count 1 -terminationsummary no -titles never `
+	NUMCOL=5
+	IFS=$' ' read -ra graphs <<< $member_elements
+
+	echo "multigraph emc_vnx_cpu_percent"
+	echo "${server}_cpuutil.value ${graphs[1]}"
+
+	echo "
+multigraph emc_vnx_network_kib"
+	echo "${server}_net_in.value ${graphs[2]}"
+	echo "${server}_net_out.value ${graphs[3]}"
+
+	echo "
+multigraph emc_vnx_storage_kib"
+	echo "${server}_stor_read.value ${graphs[4]}"
+	echo "${server}_stor_write.value ${graphs[5]}"
+
+done
+if [ -z $nas_server_ok ]; then
+	echo "No active data movers!"
+	exit 1
+fi
+exit 0
+

--- a/plugins/emc/emc_vnx_nfsv3_stats
+++ b/plugins/emc/emc_vnx_nfsv3_stats
@@ -1,0 +1,266 @@
+#!/bin/bash
+######################################################################################################################
+#                 Plugin to monitor NFS statistics of EMC VNX 5300 Unified Storage system                            #
+######################################################################################################################
+
+# Author: Evgeny Beysembaev <megabotva@gmail.com>
+
+#####################################
+#         Description               #
+#####################################
+
+# The plugin monitors NFS v3 statistics of EMC Unified Storage system. Probably it can also be compatible with 
+# other Isilon or Celerra systems. It uses SSH to connect to Control Stations, then remotely executes 
+# /nas/sbin/server_stats and fetches and parses data from it. It supports gathering data both from active/active 
+# and active/passive Datamover configurations, ignoring offline or standby Datamovers. If all Datamovers are 
+# offline or absent, the plugin returns error.
+# This plugin also automatically chooses Primary Control Station from the list by calling /nasmcd/sbin/getreason and 
+# /nasmcd/sbin/t2slot.
+# 
+# At the moment data is gathered from the following statistics sources:
+# nfs.v3.op - Tons of timings about NFS RPC calls
+# nfs.client - Here new Client addresses are rescanned and added automatically.
+# 
+# It's quite easy to comment out unneeded data to make graphs less overloaded or to add new statistics sources.
+ 
+#####################################
+#        Configuration              #
+#####################################
+
+# The plugin uses SSH to connect to Control Stations. It's possible to use 'nasadmin' user, but it would be better
+# if you create read-only global user by Unisphere Client. The user should have only Operator role.
+# I created "operator" user but due to the fact that Control Stations already had one internal "operator" user,
+# the new one was called "operator1". So be careful.
+# 
+# On munin-node side choose a user which will be used to connect through SSH. Generally user "munin" is ok. Then,
+# execute "sudo su munin -s /bin/bash", "ssh-keygen" and "ssh-copy-id" to both Control Stations with newly created 
+# user.
+# 
+# Make a link from /usr/share/munin/plugins/emc_vnx_nfsv3_stats to /etc/munin/plugins/emc_vnx_nfsv3_stats_<NAME>,
+# where <NAME> is any arbitrary name of your storage system. The plugin will return <NAME> in its answer 
+# as "host_name" field.
+# Assume your storage system is called "VNX5300".
+# 
+# Make a configuration file at /etc/munin/plugin-conf.d/emc_vnx_nfsv3_stats_VNX5300
+# 
+# [emc_vnx_nfsv3_stats_vnx5300]
+# user munin							# SSH Client local user
+# env.username operator1					# Remote user with Operator role
+# env.cs_addr 192.168.1.1 192.168.1.2				# Control Stations addresses
+# env.nas_servers server_2 server_3				# This is the default value and can be omitted
+
+#####################################
+#           History                 #
+#####################################
+
+# 08.11.2016 - First Release
+
+######################################################################################################################
+
+export LANG=C
+
+TARGET=$(echo "${0##*/}" | cut -d _ -f 5)
+: ${nas_servers:="server_2 server_3"}
+SSH_CHECK='ssh -q $username@$CS "/nasmcd/sbin/getreason | grep -w slot_\`/nasmcd/sbin/t2slot\` | cut -d- -f1"'
+
+if [ "$1" = "autoconf" ]; then
+	echo "yes"
+	exit 0
+fi
+
+if [ -z "$username" ]; then
+	echo "No username!"
+	exit 1
+fi
+
+if [ -z "$cs_addr" ]; then
+	echo "No control station addresses!"
+	exit 1
+fi
+
+#Choosing Cotrol Station. Code have to be "10"
+for CS in $cs_addr; do
+	if [ "`eval $SSH_CHECK`" -eq "10" ]; then
+#		echo "$CS is Primary"
+		PRIMARY_CS=$CS
+		break
+	fi
+done
+
+if [ -z "$PRIMARY_CS" ]; then
+	echo "No alive primary Control Station from list \"$cs_addr\"";
+	exit 1;
+fi
+
+SSH="ssh -q $username@$PRIMARY_CS . /home/operator1/.bash_profile; "
+
+echo "host_name ${TARGET}"
+
+if [ "$1" = "config" ] ; then
+	for server in $nas_servers; do
+		$SSH nas_server -i $server | grep -q 'type *= nas'
+		if [ "$?" != 0 ]  ; then continue; fi
+		nas_server_ok=TRUE
+#nfs.v3.op data
+		member_elements=`$SSH server_stats $server -info nfs.v3.op | grep member_elements | sed -ne 's/^.*= //p'`
+		IFS=',' read -ra graphs <<< $member_elements
+		echo "multigraph vnx_emc_calls_s
+graph_title EMC VNX 5300 NFS V3 Calls per second
+graph_vlabel Calls
+graph_category nfs
+graph_args --base 1000"
+		for graph in "${graphs[@]}"; do
+        	        field=`echo "$graph" | cut -d '.' -f4 `
+			echo "${server}_$field.label $server $field"
+        	done
+
+		echo "
+multigraph vnx_emc_usec_call
+graph_title EMC VNX 5300 NFS V3 uSeconds per call
+graph_vlabel uSec / call
+graph_category nfs
+graph_args --base 1000"
+		for graph in "${graphs[@]}"; do
+                	field=`echo "$graph" | cut -d '.' -f4 `
+			echo "${server}_$field.label $server $field"
+        	done
+		echo "
+multigraph vnx_emc_op_percent
+graph_title EMC VNX 5300 NFS V3 Op %
+graph_vlabel %
+graph_category nfs"
+		for graph in "${graphs[@]}"; do
+                	field=`echo "$graph" | cut -d '.' -f4 `
+			echo "${server}_$field.label $server $field"
+			echo "${server}_$field.min 0"
+        	done
+
+
+#nfs.client data
+#							 Total    Read     Write   Suspicious   Total    Read     Write      Avg   
+#                                                      Ops/s    Ops/s    Ops/s    Ops diff    KiB/s    KiB/s    KiB/s   uSec/call
+		member_elements=`$SSH server_stats server_2 -monitor nfs.client -count 1 -terminationsummary no -titles never | sed -ne 's/^.*id=//p' | cut -d' ' -f1`
+		readarray graphs2 <<< $member_elements
+		echo "
+multigraph vnx_emc_nfs_client_ops_s
+graph_title EMC VNX 5300 NFS Client Ops/s
+graph_vlabel Ops/s
+graph_category nfs"
+		echo -n "graph_order "
+		for graph in "${graphs2[@]}"; do
+                        field=`echo "$graph" | sed -ne 's/\./_/pg' `
+			echo -n "${server}_${field}_r ${server}_${field}_w ${server}_${field}_t ${server}_${field}_s "
+		done
+		echo " "
+		for graph in "${graphs2[@]}"; do
+                        field=`echo "$graph" | sed -ne 's/\./_/pg' `
+                        echo "${server}_${field}_r.label $server $field Read Ops/s"
+                        echo "${server}_${field}_w.label $server $field Write Ops/s"
+                        echo "${server}_${field}_w.draw STACK"
+                        echo "${server}_${field}_t.label $server $field Total Ops/s"
+			echo "${server}_${field}_s.label $server $field Suspicious Ops diff"
+                done
+
+		echo "
+multigraph vnx_emc_nfs_client_kib_s
+graph_title EMC VNX 5300 NFS Client KiB/s
+graph_vlabel KiB/s
+graph_category nfs"
+		echo -n "graph_order "
+		for graph in "${graphs2[@]}"; do
+                        field=`echo "$graph" | sed -ne 's/\./_/pg' `
+			echo -n "${server}_${field}_r ${server}_${field}_w ${server}_${field}_t "
+		done
+		echo " "
+		for graph in "${graphs2[@]}"; do
+                        field=`echo "$graph" | sed -ne 's/\./_/pg' `
+                        echo "${server}_${field}_r.label $server $field Read KiB/s"
+                        echo "${server}_${field}_w.label $server $field Write KiB/s"
+                        echo "${server}_${field}_w.draw STACK"
+                        echo "${server}_${field}_t.label $server $field Total KiB/s"
+                done
+
+		echo "
+multigraph vnx_emc_nfs_client_avg_usec
+graph_title EMC VNX 5300 NFS Client Avg uSec/call
+graph_vlabel uSec/call
+graph_category nfs"
+		for graph in "${graphs2[@]}"; do
+                        field=`echo "$graph" | sed -ne 's/\./_/pg' `
+                        echo "${server}_${field}.label $server $field Avg uSec/call"
+                done
+	done
+	if [ -z $nas_server_ok ]; then
+		echo "No active data movers!"
+		exit 1
+	fi
+exit 0
+fi
+
+#nfs.v3.op data
+for server in $nas_servers; do
+	$SSH nas_server -i $server | grep -q 'type *= nas'
+	if [ "$?" != 0 ]  ; then continue; fi
+	nas_server_ok=TRUE
+	member_elements=`$SSH server_stats $server -monitor nfs.v3.op -count 1 -terminationsummary no -titles never | sed -ne 's/^.*v3/v3/p'`
+	NUMCOL=5
+	LINES=`wc -l <<< $member_elements`
+	while IFS=$'\n' read -ra graphs ; do
+		element+=( $graphs )
+	done <<< $member_elements
+
+	echo "multigraph vnx_emc_calls_s"
+	for ((i=0; i<$((LINES)); i++ )); do
+		echo "${server}_${element[i*$NUMCOL]}".value "${element[i*$NUMCOL+1]}"
+	done
+
+	echo "
+multigraph vnx_emc_usec_call"
+	for ((i=0; i<$((LINES)); i++ )); do
+		echo "${server}_${element[i*$NUMCOL]}".value "${element[i*$NUMCOL+3]}"
+	done
+
+	echo "
+multigraph vnx_emc_op_percent"
+	for ((i=0; i<$((LINES)); i++ )); do
+		echo "${server}_${element[i*$NUMCOL]}".value "${element[i*$NUMCOL+4]}"
+	done
+
+	element=()
+#nfs.client data
+	echo "
+multigraph vnx_emc_nfs_client_ops_s"
+        member_elements=`$SSH server_stats server_2 -monitor nfs.client -count 1 -terminationsummary no -titles never | sed -ne 's/^.*id=//p'`
+	NUMCOL=9
+        LINES=`wc -l <<< $member_elements`
+	while IFS=$'\n' read -ra graphs; do
+		element+=($graphs)
+	done  <<< $member_elements
+	for (( i=0; i<$((LINES)); i++ )); do
+		client=` echo ${element[i*$NUMCOL]} | sed -ne 's/\./_/pg'`
+               echo "${server}_${client}_r".value "${element[$i*$NUMCOL+2]}"
+               echo "${server}_${client}_w".value "${element[$i*$NUMCOL+3]}"
+               echo "${server}_${client}_t".value "${element[$i*$NUMCOL+1]}"
+               echo "${server}_${client}_s".value "${element[$i*$NUMCOL+4]}"
+        done
+	echo "
+multigraph vnx_emc_nfs_client_kib_s"
+	for (( i=0; i<$((LINES)); i++ )); do
+		client=` echo ${element[i*$NUMCOL]} | sed -ne 's/\./_/pg'`
+               echo "${server}_${client}_r".value "${element[$i*$NUMCOL+6]}"
+               echo "${server}_${client}_w".value "${element[$i*$NUMCOL+7]}"
+               echo "${server}_${client}_t".value "${element[$i*$NUMCOL+5]}"
+        done
+	echo "
+multigraph vnx_emc_nfs_client_avg_usec"
+	for (( i=0; i<$((LINES)); i++ )); do
+		client=` echo ${element[i*$NUMCOL]} | sed -ne 's/\./_/pg'`
+		echo "${server}_${client}".value "${element[$i*$NUMCOL+8]}"
+	done
+done
+if [ -z $nas_server_ok ]; then
+	echo "No active data movers!"
+	exit 1
+fi
+exit 0
+


### PR DESCRIPTION
The plugin monitors LUN of EMC VNX5300 Unified Storage FLARE SP's. Probably it can also be compatible with other Clariion systems. It uses SSH to connect to Control Stations, then remotely executes 
/nas/sbin/navicli and fetches and parses data from it. Obviously, it's easy to reconfigure plugin not to use 
Control Stations' navicli in favor of using locally installed /opt/Navisphere's cli. There is no difference which
Storage Processor to use to gather data, so this plugin tries both of them and uses the first active one.
This plugin also automatically chooses Primary Control Station from the list by calling /nasmcd/sbin/getreason and /nasmcd/sbin/t2slot.
