### PR TITLE
Fix OpenWrt SNMP memory plugin

### DIFF
--- a/plugins/openwrt/snmp__memory_openwrt
+++ b/plugins/openwrt/snmp__memory_openwrt
@@ -1,76 +1,81 @@
-#!/usr/bin/perl -w
-#
-# Copyright (C) 2008 J.M.Roth
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; version 2 dated June,
-# 1991.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-#
-#
-# $Log$
-#
-# Inspired by snmp__processes
-#
-#%# family=snmpauto
-#%# capabilities=snmpconf
+#!/usr/local/bin/perl -w
+# -*- perl -*-
+# vim: ft=perl
+
+=head1 NAME
+
+snmp__memory_openwrt - Munin plugin to monitor the memory usage of an OpenWrt
+device.
+
+=head1 APPLICABLE SYSTEMS
+
+OpenWrt devices which have snmpd installed.
+
+=head1 CONFIGURATION
+
+As a rule SNMP plugins need site specific configuration.  The default
+configuration (shown here) will only work on insecure sites/devices.
+
+   [snmp_*]
+	env.version 2
+        env.community public
+
+In general SNMP is not very secure at all unless you use SNMP version
+3 which supports authentication and privacy (encryption).  But in any
+case the community string for your devices should not be "public".
+
+Please see 'perldoc Munin::Plugin::SNMP' for further configuration
+information.
+
+=head1 INTERPRETATION
+
+The total and used memory on the system.
+
+=head1 MIB INFORMATION
+
+This plugin requires support for the HOST-RESOURCES-MIB (RFC 2790).  It
+reports the contents of the hrStorageSize and hrStorageUsed OIDs.
+
+=head1 MAGIC MARKERS
+
+  #%# family=snmpauto
+  #%# capabilities=snmpconf
+
+=head1 VERSION
+
+  $Id$
+
+=head1 BUGS
+
+None known.
+
+=head1 AUTHOR
+
+Copyright (C) 2017 Hanson Wong
+
+Based on snmp__memory_openwrt (C) 2008 J.M.Roth
+
+=head1 LICENSE
+
+GPLv2.
+
+=cut
 
 use strict;
-use Net::SNMP;
+use Munin::Plugin::SNMP;
 
