### PR TITLE
Update oracle_sysstat_ plugin

### DIFF
--- a/plugins/oracle/oracle_sysstat_
+++ b/plugins/oracle/oracle_sysstat_
@@ -411,7 +411,15 @@ getvalue_func[$key]=getvalue_cputime
 key=cachehit
 # buf_hitratio = 1 - physical_reads / ( db_block_gets + consistent_gets )
 # lib_hitratio = 1 - reloads / pins
-# dic_hitratio = ( gets - misses ) / gets
+# dict_hitratio = ( gets - misses ) / gets
+field_info=$( for field in buf_physical buf_logical lib_pins lib_reloads dict_gets dict_getmisses
+   do
+       echo "${field}.graph no"
+       echo "${field}.type DERIVE"
+       echo "${field}.min 0"
+       echo "${field}.label ${field}"
+   done
+)
 global_attrs[$key]="
     graph_title Oracle Cache Hit Ratio
     graph_category db
@@ -420,23 +428,15 @@ global_attrs[$key]="
     graph_info Oracle Cache Hit Ratio - The graph shows cache hit ratio between munin-update intervals (5 minutes in most cases).
     graph_scale no
 
-    $( for field in buf_physical buf_logical lib_pins lib_reloads dic_gets dic_getmisses
-       do
-           echo "${field}.graph no"
-           echo "${field}.type DERIVE"
-           echo "${field}.min 0"
-           echo "${field}.label ${field}"
-       done
-    )
-
+    ${field_info}
     buf_hitratio.cdef 100,1,buf_physical,buf_logical,/,-,*,FLOOR
     lib_hitratio.cdef 100,1,lib_reloads,lib_pins,/,-,*,FLOOR
-    dic_hitratio.cdef 100,dic_gets,dic_getmisses,-,dic_gets,/,*,FLOOR
+    dict_hitratio.cdef 100,dict_gets,dict_getmisses,-,dict_gets,/,*,FLOOR
 "
 data_attrs[$key]="
     buf_hitratio GAUGE LINE Buffer Cache Hit Ratio
     lib_hitratio GAUGE LINE Library Cache Hit Ratio
-    dic_hitratio GAUGE LINE Dictionary Cache Hit Ratio
+    dict_hitratio GAUGE LINE Dictionary Cache Hit Ratio
 "
 getvalue_func[$key]=getvalue_cachehit
 
@@ -470,7 +470,7 @@ global_attrs[$key]="
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel microseconds
-    graph_info Oracle Wait Events - It may looks wierd that Y-axis indicates 'microseconds per second'. Although number of times of wait event looks easier to understand, in many cases the number of events does not matter, but wait time become more important to analyze bottle necks.
+    graph_info Oracle Wait Events - It may look wierd that Y-axis indicates 'microseconds per second'. Although number of times of wait event looks easier to understand, in many cases the number of events does not matter, but wait time become more important to analyze bottle necks.
 "
 data_attrs[$key]=""
 getfield_func[$key]=getfield_eventwait
