### PR TITLE
Use $MUNIN_PLUGSTATE instead of hardcoded path

### DIFF
--- a/plugins/ssh/openssh-denyhosts
+++ b/plugins/ssh/openssh-denyhosts
@@ -15,7 +15,7 @@ mktemp -t
 }       
 
 AUTH_LOG=${logfile:-/var/log/auth.log}
-STATEFILE=/var/lib/munin/plugin-state/sshd.offset
+STATEFILE=$MUNIN_PLUGSTATE/sshd.offset
 LOGTAIL=${logtail:-`which logtail`}
 
 if [ "$1" = "autoconf" ]; then


### PR DESCRIPTION
`/var/lib/munin/plugin-state` even doesn't exist on Ubuntu 16.04