### PR TITLE
fix crash if access.log is empty

### DIFF
--- a/plugins/nginx/nginx_error
+++ b/plugins/nginx/nginx_error
@@ -97,10 +97,12 @@ http_codes[503]='Service Unavailable'
 do_ () { # Fetch
   declare -A line_counts
   values=`awk '{print $9}' $log | sort | uniq -c`
-  while read -r line; do
-        read -a tmp <<< "$line";
-        line_counts[${tmp[1]}]=${tmp[0]};
-  done <<< "$values"
+  if [ -n "$values" ]; then
+    while read -r line; do
+      read -a tmp <<< "$line";
+      line_counts[${tmp[1]}]=${tmp[0]};
+    done <<< "$values"
+  fi
 
   for k in ${!http_codes[@]}; do
     echo "error$k.value ${line_counts[$k]:-0}"


### PR DESCRIPTION
If the only file found is empty (access.log with the default pattern), the following error happens:
```
/etc/munin/plugins/nginx_error: line 104: line_counts[${tmp[1]}]: bad array subscript
```
This patch will prevent the crash by testing if any values were found.