@@ -638,10 +638,11 @@ config() {
     # print data source attributes
     # split line into field,type,draw,label 
     local fields field type draw label
+    fields=
     while read -r field type draw label
     do
-        [ -z "${field:-}" ] && continue
-        fields="${fields:-} ${field}"
+        [ -z "$field" ] && continue
+        fields="${fields} ${field}"
 
         echo "${field}.type ${type}"
         echo "${field}.draw ${draw}"
@@ -678,19 +679,18 @@ getvalue_sysstat() {
     do
         [ -z "$field" ] && continue
 
-        cat <<EOF
-${sqlplus_variables}
-VAR vf VARCHAR2(64)
-VAR vl VARCHAR2(64)
-EXEC :vf := '${field}' 
-EXEC :vl := '${label}' 
-SELECT
-  :vf || '.value ' || value
-FROM
-  v\$sysstat
-WHERE
-  name = :vl;
-EOF
+        echo "${sqlplus_variables}
+          VAR vf VARCHAR2(64)
+          VAR vl VARCHAR2(64)
+          EXEC :vf := '${field}' 
+          EXEC :vl := '${label}' 
+          SELECT
+            :vf || '.value ' || value
+          FROM
+            v\$sysstat
+          WHERE
+            name = :vl;
+        "
     done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
 }
 
@@ -700,19 +700,18 @@ getvalue_sgainfo() {
     do
         [ -z "$field" ] && continue
 
-        cat <<EOF
-${sqlplus_variables}
-VAR vf VARCHAR2(64)
-VAR vl VARCHAR2(64)
-EXEC :vf := '${field}' 
-EXEC :vl := '${label}' 
-SELECT
-  :vf || '.value ' || bytes
-FROM
-  v\$sgainfo
-WHERE
-  name = :vl;
-EOF
+        echo "${sqlplus_variables}
+          VAR vf VARCHAR2(64)
+          VAR vl VARCHAR2(64)
+          EXEC :vf := '${field}' 
+          EXEC :vl := '${label}' 
+          SELECT
+            :vf || '.value ' || bytes
+          FROM
+            v\$sgainfo
+          WHERE
+            name = :vl;
+        "
     done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
 }
 
@@ -722,19 +721,18 @@ getvalue_pgastat() {
     do
         [ -z "$field" ] && continue
 
-        cat <<EOF
-${sqlplus_variables}
-VAR vf VARCHAR2(64)
-VAR vl VARCHAR2(64)
-EXEC :vf := '${field}' 
-EXEC :vl := '${label}' 
-SELECT
-  :vf || '.value ' || value
-FROM
-  v\$pgastat
-WHERE
-  name = :vl;
-EOF
+        echo "${sqlplus_variables}
+          VAR vf VARCHAR2(64)
+          VAR vl VARCHAR2(64)
+          EXEC :vf := '${field}' 
+          EXEC :vl := '${label}' 
+          SELECT
+            :vf || '.value ' || value
+          FROM
+            v\$pgastat
+          WHERE
+            name = :vl;
+        "
     done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
 }
 
@@ -744,19 +742,18 @@ getvalue_cputime() {
     do
         [ -z "$field" ] && continue
 
-        cat <<EOF
-${sqlplus_variables}
-VAR vf VARCHAR2(64)
-VAR vl VARCHAR2(64)
-EXEC :vf := '${field}' 
-EXEC :vl := '${label}' 
-SELECT
-  :vf || '.value ' || ROUND( value / 1000000 )
-FROM
-  v\$sys_time_model
-WHERE
-  stat_name = :vl;
-EOF
+        echo "${sqlplus_variables}
+          VAR vf VARCHAR2(64)
+          VAR vl VARCHAR2(64)
+          EXEC :vf := '${field}' 
+          EXEC :vl := '${label}' 
+          SELECT
+            :vf || '.value ' || ROUND( value / 1000000 )
+          FROM
+            v\$sys_time_model
+          WHERE
+            stat_name = :vl;
+        "
     done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
 }
 
@@ -779,8 +776,8 @@ WHERE
 ;
 SELECT 'lib_pins.value '    || SUM(pins)    FROM v\$librarycache;
 SELECT 'lib_reloads.value ' || SUM(reloads) FROM v\$librarycache;
-SELECT 'dic_gets.value '      || SUM(gets)      FROM v\$rowcache;
-SELECT 'dic_getmisses.value ' || SUM(getmisses) FROM v\$rowcache;
+SELECT 'dict_gets.value '      || SUM(gets)      FROM v\$rowcache;
+SELECT 'dict_getmisses.value ' || SUM(getmisses) FROM v\$rowcache;
 EOF
 }
 

--- a/plugins/oracle/oracle_sysstat_
+++ b/plugins/oracle/oracle_sysstat_
@@ -7,31 +7,38 @@
 
   oracle_sysstat_* - Munin plugin to monitor Oracle Statistics
 
