### PR TITLE
Correctly detect the Routing Engines on Virtual Chassis

### DIFF
--- a/plugins/snmp/snmp__juniper
+++ b/plugins/snmp/snmp__juniper
@@ -109,8 +109,7 @@ class JunOSSnmpClient(object):
 				if not str(name).startswith(jnxOperatingTable):
 					continue
 
-				# TODO: Find a better way to get the routing engines in a cluster
-				if str(value).endswith(' Routing Engine'):
+				if 'Routing Engine' in str(value):
 					devices[str(name)[len(jnxOperatingTable):]] = re.sub("[^\w]", '_', str(value).replace(' Routing Engine', ''))
 		return devices
 


### PR DESCRIPTION
The current recommended firmware for EX3400 (JUNOS 15.1X53-D55.5) lists the routing engines as 'Routing engine <member id>' when the switches are stacked in a Virtual Chassis.
The former code failed to detect these strings, so I relaxed it a bit.
This matches the documentation found here: https://kb.juniper.net/InfoCenter/index?page=content&id=KB17526&actp=search