-my $DEBUG = 0;
-
-my $host      = $ENV{host}      || undef;
-my $port      = $ENV{port}      || 161;
-my $community = $ENV{community} || "public";
-my $iface     = $ENV{interface} || undef;
-
-my $response;
-
-if (defined $ARGV[0] and $ARGV[0] eq "snmpconf")
-{
-	print "require 1.3.6.1.2.1.25.2.3.1.5.2\n"; # Number
-	print "require 1.3.6.1.2.1.25.2.3.1.6.2\n"; # Number
+if (defined $ARGV[0] and $ARGV[0] eq 'snmpconf') {
+	print "require 1.3.6.1.2.1.25.2.3.1.5.1\n";
+	print "require 1.3.6.1.2.1.25.2.3.1.6.1\n";
 	exit 0;
 }
 
-my @split_result = split(/_/, $0);
-$host = $split_result[1];
-if ($host =~ /^([^:]+):(\d+)$/)
-{
-    $host = $1;
-    $port = $2;
-}
-if ($host eq '' || !defined $host)
-{
-	print "# Debug: $0 -- $1\n" if $DEBUG;
-	die "# Error: couldn't understand what I'm supposed to monitor.";
-}
+if (defined $ARGV[0] and $ARGV[0] eq "config") {
+	my ($host) = Munin::Plugin::SNMP->config_session();
 
-my ($session, $error) = Net::SNMP->session(
-		-hostname  => $host,
-		-community => $community,
-		-port      => $port
-	);
-
-if (!defined ($session))
-{
-	die "Croaking: $error";
-}
-
-if (defined $ARGV[0] and $ARGV[0] eq "config")
-{
-	print "host_name $host\n";
-	print "graph_title Memory usage
+	print "host_name $host\n" unless ($host eq 'localhost');
+	print <<'EOC';
+graph_title Memory usage
 graph_args --base 1000 -l 0 
 graph_vlabel kB
 graph_category memory
@@ -81,29 +86,10 @@ memsize.info The total memory.
 memused.info The memory in use.
 memsize.draw LINE1
 memused.draw LINE2
-";
-
+EOC
 	exit 0;
 }
 
-print "memsize.value ", &get_single ($session, "1.3.6.1.2.1.25.2.3.1.5.2"), "\n";
-print "memused.value ", &get_single ($session, "1.3.6.1.2.1.25.2.3.1.6.2"), "\n";
-
-sub get_single
-{
-	my $handle = shift;
-	my $oid    = shift;
-
-	print "# Getting single $oid...\n" if $DEBUG;
-
-	$response = $handle->get_request ($oid);
-
-	if (!defined $response->{$oid})
-	{
-	    return undef;
-	}
-	else
-	{
-	    return $response->{$oid};
-	}
-}
+my $session = Munin::Plugin::SNMP->session();
+print "memsize.value ", $session->get_single('1.3.6.1.2.1.25.2.3.1.5.1'), "\n";
+print "memused.value ", $session->get_single('1.3.6.1.2.1.25.2.3.1.6.1'), "\n";

--- a/plugins/openwrt/snmp__memory_openwrt
+++ b/plugins/openwrt/snmp__memory_openwrt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/env perl -w
 # -*- perl -*-
 # vim: ft=perl
 

--- a/plugins/openwrt/snmp__memory_openwrt
+++ b/plugins/openwrt/snmp__memory_openwrt
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # -*- perl -*-
 # vim: ft=perl
 

--- a/plugins/openwrt/snmp__memory_openwrt
+++ b/plugins/openwrt/snmp__memory_openwrt
@@ -16,8 +16,8 @@ OpenWrt devices which have snmpd installed.
 As a rule SNMP plugins need site specific configuration.  The default
 configuration (shown here) will only work on insecure sites/devices.
 
-   [snmp_*]
-	env.version 2
+    [snmp_*]
+        env.version 2
         env.community public
 
 In general SNMP is not very secure at all unless you use SNMP version
@@ -41,10 +41,6 @@ reports the contents of the hrStorageSize and hrStorageUsed OIDs.
   #%# family=snmpauto
   #%# capabilities=snmpconf
 
-=head1 VERSION
-
-  $Id$
-
 =head1 BUGS
 
 None known.
@@ -65,16 +61,16 @@ use strict;
 use Munin::Plugin::SNMP;
 
 if (defined $ARGV[0] and $ARGV[0] eq 'snmpconf') {
-	print "require 1.3.6.1.2.1.25.2.3.1.5.1\n";
-	print "require 1.3.6.1.2.1.25.2.3.1.6.1\n";
-	exit 0;
+    print "require 1.3.6.1.2.1.25.2.3.1.5.1\n";
+    print "require 1.3.6.1.2.1.25.2.3.1.6.1\n";
+    exit 0;
 }
 
 if (defined $ARGV[0] and $ARGV[0] eq "config") {
-	my ($host) = Munin::Plugin::SNMP->config_session();
+    my ($host) = Munin::Plugin::SNMP->config_session();
 
-	print "host_name $host\n" unless ($host eq 'localhost');
-	print <<'EOC';
+    print "host_name $host\n" unless ($host eq 'localhost');
+    print <<'EOC';
 graph_title Memory usage
 graph_args --base 1000 -l 0 
 graph_vlabel kB
@@ -87,7 +83,7 @@ memused.info The memory in use.
 memsize.draw LINE1
 memused.draw LINE2
 EOC
-	exit 0;
+    exit 0;
 }
 
 my $session = Munin::Plugin::SNMP->session();


### PR DESCRIPTION
Basically a rewrite of the existing plugin:
- Added documentation
- Updated to use Munin::Plugin::SNMP
- Fixed OID for snmpd on latest builds of OpenWrt/LEDE