-    execute              - To monitor Oracle Sysstat Execute Count
-    parse                - To monitor Oracle Sysstat Parse Count
-    tablefetch           - To monitor Oracle Sysstat Table Fetch Rows
-    tablescan            - To monitor Oracle Sysstat Table Scans
-    transaction          - To monitor Oracle Sysstat Transactions
-    sort                 - To monitor Oracle Sysstat Sorts
-    cursor               - To monitor Oracle Sysstat Open Cursor
-    enqueue              - To monitor Oracle Sysstat Enqueues
-    redolog              - To monitor Oracle Sysstat Redo Log
-    physicaliops         - To monitor Oracle Sysstat Physical I/O Requests
-    physicalrw           - To monitor Oracle Sysstat Physical Read/Write Bytes
-    netrw                - To monitor Oracle Sysstat Network Send/Receive Bytes
-    sgainfo              - To monitor Oracle Memory SGA
-    pgastat              - To monitor Oracle Memory PGA
-    cachehit             - To monitor Oracle Cache Hit Ratio
-    sessionuser          - To monitor Oracle Session Users
-    sessionwait          - To monitor Oracle Session Wait
-    eventwait            - To monitor Oracle Wait Events
-    eventwaitapplication - To monitor Oracle Wait Events Application
-    eventwaitconcurrency - To monitor Oracle Wait Events Concurrency
-    eventwaituserio      - To monitor Oracle Wait Events User I/O
-    eventwaitsystemio    - To monitor Oracle Wait Events System I/O
-    eventwaitcluster     - To monitor Oracle Wait Events Cluster
-    tablespace           - To monitor Oracle Table Space Usage
-    asmusage             - To monitor Oracle ASM Disk Group Usage
+    execute                 - To monitor Oracle Sysstat SQL Execute Count
+    parse                   - To monitor Oracle Sysstat SQL Parse Count
+    tablefetch              - To monitor Oracle Sysstat SQL Table Fetch Rows
+    tablescan               - To monitor Oracle Sysstat SQL Table Scans
+    transaction             - To monitor Oracle Sysstat SQL Transactions
+    sort                    - To monitor Oracle Sysstat SQL Sorts
+    logon                   - To monitor Oracle Sysstat User Logons
+    cursor                  - To monitor Oracle Sysstat User Opened Cursors
+    enqueue                 - To monitor Oracle Sysstat Enqueues
+    redolog                 - To monitor Oracle Sysstat Redo Entries
+    redosize                - To monitor Oracle Sysstat Redo Size
+    physicaliops            - To monitor Oracle Sysstat I/O Physical Requests
+    physicalrw              - To monitor Oracle Sysstat I/O Physical Bytes
+    blockrw                 - To monitor Oracle Sysstat I/O Blocks
+    netrw                   - To monitor Oracle Sysstat I/O Network Bytes
+    sgainfo                 - To monitor Oracle Memory SGA
+    pgastat                 - To monitor Oracle Memory PGA
+    cputime                 - To monitor Oracle CPU Time
+    cachehit                - To monitor Oracle Cache Hit Ratio
+    sessionuser             - To monitor Oracle Session Users
+    sessionwait             - To monitor Oracle Session Wait
+    eventwait               - To monitor Oracle Wait Events
+    eventwaitapplication    - To monitor Oracle Wait Events Application
+    eventwaitnetwork        - To monitor Oracle Wait Events Network
+    eventwaitconcurrency    - To monitor Oracle Wait Events Concurrency
+    eventwaituserio         - To monitor Oracle Wait Events User I/O
+    eventwaitsystemio       - To monitor Oracle Wait Events System I/O
+    eventwaitcluster        - To monitor Oracle Wait Events Cluster
+    eventwaitadministrative - To monitor Oracle Wait Events Administrative
+    eventwaitconfiguration  - To monitor Oracle Wait Events Configuration
+    tablespace              - To monitor Oracle Table Space Usage
+    asmusage                - To monitor Oracle ASM Disk Group Usage
 
 =head1 CONFIGURATION
 
@@ -77,11 +84,11 @@
 #%# family=contrib
 #%# capabilities=autoconf suggest
 
-# Include plugin.sh
-. "${MUNIN_LIBDIR}/plugins/plugin.sh"
-
 # Like perl 'use strict;' 
-#set -o nounset
+set -o nounset
+
+# Include plugin.sh
+. "${MUNIN_LIBDIR:-}/plugins/plugin.sh"
 
 # Environments
 : "${ORACLE_HOME:=$( echo /opt/oracle/product/* )}"
@@ -102,56 +109,57 @@ declare -A getvalue_func # required
 
 key=execute
 global_attrs[$key]="
-    graph_title Oracle Sysstat Execute Count
+    graph_title Oracle Sysstat SQL Execute Count
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count per second
-    graph_info Oracle Sysstat Execute Count
+    graph_info Oracle Sysstat SQL Execute Count
 "
 data_attrs[$key]="
-    execute_count    DERIVE LINE execute count
-    user_calls       DERIVE LINE user calls
-    recursive_calls  DERIVE LINE recursive calls
+    execute_count   DERIVE LINE execute count
+    user_calls      DERIVE LINE user calls
+    recursive_calls DERIVE LINE recursive calls
 "
 getvalue_func[$key]=getvalue_sysstat
 
 key=parse
 global_attrs[$key]="
-    graph_title Oracle Sysstat Parse Count
+    graph_title Oracle Sysstat SQL Parse Count
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count per second
-    graph_info Oracle Sysstat Parse Count
+    graph_info Oracle Sysstat SQL Parse Count
 "
 data_attrs[$key]="
-    parse_count_total     DERIVE LINE parse count (total)
-    parse_count_hard      DERIVE LINE parse count (hard)
-    parse_count_failures  DERIVE LINE parse count (failures)
-    parse_count_describe  DERIVE LINE parse count (describe)
+    parse_count_total    DERIVE LINE parse count (total)
+    parse_count_hard     DERIVE LINE parse count (hard)
+    parse_count_describe DERIVE LINE parse count (describe)
+    parse_count_failures DERIVE LINE parse count (failures)
 "
 getvalue_func[$key]=getvalue_sysstat
 
 key=tablefetch
 global_attrs[$key]="
-    graph_title Oracle Sysstat Table Fetch Rows
+    graph_title Oracle Sysstat SQL Table Fetch Rows
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count per second
-    graph_info Oracle Sysstat Table Scans
+    graph_info Oracle Sysstat SQL Table Fetch Rows
 "
 data_attrs[$key]="
