### PR TITLE
Category Tree: Reduce number of categories

### DIFF
--- a/plugins/disk/disk-io-multigraph-munin-plugin
+++ b/plugins/disk/disk-io-multigraph-munin-plugin
@@ -1,2 +1,20 @@
-Check http://aouyar.github.com/PyMunin/ to get the most recent versionof the 
+graph_category other
+
+=head1 NAME
+
+PyMunin - Multigraph Plugins using Python
+
+=head1 DESCRIPTION
+
+Check http://aouyar.github.com/PyMunin/ to get the most recent version of the
 PyMunin Multi graph Munin Plugins and documentation.
+
+=head1 AUTHOR
+
+PyMunin has been developed by Ali Onur Uyar (https://github.com/aouyar)).
+
+=head1 LICENSE
+
+PyMunin is copyrighted free software made available under the terms of the GPL License Version 3 or later.
+
+=cut

--- a/plugins/http/http_load_
+++ b/plugins/http/http_load_
@@ -93,7 +93,6 @@ my $debug=0;
 my $timeout=10;
 my $max_redirects=10;
 my $scriptname="http_load_";
-my $category="network"; # The munin graph category
 my $useragent="Mozilla/5.0";
 
 # Function to read the $url_file and return the contents in a hash
@@ -361,7 +360,7 @@ if($ARGV[0] and $ARGV[0] eq "autoconf") {
 	
         print "graph_title $urls{$id} ${type}\n";
         print "graph_args -l 0 --base 1000\n";
-        print "graph_category " . $category . "\n";
+        print "graph_category webserver\n";
 	$debug && print "Reading cache file\n";
 	my $cachefile=$cachedir . "/" . &get_cache_file_name($scriptname,$id,$type);
 	my %cache=read_cache($cachefile);

--- a/plugins/http/http_request_time
+++ b/plugins/http/http_request_time
@@ -110,7 +110,7 @@ if ( defined $ARGV[0] and $ARGV[0] eq "config" )
 	print "graph_title HTTP(S) Request response times\n";
 	print "graph_args --base 1000\n";
 	print "graph_vlabel response time in ms\n";
-	print "graph_category other\n";
+	print "graph_category webserver\n";
 
 	my @go;
 	foreach my $name (keys %URLS) {
@@ -130,7 +130,7 @@ if ( defined $ARGV[0] and $ARGV[0] eq "config" )
 		print "graph_title $$url{'url'}\n";
 		print "graph_args --base 1000\n";
 		print "graph_vlabel response time in ms\n";
-		print "graph_category other\n";
+		print "graph_category webserver\n";
 		print "$name.label $$url{'label'}\n";
 		print "$name.info The response time of a single request\n";
 		print "$name.min 0\n";

--- a/plugins/mail/postfix_mail_stats
+++ b/plugins/mail/postfix_mail_stats
@@ -38,6 +38,7 @@ if [ "$1" = "config" ]; then
         echo 'graph_title Postfix Mail Counter'
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel Hourly Messages'
+        echo 'graph_category mail'
         echo 'received.label Delivered'
         echo 'sent.label Outgoing'
         echo 'rejecthelo.label Invalid HELO'

--- a/plugins/memcached/memcached_multi_
+++ b/plugins/memcached/memcached_multi_
@@ -183,7 +183,7 @@ $graphs{items} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Items in Memcached',
-        category => 'memcached global items',
+        category => 'memcached',
         title => 'Items',
         info => 'Number of items in use by memcached',
     },
@@ -197,7 +197,7 @@ $graphs{memory} = {
     config => {
         args => '--base 1024 --lower-limit 0',
         vlabel => 'Bytes Used',
-        category => 'memcached global memory',
+        category => 'memcached',
         title => 'Memory Usage',
         info => 'Memory consumption of memcached',
     },
@@ -244,7 +244,7 @@ $graphs{commands} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Commands per ${graph_period}',
-        category => 'memcached global commands',
+        category => 'memcached',
         title => 'Commands',
         info => 'Number of commands being handled by memcached',
     },
@@ -290,7 +290,7 @@ $graphs{evictions} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Evictions per ${graph_period}',
-        category => 'memcached global evictions',
+        category => 'memcached',
         title => 'Evictions',
         info => 'Number of evictions per second',
     },
@@ -308,7 +308,7 @@ $graphs{unfetched} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Unfetched Items per ${graph_period}',
-        category => 'memcached global unfetched',
+        category => 'memcached',
         title => 'Unfetched Items',
         info => 'Number of items that were never touched get/incr/append/etc before X occurred',
     },
