### PR TITLE
Fix inconsistent category order of varnish4_ plugin

### DIFF
--- a/plugins/varnish/varnish4_
+++ b/plugins/varnish/varnish4_
@@ -1081,7 +1081,7 @@ sub get_config
 		print_if_exist(\%ASPECTS,$graph,$field,"graph_$field");
 	}
 
-	foreach my $value (keys %values) {
+	foreach my $value (sort keys %values) {
 		# Just print the description/type if it's a dynamic
 		# counter. It'll be silent if it isn't.
 		if(print_dynamic($value,'.label',('description','type','ident'))) {


### PR DESCRIPTION
Varnish4_ plugin displays categories in an arbitrary order, changing
the colors of the graphs with each run.

This fix introduces a 'sort' statement in the category iteration function
to force the same order consistently.

Fixes issue #819