-    table_fetch_by_rowid   DERIVE LINE table fetch by rowid
-    table_scan_rows_gotten DERIVE LINE table scan rows gotten
+    table_fetch_by_rowid      DERIVE LINE table fetch by rowid
+    table_scan_rows_gotten    DERIVE LINE table scan rows gotten
+    table_fetch_continued_row DERIVE LINE table fetch continued row
 "
 getvalue_func[$key]=getvalue_sysstat
 
 key=tablescan
 global_attrs[$key]="
-    graph_title Oracle Sysstat Table Scans
+    graph_title Oracle Sysstat SQL Table Scans
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count per second
-    graph_info Oracle Sysstat Table Scans
+    graph_info Oracle Sysstat SQL Table Scans
 "
 data_attrs[$key]="
     table_scans_short_tables DERIVE LINE table scans (short tables)
@@ -161,11 +169,11 @@ getvalue_func[$key]=getvalue_sysstat
 
 key=transaction
 global_attrs[$key]="
-    graph_title Oracle Sysstat Transactions
+    graph_title Oracle Sysstat SQL Transactions
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count per second
-    graph_info Oracle Sysstat Transactions
+    graph_info Oracle Sysstat SQL Transactions
 "
 data_attrs[$key]="
     user_commits   DERIVE LINE user commits
@@ -175,11 +183,11 @@ getvalue_func[$key]=getvalue_sysstat
 
 key=sort
 global_attrs[$key]="
-    graph_title Oracle Sysstat Sorts
+    graph_title Oracle Sysstat SQL Sorts
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count per second
-    graph_info Oracle Sysstat - Sorts
+    graph_info Oracle Sysstat SQL Sorts
 "
 data_attrs[$key]="
     sorts_memory DERIVE LINE sorts (memory)
@@ -187,13 +195,26 @@ data_attrs[$key]="
 "
 getvalue_func[$key]=getvalue_sysstat
 
+key=logon
+global_attrs[$key]="
+    graph_title Oracle Sysstat User Logons
+    graph_category db
+    graph_args --base 1000 --lower-limit 0 --rigid
+    graph_vlabel count per second
+    graph_info Oracle Sysstat User Logons
+"
+data_attrs[$key]="
+    logon DERIVE LINE logons cumulative
+"
+getvalue_func[$key]=getvalue_sysstat
+
 key=cursor
 global_attrs[$key]="
-    graph_title Oracle Sysstat Open Cursors
+    graph_title Oracle Sysstat User Opened Cursors
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count
-    graph_info Oracle Sysstat Open Cursors
+    graph_info Oracle Sysstat User Opened Cursors
 "
 data_attrs[$key]="
     open_cursor GAUGE LINE opened cursors current
@@ -220,26 +241,42 @@ getvalue_func[$key]=getvalue_sysstat
 
 key=redolog
 global_attrs[$key]="
-    graph_title Oracle Sysstat Redo Log
+    graph_title Oracle Sysstat Redo Entries
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel count per second
-    graph_info Oracle Sysstat Redo Log
+    graph_info Oracle Sysstat Redo Entries
 "
 data_attrs[$key]="
     redo_entries                   DERIVE LINE redo entries
+    redo_writes                    DERIVE LINE redo writes
+    redo_synch_writes              DERIVE LINE redo synch writes
     redo_buffer_allocation_retries DERIVE LINE redo buffer allocation retries
     redo_log_space_requests        DERIVE LINE redo log space requests
 "
 getvalue_func[$key]=getvalue_sysstat
 
+key=redosize
+global_attrs[$key]="
+    graph_title Oracle Sysstat Redo Size
+    graph_category db
+    graph_args --base 1024 --lower-limit 0 --rigid
+    graph_vlabel bytes per second
+    graph_info Oracle Sysstat Redo Size
+"
+data_attrs[$key]="
+    redo_size    DERIVE LINE redo size
+    redo_wastage DERIVE LINE redo wastage
+"
+getvalue_func[$key]=getvalue_sysstat
+
 key=physicaliops
 global_attrs[$key]="
-    graph_title Oracle Sysstat Physical I/O Requests
+    graph_title Oracle Sysstat I/O Physical Requests
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel iops
-    graph_info Oracle Sysstat Physical I/O Requests
+    graph_info Oracle Sysstat I/O Physical Requests
 "
 data_attrs[$key]="
     physical_read_total        DERIVE LINE2 physical read total IO requests
@@ -253,11 +290,11 @@ getvalue_func[$key]=getvalue_sysstat
 
 key=physicalrw
 global_attrs[$key]="
-    graph_title Oracle Sysstat Physical Read/Write Bytes
+    graph_title Oracle Sysstat I/O Physical Bytes
     graph_category db
     graph_args --base 1024 --lower-limit 0 --rigid
     graph_vlabel bytes per second
-    graph_info Oracle Sysstat Physical Read/Write Bytes
+    graph_info Oracle Sysstat I/O Physical Bytes
 "
 data_attrs[$key]="
     physical_read_total  DERIVE LINE2 physical read total bytes
