### PR TITLE
Http load  fix long domains

### DIFF
--- a/plugins/http/http_load_
+++ b/plugins/http/http_load_
@@ -170,14 +170,23 @@ sub get_cache_file_name{
 	return $file;
 }
 
-# Get fieldname (making sure it is munin "compatible" as a fieldname)
+# Get fieldname (making sure it is munin-1.0 "compatible" as a fieldname)
 # 1. Remove all non-word characters from a string)
 # 2. Make sure it has maximum 19 characters
+#    2.1 If not, truncate the host part, while keeping anything after an underscore (e.g., HTTP response status)
 sub get_fieldname{
 	my $url=$_[0];
 	$url =~ s/\W//g;
 	if(length($url) > 19){
-		$url =  substr($url, 0, 19);
+		$url =~ s/(\S+)_(\S+)/ /g;
+		my $host = $1;
+		my $info = $2;
+		my $suffixlength = length($info) + 1;
+		if ($suffixlength > 1) {
+			$url = substr($host, 0, 19 - $suffixlength) . '_' . $info;
+		} else {
+			$url = substr($url, 0, 19);
+		}
 	}
 	return $url;
 }


### PR DESCRIPTION
Munin 1.0 supports fieldnames of at most 19 characters. For domain names
longer than that, this plugin simply truncate the names in its own cache
down to 19.

This creates an issue with the `response` graph, which appends the HTTP
status code to the hostname to make multiple variables. Truncating to
this string loses this information, leading to an empty graph.
