### PR TITLE
Allow for _ in original dataset name

### DIFF
--- a/plugins/zfs/zfs_usage_
+++ b/plugins/zfs/zfs_usage_
@@ -160,6 +160,7 @@ sub do_collect {
 
     foreach my $line (split(/\n/, `$fsget` )) {
         my ($name, $key, $value, undef ) = (split(/\t/,$line));
+        ($name =~ s/_/__/g);
         ($name =~ s/\//_/g);
         $filesystems->{$name}->{$key}=$value;
     }
@@ -170,6 +171,7 @@ sub do_config_fs {
     my ($fs) = @_;
     my $fs_slash = ($fs);
     ($fs_slash =~ s/_/\//g);
+    ($fs_slash =~ s/\/\//_/g);
 
     if ( $fs ne $zpool ) {
         printf( "multigraph zfs_usage_%s.%s\n",


### PR DESCRIPTION
The current code escapes / (which is legal as part of a dataset name for ZFS, but illegal as part of a munin graph name) into _ (which is legal for both). The result is that any _ characters in the original filename get changed into / in the legend, which is confusing.

Fix by escaping any existing _ characters into __ first, and then later replacing // into _ again. // is a sequence that will not occur in a ZFS dataset name, so any double-/ sequence must therefore have been a _ originally.