@@ -267,13 +304,32 @@ data_attrs[$key]="
 "
 getvalue_func[$key]=getvalue_sysstat
 
+key=blockrw
+global_attrs[$key]="
+    graph_title Oracle Sysstat I/O Blocks
+    graph_category db
+    graph_args --base 1000 --lower-limit 0 --rigid
+    graph_vlabel blocks per second
+    graph_info Oracle Sysstat I/O Blocks
+"
+data_attrs[$key]="
+    db_block_gets      DERIVE LINE db block gets
+    db_block_changes   DERIVE LINE db block changes
+    consistent_gets    DERIVE LINE consistent gets
+    consistent_changes DERIVE LINE consistent changes
+    physical_reads     DERIVE LINE physical reads
+    physical_writes    DERIVE LINE physical writes
+"
+getvalue_func[$key]=getvalue_sysstat
+
+
 key=netrw
 global_attrs[$key]="
-    graph_title Oracle Sysstat Network Send/Receive Bytes
+    graph_title Oracle Sysstat I/O Network Bytes
     graph_category db
     graph_args --base 1024 --lower-limit 0 --rigid
     graph_vlabel bytes per second
-    graph_info Oracle Sysstat Network Send/Receive Bytes
+    graph_info Oracle Sysstat I/O Network Bytes
 "
 data_attrs[$key]="
     bytes_sent_via_sql_net_to_client       DERIVE LINE bytes sent via SQL*Net to client
@@ -314,25 +370,73 @@ global_attrs[$key]="
     graph_info Oracle Memory PGA
 "
 data_attrs[$key]="
-    pga_target    GAUGE LINE aggregate PGA auto target
-    pga_allocated GAUGE LINE total PGA allocated
-    pga_inuse     GAUGE AREA total PGA inuse
+    pga_target       GAUGE LINE aggregate PGA target parameter
+    pga_auto_target  GAUGE LINE aggregate PGA auto target
+    pga_allocated    GAUGE LINE total PGA allocated
+    pga_inuse        GAUGE AREA total PGA inuse
 "
 getvalue_func[$key]=getvalue_pgastat
 
+key=cputime
+global_attrs[$key]="
+    graph_title Oracle CPU Time
+    graph_category db
+    graph_args --base 1000 --lower-limit 0 --rigid
+    graph_vlabel seconds
+    graph_info Oracle CPU Time
+"
+data_attrs[$key]="
+    db_time                                        DERIVE LINE2 DB time
+    db_cpu                                         DERIVE LINE2 DB CPU
+    background_elapsed_time                        DERIVE LINE2 background elapsed time
+    background_cpu_time                            DERIVE LINE2 background cpu time
+    connection_management_call_elapsed_time        DERIVE LINE  connection management call elapsed time
+    sequence_load_elapsed_time                     DERIVE LINE  sequence load elapsed time
+    sql_execute_elapsed_time                       DERIVE LINE  sql execute elapsed time
+    parse_time_elapsed                             DERIVE LINE  parse time elapsed
+    hard_parse_elapsed_time                        DERIVE LINE  hard parse elapsed time
+    hard_parse_sharing_criteria_elapsed_time       DERIVE LINE  hard parse (sharing criteria) elapsed time
+    hard_parse_bind_mismatch_elapsed_time          DERIVE LINE  hard parse (bind mismatch) elapsed time
+    failed_parse_elapsed_time                      DERIVE LINE  failed parse elapsed time
+    failed_parse_out_of_shared_memory_elapsed_time DERIVE LINE  failed parse (out of shared memory) elapsed time
+    pl_sql_execution_elapsed_time                  DERIVE LINE  PL/SQL execution elapsed time
+    inbound_pl_sql_rpc_elapsed_time                DERIVE LINE  inbound PL/SQL rpc elapsed time
+    pl_sql_compilation_elapsed_time                DERIVE LINE  PL/SQL compilation elapsed time
+    java_execution_elapsed_time                    DERIVE LINE  Java execution elapsed time
+    repeated_bind_elapsed_time                     DERIVE LINE  repeated bind elapsed time
+    rman_cpu_time_backup_restore                   DERIVE LINE  RMAN cpu time (backup/restore)
+"
+getvalue_func[$key]=getvalue_cputime
+
 key=cachehit
+# buf_hitratio = 1 - physical_reads / ( db_block_gets + consistent_gets )
+# lib_hitratio = 1 - reloads / pins
+# dic_hitratio = ( gets - misses ) / gets
 global_attrs[$key]="
     graph_title Oracle Cache Hit Ratio
     graph_category db
     graph_args --base 1000 --lower-limit 0 --upper-limit 100 --rigid
     graph_vlabel %