@@ -324,7 +324,7 @@ $graphs{slabchnks} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Available Chunks for this Slab',
-        category => 'memcached slab chunk usage',
+        category => 'memcached',
         title => 'Chunk Usage for Slab: ',
         info => 'This graph shows you the chunk usage for this memory slab.',
     },
@@ -339,7 +339,7 @@ $graphs{slabhits} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Hits per Slab per ${graph_period}',
-        category => 'memcached slab commands',
+        category => 'memcached',
         title => 'Hits for Slab: ',
         info => 'This graph shows you the successful hit rate for this memory slab.',
     },
@@ -359,7 +359,7 @@ $graphs{slabevics} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Evictions per Slab per ${graph_period}',
-        category => 'memcached slab evictions',
+        category => 'memcached',
         title => 'Evictions for Slab: ',
         info => 'This graph shows you the eviction rate for this memory slab.',
     },
@@ -377,7 +377,7 @@ $graphs{slabevictime} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => ' since Request for LEI',
-        category => 'memcached slab eviction time',
+        category => 'memcached',
         title => 'Eviction Request Time for Slab: ',
         info => 'This graph shows you the time since we requested the last evicted item',
     },
@@ -391,7 +391,7 @@ $graphs{slabitems} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Items per Slab',
-        category => 'memcached slab item count',
+        category => 'memcached',
         title => 'Items in Slab: ',
         info => 'This graph shows you the number of items and reclaimed items per slab.',
     },
@@ -405,7 +405,7 @@ $graphs{slabitemtime} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => ' since item was stored',
-        category => 'memcached slab item age',
+        category => 'memcached',
         title => 'Age of Eldest Item in Slab: ',
         info => 'This graph shows you the time of the eldest item in this slab',
     },
@@ -418,7 +418,7 @@ $graphs{slabunfetched} = {
     config => {
         args => '--base 1000 --lower-limit 0',
         vlabel => 'Unfetched Items per ${graph_period}',
-        category => 'memcached slab unfetched',
+        category => 'memcached',
         title => 'Unfetched Items in Slab: ',
         info => 'Number of items that were never touched get/incr/append/etc before X occurred',
     },

--- a/plugins/minecraft/minecraft-users-ram_
+++ b/plugins/minecraft/minecraft-users-ram_
@@ -8,6 +8,7 @@ MC_PORT=${0##*_}
 if [ "$1" = "config" ]
 then
     printf 'graph_title Minecraft-Server (Port %s)\n' ${MC_PORT}
+    printf 'graph_catecory games'
     printf 'graph_vlabel Anzahl\n'
     printf 'users.label Benutzer\n'
     printf 'ramusage.label Verwendeter RAM in GiB\n'

--- a/plugins/modem/cisco-epc3010_
+++ b/plugins/modem/cisco-epc3010_
@@ -58,7 +58,7 @@ config)
   if [ $DIRECTION == "downstream" ]; then
     printf "graph_title Cisco EPC3010 Downstream measurements\n";
     printf "graph_args -l 0 --base 1000\n"
-    printf "graph_category other\n"
+    printf "graph_category sensors\n"
     printf "graph_vlabel Small number is Power Level, large number is SNR\n"
     printf "graph_info Downstream Signal to Noise Ratio (dB) and Power Level (dBmV) from Cisco EPC3010 modem. Info is scraped from statuspage on the modem (http://192.168.100.1)\n"
     printf "channel_1_pwr.label Channel 1 (dBmV)\n"
@@ -98,7 +98,7 @@ config)
   if [ "$DIRECTION" == "upstream" ]; then
     printf "graph_title Cisco EPC3010 Upstream measurements\n"
     printf "graph_args -l 30 --base 1000\n"
