### PR TITLE
wordpress-multisite: wrong variable name

### DIFF
--- a/plugins/other/wordpress-multisite
+++ b/plugins/other/wordpress-multisite
@@ -46,7 +46,7 @@ DB_OPTIONS=${mysqlopts}
 DB_CONNECTION=${mysqlconnection:--hlocalhost}
 DB_NAME=${database}
 DB_PREFIX=${dbprefix:-wp_}
-NETWORK_SIZE=${network_size:-2}
+NETWORK_SIZE=${networksize:-2}
 
 MYSQL_CMD=$(which mysql)
 


### PR DESCRIPTION
The variable NETWORK_SIZE was filled by network_size if declared. But documentation said that the other variable was called networksize. Changed it to the latter.

(Hope this is the right place after the old pull request was done?)