-    graph_info Oracle Cache Hit Ratio
+    graph_info Oracle Cache Hit Ratio - The graph shows cache hit ratio between munin-update intervals (5 minutes in most cases).
     graph_scale no
+
+    $( for field in buf_physical buf_logical lib_pins lib_reloads dic_gets dic_getmisses
+       do
+           echo "${field}.graph no"
+           echo "${field}.type DERIVE"
+           echo "${field}.min 0"
+           echo "${field}.label ${field}"
+       done
+    )
+
+    buf_hitratio.cdef 100,1,buf_physical,buf_logical,/,-,*,FLOOR
+    lib_hitratio.cdef 100,1,lib_reloads,lib_pins,/,-,*,FLOOR
+    dic_hitratio.cdef 100,dic_gets,dic_getmisses,-,dic_gets,/,*,FLOOR
 "
 data_attrs[$key]="
-    buf_hitratio  GAUGE LINE Buffer Cache Hit Ratio
-    lib_hitratio  GAUGE LINE Library Cache Hit Ratio
-    dict_hitratio GAUGE LINE Dictionary Cache Hit Ratio
+    buf_hitratio GAUGE LINE Buffer Cache Hit Ratio
+    lib_hitratio GAUGE LINE Library Cache Hit Ratio
+    dic_hitratio GAUGE LINE Dictionary Cache Hit Ratio
 "
 getvalue_func[$key]=getvalue_cachehit
 
@@ -366,7 +470,7 @@ global_attrs[$key]="
     graph_category db
     graph_args --base 1000 --lower-limit 0 --rigid
     graph_vlabel microseconds
-    graph_info Oracle Wait Events
+    graph_info Oracle Wait Events - It may looks wierd that Y-axis indicates 'microseconds per second'. Although number of times of wait event looks easier to understand, in many cases the number of events does not matter, but wait time become more important to analyze bottle necks.
 "
 data_attrs[$key]=""
 getfield_func[$key]=getfield_eventwait
@@ -383,6 +487,18 @@ global_attrs[$key]="
 data_attrs[$key]=""
 getfield_func[$key]="getfield_eventwait2 Application"
 getvalue_func[$key]="getvalue_eventwait2 Application"
+
+key=eventwaitnetwork
+global_attrs[$key]="
+    graph_title Oracle Wait Events Network
+    graph_category db
+    graph_args --base 1000 --lower-limit 0 --rigid
+    graph_vlabel microseconds
+    graph_info Oracle Wait Events Network
+"
+data_attrs[$key]=""
+getfield_func[$key]="getfield_eventwait2 Network"
+getvalue_func[$key]="getvalue_eventwait2 Network"
 
 key=eventwaitconcurrency
 global_attrs[$key]="
@@ -433,6 +549,30 @@ data_attrs[$key]=" "
 getfield_func[$key]="getfield_eventwait2 Cluster"
 getvalue_func[$key]="getvalue_eventwait2 Cluster"
 
+key=eventwaitadministrative
+global_attrs[$key]="
+    graph_title Oracle Wait Events Administrative
+    graph_category db
+    graph_args --base 1000 --lower-limit 0 --rigid
+    graph_vlabel microseconds
+    graph_info Oracle Wait Events Administrative
+"
+data_attrs[$key]=" "
+getfield_func[$key]="getfield_eventwait2 Administrative"
+getvalue_func[$key]="getvalue_eventwait2 Administrative"
+
+key=eventwaitconfiguration
+global_attrs[$key]="
+    graph_title Oracle Wait Events Configuration
+    graph_category db
+    graph_args --base 1000 --lower-limit 0 --rigid
+    graph_vlabel microseconds
+    graph_info Oracle Wait Events Configuration
+"
+data_attrs[$key]=" "
+getfield_func[$key]="getfield_eventwait2 Configuration"
+getvalue_func[$key]="getvalue_eventwait2 Configuration"
+
 key=tablespace
 global_attrs[$key]="
     graph_title Oracle Table Space Usage
@@ -466,6 +606,7 @@ getvalue_func[$key]=getvalue_asmusage
 # sqlplus options
 : "${sqlplus:=sqlplus -S -L}"
 sqlplus_variables="
+    whenever sqlerror exit sql.sqlcode
     set pagesize 0
     set feed off
     set head off
