### PR TITLE
Fixed output of transactions script

### DIFF
--- a/plugins/postgresql/postgresql_transactions
+++ b/plugins/postgresql/postgresql_transactions
@@ -40,4 +40,4 @@ if [ "$1" = "config" ]; then
    echo 'rollbacks.info Number of transaction rollbacks.'
    exit 0
 fi
-psql -h ${dbserver} -U ${dbuser} -tc "SELECT '\ncommits.value '||SUM(xact_commit)::TEXT || '\nrollbacks.value '||SUM(xact_rollback)::TEXT FROM pg_stat_database;"
+psql -h ${dbserver} -U ${dbuser} -tc "SELECT 'commits.value '||SUM(xact_commit)::TEXT||E'\nrollbacks.value '||SUM(xact_rollback)::TEXT FROM pg_stat_database;" --no-align


### PR DESCRIPTION
The current output of this script is:

```
root@master:/etc/munin/plugins# ./pg_transactions 
 \ncommits.value xxxx\nrollbacks.value xxxx
```

By removing the first `\n` and by adding an `E` before the second `\n` the output is:

```
root@master:/etc/munin/plugins# ./pg_transactions 
 commits.value xxxx +
 rollbacks.value xxxx
```

And lastly by adding the `--no-align` attribute you get the correct output:

```
root@master:/etc/munin/plugins# ./pg_transactions 
commits.value xxxx
rollbacks.value xxxx
```