-    printf "graph_category other\n"
+    printf "graph_category sensors\n"
     printf "graph_vlabel Power level in dBmV\n"
     printf "graph_info Upstream Power Levels from Cisco EPC3010 modem,scraped from its statuspage (http://192.168.100.1)\n"
     printf "channel_1_pwr.label Channel 1 (dBmV)\n"

--- a/plugins/network/dns/dnsresponse_
+++ b/plugins/network/dns/dnsresponse_
@@ -66,7 +66,7 @@ if ( defined $ARGV[0] and $ARGV[0] eq "config" ) {
 	print "graph_title $dnsip DNS response time\n";
 	print "graph_vlabel milliseconds\n";
 	print "graph_scale no\n";
-	print "graph_category Other\n";
+	print "graph_category dns\n";
 	print "graph_info Time taken by $dnsip to resolve $site $times times.\n";
 	#my @val = ("min", "avg", "median", "max");
 	my @val = ("avg", "median", "stddev");

--- a/plugins/nginx/nginx_byprojects/byprojects_access
+++ b/plugins/nginx/nginx_byprojects/byprojects_access
@@ -56,7 +56,7 @@ if(defined($ARGV[0])) {
     print "graph_title $server access byprojects\n";
     print "graph_total Total\n";
     print "graph_vlabel Access by \${graph_period}\n";
-    print "graph_category $server\n";
+    print "graph_category webserver\n";
     print "graph_info This graph show $server access by various projects.\n";
     while ((my $project, my @files) = each(%logs)) {
       print $project.".label $project\n";

--- a/plugins/nginx/nginx_byprojects/byprojects_bandwidth
+++ b/plugins/nginx/nginx_byprojects/byprojects_bandwidth
@@ -63,7 +63,7 @@ if(defined($ARGV[0])) {
     print "graph_title $server total bandwidth byprojects\n";
     print "graph_total Total\n";
     print "graph_vlabel Bits\n";
-    print "graph_category $server\n";
+    print "graph_category webserver\n";
     print "graph_info This graph show $server total bandwidth used by various " .
       "projects.\n";
     while ((my $project, my @files) = each(%logs)) {

--- a/plugins/nginx/nginx_byprojects/byprojects_inout_bandwidth
+++ b/plugins/nginx/nginx_byprojects/byprojects_inout_bandwidth
@@ -60,7 +60,7 @@ if(defined($ARGV[0])) {
     print "graph_title $server in/out bandwidth byprojects\n";
     print "graph_args --base 1000\n";
     print "graph_vlabel bits per \${graph_period} in (-) / out (+)\n";
-    print "graph_category $server\n";
+    print "graph_category webserver\n";
     print "graph_info This graph show $server in/out bandwidth used by various" .
       " projects.\n";
     while ((my $project, my @files) = each(%logs)) {


### PR DESCRIPTION
Review of "other" plugins. If the gallery build script doesn't find pure string graph_category some-category the plugin will be put into default category "other". With this commit, I fixed some of these.

Btw. We have to think about multi-plugins. The build script is at the time not able to handle multiple categories..

In this commit I made changes on one multi-plugin that defined sort of sub-categories referring all to "memcached". Therefore I set them all to their /top-category/ to reduce the number of categories we present per default in the Munin tree. If a user want's to have more or other categories shown in her/his Munin instance: set your own categories for the plugins in Munin-Master configuration (Node-Tree of munin.conf)