### PR TITLE
graph_period for postfix_mailstats

### DIFF
--- a/plugins/postfix/postfix_mailstats
+++ b/plugins/postfix/postfix_mailstats
@@ -26,6 +26,7 @@
 #   group adm
 #   env.logdir /var/log
 #   env.logfile mail.log
+#   env.graph_period seconds #minute
 
 use strict;
 use warnings;
@@ -34,6 +35,7 @@ use Munin::Plugin;
 
 my $LOGDIR  = $ENV{'logdir'}  || '/var/log';
 my $LOGFILE = $ENV{'logfile'} || 'mail.log';
+my $graph_period = $ENV{'graph_period'} || 'seconds';
 my $logfile = $LOGDIR .'/'. $LOGFILE;
 
 my $delivered;
@@ -69,7 +71,7 @@ sub config
 {
     print "graph_title Postfix message throughput\n";
     print "graph_args --base 1000 -l 0\n";
-    print "graph_vlabel mails / \${graph_period}\n";
+    print "graph_vlabel mails / $graph_period\n";
     print "graph_scale  no\n";
     print "graph_total  Total\n";
     print "graph_category mail\n";


### PR DESCRIPTION
graph_period is now configurable for low-traffic systems.
also fixed issue with syntax for graph_period in config-function