### PR TITLE
dont waste time by retrieving per script stats

### DIFF
--- a/plugins/php/php_opcache.php
+++ b/plugins/php/php_opcache.php
@@ -5,7 +5,7 @@
 
 if (function_exists('opcache_get_status')) 
 {
-	$data = opcache_get_status();
+	$data = opcache_get_status(false);
 	$output = array(
 		'mem_used.value' => $data['memory_usage']['used_memory'],
 		'mem_free.value' => $data['memory_usage']['free_memory'],


### PR DESCRIPTION
as per http://php.net/opcache_get_status passing false to `opcache_get_status()` will reduce unnecessary generation of per scripts stats data.