@@ -484,10 +625,13 @@ autoconf() {
 }
 
 suggest() {
+    # print hash keys as available module names
     echo "${!global_attrs[@]}" | tr ' ' '\n' | sort
 }
 
 config() {
+    local label_max_length=45
+
     # print global attributes
     sed -e 's/^  *//' -e '/^$/d' <<< "${global_attrs[$module]}"
 
@@ -496,12 +640,15 @@ config() {
     local fields field type draw label
     while read -r field type draw label
     do
-        [ -z "$field" ] && continue
-        fields="${fields} ${field}"
+        [ -z "${field:-}" ] && continue
+        fields="${fields:-} ${field}"
 
-        echo "${field}.type"  "$type"
-        echo "${field}.draw"  "$draw"
-        echo "${field}.label" "$label"
+        echo "${field}.type ${type}"
+        echo "${field}.draw ${draw}"
+        echo "${field}.label ${label:0:${label_max_length}}"
+        if [ "${type}" = DERIVE ]; then
+            echo "${field}.min 0"
+        fi
     done <<< "${data_attrs[$module]}"
 
     echo graph_order "$fields"
@@ -531,7 +678,7 @@ getvalue_sysstat() {
     do
         [ -z "$field" ] && continue
 
-        ${sqlplus} "${oracle_auth}" <<EOF
+        cat <<EOF
 ${sqlplus_variables}
 VAR vf VARCHAR2(64)
 VAR vl VARCHAR2(64)
@@ -544,7 +691,7 @@ FROM
 WHERE
   name = :vl;
 EOF
-    done <<< "${data_attrs[$module]}"
+    done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
 }
 
 getvalue_sgainfo() {
@@ -553,7 +700,7 @@ getvalue_sgainfo() {
     do
         [ -z "$field" ] && continue
 
-        ${sqlplus} "${oracle_auth}" <<EOF
+        cat <<EOF
 ${sqlplus_variables}
 VAR vf VARCHAR2(64)
 VAR vl VARCHAR2(64)
@@ -566,7 +713,7 @@ FROM
 WHERE
   name = :vl;
 EOF
-    done <<< "${data_attrs[$module]}"
+    done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
 }
 
 getvalue_pgastat() {
@@ -575,7 +722,7 @@ getvalue_pgastat() {
     do
         [ -z "$field" ] && continue
 
-        ${sqlplus} "${oracle_auth}" <<EOF
+        cat <<EOF
 ${sqlplus_variables}
 VAR vf VARCHAR2(64)
 VAR vl VARCHAR2(64)
@@ -588,36 +735,57 @@ FROM
 WHERE
   name = :vl;
 EOF
-    done <<< "${data_attrs[$module]}"
+    done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
+}
+
+getvalue_cputime() {
+    local field type draw label
+    while read -r field type draw label
+    do
+        [ -z "$field" ] && continue
+
+        cat <<EOF
+${sqlplus_variables}
+VAR vf VARCHAR2(64)
+VAR vl VARCHAR2(64)
+EXEC :vf := '${field}' 
+EXEC :vl := '${label}' 
+SELECT
+  :vf || '.value ' || ROUND( value / 1000000 )
+FROM
+  v\$sys_time_model
+WHERE
+  stat_name = :vl;
+EOF
+    done <<< "${data_attrs[$module]}" | ${sqlplus} "${oracle_auth}"
 }
 
 getvalue_cachehit() {
     ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
 SELECT
-  'buf_hitratio.value ' || ROUND( ( 1 - a.value / ( b.value + c.value ) ) * 100 )
+  'buf_physical.value ' || value
 FROM
-  v\$sysstat a, v\$sysstat b, v\$sysstat c
+  v\$sysstat
 WHERE
-  a.name = 'physical reads' AND
-  b.name = 'db block gets' AND
-  c.name = 'consistent gets'
+  name = 'physical reads cache'
 ;
-SELECT
-  'lib_hitratio.value ' || ROUND( SUM(pins) / ( SUM(pins) + SUM(reloads) ) * 100 )
-FROM
-  v\$librarycache
+SELECT 
+  'buf_logical.value ' || ( sd.value + sc.value )
+FROM 
+  v\$sysstat sd, v\$sysstat sc 
+WHERE 
+  sd.name = 'db block gets from cache' AND sc.name = 'consistent gets from cache'
 ;
-SELECT
-  'dict_hitratio.value ' || ROUND( ( 1 - SUM(getmisses) / SUM(gets) ) * 100 )
-FROM
-  v\$rowcache
-;
+SELECT 'lib_pins.value '    || SUM(pins)    FROM v\$librarycache;
+SELECT 'lib_reloads.value ' || SUM(reloads) FROM v\$librarycache;
+SELECT 'dic_gets.value '      || SUM(gets)      FROM v\$rowcache;
+SELECT 'dic_getmisses.value ' || SUM(getmisses) FROM v\$rowcache;
 EOF
 }
 
 getfield_sessionuser() {
-    data_attrs[$module]="$( ${sqlplus} "${oracle_auth}" <<EOF
+    data_attrs[$module]=$( ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
 SELECT
   REGEXP_REPLACE( username, '^[^A-Za-z_]|[^A-Za-z0-9_]', '_' ) ||
@@ -629,7 +797,7 @@ WHERE
 ORDER BY
   username;
 EOF
-)"
+)
 }
 
 getvalue_sessionuser() {
@@ -655,8 +823,9 @@ EOF
 }
 
 getfield_sessionwait() {
-    data_attrs[$module]="$( ${sqlplus} "${oracle_auth}" <<EOF
+    data_attrs[$module]=$( ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
+SELECT 'CPU GAUGE AREASTACK CPU' from dual;
 SELECT
   REGEXP_REPLACE( wait_class, '^[^A-Za-z_]|[^A-Za-z0-9_]', '_' ) ||
   ' GAUGE AREASTACK ' || wait_class
@@ -671,12 +840,19 @@ ORDER BY
 SELECT 'Other GAUGE AREASTACK Other' from dual;
 SELECT 'Idle  GAUGE AREASTACK Idle' from dual;
 EOF
-)"
+)
 }
 
 getvalue_sessionwait() {
     ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
+SELECT
+  'CPU.value ' || count(wait_class)
+FROM
+  v\$session
+WHERE
+  wait_time != 0
+;
 SELECT
   REGEXP_REPLACE( en.wait_class, '^[^A-Za-z_]|[^A-Za-z0-9_]', '_' ) || '.value ' ||
   count(se.wait_class)
@@ -691,14 +867,16 @@ FROM
   LEFT JOIN v\$session se
 ON
   en.wait_class = se.wait_class AND 
-  se.username is not null
+  se.username is not null AND
+  se.wait_time = 0
 GROUP BY
-  en.wait_class;
+  en.wait_class
+;
 EOF
 }
 
 getfield_eventwait() {
-    data_attrs[$module]="$( ${sqlplus} "${oracle_auth}" <<EOF
+    data_attrs[$module]=$( ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
 SELECT
   REGEXP_REPLACE( wait_class, '^[^A-Za-z_]|[^A-Za-z0-9_]', '_' ) ||
@@ -713,7 +891,7 @@ ORDER BY
   wait_class;
 SELECT 'Other DERIVE LINE Other' from dual;
 EOF
-)"
+)
 }
 
 getvalue_eventwait() {
@@ -743,13 +921,13 @@ EOF
 getfield_eventwait2() {
     local waitclass="$1"
 
-    data_attrs[$module]="$( ${sqlplus} "${oracle_auth}" <<EOF
+    data_attrs[$module]=$( ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
 VAR vl VARCHAR2(64)
 EXEC :vl := '${waitclass}' 
 SELECT
   REGEXP_REPLACE( name, '^[^A-Za-z_]|[^A-Za-z0-9_]', '_' ) ||
-  ' DERIVE LINE ' || SUBSTR( name, 1, 45 )
+  ' DERIVE LINE ' || name
 FROM
   v\$event_name 
 WHERE
@@ -757,7 +935,7 @@ WHERE
 ORDER BY
   name;
 EOF
-)"
+)
 }
 
 getvalue_eventwait2() {
@@ -780,7 +958,7 @@ EOF
 }
 
 getfield_tablespace() {
-    data_attrs[$module]="$( ${sqlplus} "${oracle_auth}" <<EOF
+    data_attrs[$module]=$( ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
 SELECT
   REGEXP_REPLACE( tablespace_name, '^[^A-Za-z_]|[^A-Za-z0-9_]', '_' ) ||
@@ -790,7 +968,7 @@ FROM
 ORDER BY
   tablespace_name;
 EOF
-)"
+)
 }
 
 getvalue_tablespace() {
@@ -822,7 +1000,7 @@ EOF
 }
 
 getfield_asmusage() {
-    data_attrs[$module]="$( ${sqlplus} "${oracle_auth}" <<EOF
+    data_attrs[$module]=$( ${sqlplus} "${oracle_auth}" <<EOF
 ${sqlplus_variables}
 SELECT
   REGEXP_REPLACE( name, '^[^A-Za-z_]|[^A-Za-z0-9_]', '_' ) ||
@@ -832,7 +1010,7 @@ FROM
 ORDER BY
   name;
 EOF
-)"
+)
 }
 
 getvalue_asmusage() {


### PR DESCRIPTION
I updated oracle_sysstat_ plugin. I have tested it in a few days and it looks working fine. Please consider this pullreq.

* Add modules
  logon
  cputime
  blockrw
  redosize
  eventwaitnetwork
  eventwaitadministrative
  eventwaitconfiguration

* Update modules
  cachehit: Changed to calculate hit ratio between munin-node update intervals by CDEF
  sessionwait: Add CPU status, Add graph_info
  table_fetch: Add table_fetch_continued_row field
  pgastat: Add aggregate PGA target parameter field

* Improvement
  Change not to execute sqlplus in for loop in getvalue funcs to improve performance
  Change to add field.min 0 when type is DERIVE
  Add label_max_length in config() to suppress new line in graph image
  Change graph_title for sorting

* Fix styles
  Enable set -o nounset
  Add double quote to suppress shellcheck warning
  Change some quote styles
  Remove meaningless double quote around $( )
  Add whenever sqlerror exit sql.sqlcode