### PR TITLE
Use pdns_control utility instead of pdns init script.

### DIFF
--- a/plugins/pdns/pdns_errors
+++ b/plugins/pdns/pdns_errors
@@ -9,11 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/etc/init.d/pdns dump"
+command="/usr/bin/pdns_control list"
 
 if [ "$1" = "autoconf" ]; then
-        echo yes
-        exit 0
+        if [ -e /usr/bin/pdns_control ]; then
+                echo yes
+                exit 0
+        else
+                echo no
+                exit 1
+        fi
 fi
 
 if [ "$1" = "config" ]; then

--- a/plugins/pdns/pdns_errors
+++ b/plugins/pdns/pdns_errors
@@ -9,15 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/usr/bin/pdns_control list"
+pdns_control="/usr/bin/pdns_control"
+command="$pdns_control list"
 
 if [ "$1" = "autoconf" ]; then
-        if [ -e /usr/bin/pdns_control ]; then
+        if [ -e "$pdns_control" ]; then
                 echo yes
                 exit 0
         else
-                echo no
-                exit 1
+                echo "no (missing $pdns_control)"
+                exit 0
         fi
 fi
 

--- a/plugins/pdns/pdns_errors
+++ b/plugins/pdns/pdns_errors
@@ -43,4 +43,4 @@ if [ "$1" = "config" ]; then
 fi
 
 
-$command | sed 's/=\([0-9]\+\),/.value \1\n/g' | grep corrupt'\|'servfail'\|'timedout | sed 's/-/_/g'
+$command | sed 's/=\([0-9]\+\),/.value \1\n/g' | egrep "corrupt|servfail|timedout" | sed 's/-/_/g'

--- a/plugins/pdns/pdns_latency
+++ b/plugins/pdns/pdns_latency
@@ -9,11 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/etc/init.d/pdns show"
+command="/usr/bin/pdns_control show"
 
 if [ "$1" = "autoconf" ]; then
-        echo yes
-        exit 0
+        if [ -e /usr/bin/pdns_control ]; then
+                echo yes
+                exit 0
+        else
+                echo no
+                exit 1
+        fi
 fi
 
 if [ "$1" = "config" ]; then
@@ -31,4 +36,4 @@ fi
 
 
 
-echo "latency.value $($command latency | awk -F= '{print $2}')"
+echo "latency.value $($command latency)"

--- a/plugins/pdns/pdns_latency
+++ b/plugins/pdns/pdns_latency
@@ -9,15 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/usr/bin/pdns_control show"
+pdns_control="/usr/bin/pdns_control"
+command="$pdns_control show"
 
 if [ "$1" = "autoconf" ]; then
-        if [ -e /usr/bin/pdns_control ]; then
+        if [ -e "$pdns_control" ]; then
                 echo yes
                 exit 0
         else
-                echo no
-                exit 1
+                echo "no (missing $pdns_control)"
+                exit 0
         fi
 fi
 

--- a/plugins/pdns/pdns_qsize
+++ b/plugins/pdns/pdns_qsize
@@ -9,11 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/etc/init.d/pdns show"
+command="/usr/bin/pdns_control show"
 
 if [ "$1" = "autoconf" ]; then
-        echo yes
-        exit 0
+        if [ -e /usr/bin/pdns_control ]; then
+                echo yes
+                exit 0
+        else
+                echo no
+                exit 1
+        fi
 fi
 
 if [ "$1" = "config" ]; then
@@ -31,5 +36,5 @@ fi
 
 
 
-echo "qsize.value $($command qsize_q | awk -F= '{print $2}')"
+echo "qsize.value $($command qsize-q)"
 

--- a/plugins/pdns/pdns_qsize
+++ b/plugins/pdns/pdns_qsize
@@ -9,15 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/usr/bin/pdns_control show"
+pdns_control="/usr/bin/pdns_control"
+command="$pdns_control show"
 
 if [ "$1" = "autoconf" ]; then
-        if [ -e /usr/bin/pdns_control ]; then
+        if [ -e "$pdns_control" ]; then
                 echo yes
                 exit 0
         else
-                echo no
-                exit 1
+                echo "no (missing $pdns_control)"
+                exit 0
         fi
 fi
 

--- a/plugins/pdns/pdns_queries
+++ b/plugins/pdns/pdns_queries
@@ -9,11 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/etc/init.d/pdns dump"
+command="/usr/bin/pdns_control list"
 
 if [ "$1" = "autoconf" ]; then
-        echo yes
-        exit 0
+        if [ -e /usr/bin/pdns_control ]; then
+                echo yes
+                exit 0
+        else
+                echo no
+                exit 1
+        fi
 fi
 
 if [ "$1" = "config" ]; then

--- a/plugins/pdns/pdns_queries
+++ b/plugins/pdns/pdns_queries
@@ -9,15 +9,16 @@
 #%# family=auto
 #%# capabilities=autoconf
 
+pdns_control="/usr/bin/pdns_control"
 command="/usr/bin/pdns_control list"
 
 if [ "$1" = "autoconf" ]; then
-        if [ -e /usr/bin/pdns_control ]; then
+        if [ -e "$pdns_control" ]; then
                 echo yes
                 exit 0
         else
-                echo no
-                exit 1
+                echo "no (missing $pdns_control)"
+                exit 0
         fi
 fi
 

--- a/plugins/pdns/pdns_queries
+++ b/plugins/pdns/pdns_queries
@@ -55,4 +55,4 @@ if [ "$1" = "config" ]; then
 fi
 
 
-$command | sed 's/=\([0-9]\+\),/.value \1\n/g' | grep udp-'\|'recursing'\|'tcp | sed 's/-/_/g'
+$command | sed 's/=\([0-9]\+\),/.value \1\n/g' | egrep "udp-|recursing|tcp" | sed 's/-/_/g'

--- a/plugins/pdns/pdns_rec_answers
+++ b/plugins/pdns/pdns_rec_answers
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -65,11 +67,11 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo a.value "$(rec_control get answers0-1)"
-echo b.value "$(rec_control get answers1-10)"
-echo c.value "$(rec_control get answers10-100)"
-echo d.value "$(rec_control get answers100-1000)"
-echo e.value "$(rec_control get answers-slow)"
-echo f.value "$(rec_control get outgoing-timeouts)"
+echo a.value "$($rec_control get answers0-1)"
+echo b.value "$($rec_control get answers1-10)"
+echo c.value "$($rec_control get answers10-100)"
+echo d.value "$($rec_control get answers100-1000)"
+echo e.value "$($rec_control get answers-slow)"
+echo f.value "$($rec_control get outgoing-timeouts)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_answers
+++ b/plugins/pdns/pdns_rec_answers
@@ -65,11 +65,11 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo a.value `rec_control get answers0-1`
-echo b.value `rec_control get answers1-10`
-echo c.value `rec_control get answers10-100`
-echo d.value `rec_control get answers100-1000`
-echo e.value `rec_control get answers-slow`
-echo f.value `rec_control get outgoing-timeouts`
+echo a.value "$(rec_control get answers0-1)"
+echo b.value "$(rec_control get answers1-10)"
+echo c.value "$(rec_control get answers10-100)"
+echo d.value "$(rec_control get answers100-1000)"
+echo e.value "$(rec_control get answers-slow)"
+echo f.value "$(rec_control get outgoing-timeouts)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_cache
+++ b/plugins/pdns/pdns_rec_cache
@@ -9,17 +9,19 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
-RESENDS="$(rec_control get cache-resends)"
+RESENDS="$($rec_control get cache-resends)"
 ISRESENDS=""
 [ "$RESENDS" != "UNKNOWN" ] && ISRESENDS="resends"
 
@@ -53,8 +55,8 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo hits.value "$(rec_control get cache-hits)"
-echo misses.value "$(rec_control get cache-misses)"
-[ "$RESENDS" != "UNKNOWN" ] && echo resends.value "$(rec_control get cache-resends)"
+echo hits.value "$($rec_control get cache-hits)"
+echo misses.value "$($rec_control get cache-misses)"
+[ "$RESENDS" != "UNKNOWN" ] && echo resends.value "$($rec_control get cache-resends)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_cache
+++ b/plugins/pdns/pdns_rec_cache
@@ -19,7 +19,7 @@ if [ "$1" = "autoconf" ]; then
 	fi
 fi
 
-RESENDS=`rec_control get cache-resends`
+RESENDS="$(rec_control get cache-resends)"
 ISRESENDS=""
 [ "$RESENDS" != "UNKNOWN" ] && ISRESENDS="resends"
 
@@ -53,8 +53,8 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo hits.value `rec_control get cache-hits`
-echo misses.value `rec_control get cache-misses`
-[ "$RESENDS" != "UNKNOWN" ] && echo resends.value `rec_control get cache-resends`
+echo hits.value "$(rec_control get cache-hits)"
+echo misses.value "$(rec_control get cache-misses)"
+[ "$RESENDS" != "UNKNOWN" ] && echo resends.value "$(rec_control get cache-resends)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_cache_size
+++ b/plugins/pdns/pdns_rec_cache_size
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -39,7 +41,7 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo entries.value "$(rec_control get cache-entries)"
-echo negative.value "$(rec_control get negcache-entries)"
+echo entries.value "$($rec_control get cache-entries)"
+echo negative.value "$($rec_control get negcache-entries)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_cache_size
+++ b/plugins/pdns/pdns_rec_cache_size
@@ -39,7 +39,7 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo entries.value `rec_control get cache-entries`
-echo negative.value `rec_control get negcache-entries`
+echo entries.value "$(rec_control get cache-entries)"
+echo negative.value "$(rec_control get negcache-entries)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_concurrent
+++ b/plugins/pdns/pdns_rec_concurrent
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -34,6 +36,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo concurrent.value "$(rec_control get concurrent-queries)"
+echo concurrent.value "$($rec_control get concurrent-queries)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_concurrent
+++ b/plugins/pdns/pdns_rec_concurrent
@@ -34,6 +34,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo concurrent.value `rec_control get concurrent-queries`
+echo concurrent.value "$(rec_control get concurrent-queries)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_issues
+++ b/plugins/pdns/pdns_rec_issues
@@ -59,10 +59,10 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo spoofs.value `rec_control get spoof-prevents`
-echo resource.value `rec_control get resource-limits`
-echo client.value `rec_control get client-parse-errors`
-echo server.value `rec_control get server-parse-errors`
-echo overflow.value `rec_control get tcp-client-overflow`
+echo spoofs.value "$(rec_control get spoof-prevents)"
+echo resource.value "$(rec_control get resource-limits)"
+echo client.value "$(rec_control get client-parse-errors)"
+echo server.value "$(rec_control get server-parse-errors)"
+echo overflow.value "$(rec_control get tcp-client-overflow)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_issues
+++ b/plugins/pdns/pdns_rec_issues
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -59,10 +61,10 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo spoofs.value "$(rec_control get spoof-prevents)"
-echo resource.value "$(rec_control get resource-limits)"
-echo client.value "$(rec_control get client-parse-errors)"
-echo server.value "$(rec_control get server-parse-errors)"
-echo overflow.value "$(rec_control get tcp-client-overflow)"
+echo spoofs.value "$($rec_control get spoof-prevents)"
+echo resource.value "$($rec_control get resource-limits)"
+echo client.value "$($rec_control get client-parse-errors)"
+echo server.value "$($rec_control get server-parse-errors)"
+echo overflow.value "$($rec_control get tcp-client-overflow)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_outqueries
+++ b/plugins/pdns/pdns_rec_outqueries
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -41,7 +43,7 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo all.value "$(rec_control get all-outqueries)"
-echo tcp.value "$(rec_control get tcp-outqueries)"
+echo all.value "$($rec_control get all-outqueries)"
+echo tcp.value "$($rec_control get tcp-outqueries)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_outqueries
+++ b/plugins/pdns/pdns_rec_outqueries
@@ -41,7 +41,7 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo all.value `rec_control get all-outqueries`
-echo tcp.value `rec_control get tcp-outqueries`
+echo all.value "$(rec_control get all-outqueries)"
+echo tcp.value "$(rec_control get tcp-outqueries)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_qtypes
+++ b/plugins/pdns/pdns_rec_qtypes
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -245,6 +247,6 @@ END {
 }
 '
 
-rec_control get-qtypelist | awk "$awkscript"
+"$rec_control" get-qtypelist | awk "$awkscript"
 
 exit 0

--- a/plugins/pdns/pdns_rec_querylatency
+++ b/plugins/pdns/pdns_rec_querylatency
@@ -34,6 +34,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo latency.value `rec_control get qa-latency`
+echo latency.value "$(rec_control get qa-latency)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_querylatency
+++ b/plugins/pdns/pdns_rec_querylatency
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -34,6 +36,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo latency.value "$(rec_control get qa-latency)"
+echo latency.value "$($rec_control get qa-latency)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_questions
+++ b/plugins/pdns/pdns_rec_questions
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -41,7 +43,7 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo all.value "$(rec_control get questions)"
-echo tcp.value "$(rec_control get tcp-questions)"
+echo all.value "$($rec_control get questions)"
+echo tcp.value "$($rec_control get tcp-questions)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_questions
+++ b/plugins/pdns/pdns_rec_questions
@@ -41,7 +41,7 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo all.value `rec_control get questions`
-echo tcp.value `rec_control get tcp-questions`
+echo all.value "$(rec_control get questions)"
+echo tcp.value "$(rec_control get tcp-questions)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_throttle
+++ b/plugins/pdns/pdns_rec_throttle
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -34,6 +36,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo throttled.value "$(rec_control get throttled-out)"
+echo throttled.value "$($rec_control get throttled-out)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_throttle
+++ b/plugins/pdns/pdns_rec_throttle
@@ -34,6 +34,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo throttled.value `rec_control get throttled-out`
+echo throttled.value "$(rec_control get throttled-out)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_unauth
+++ b/plugins/pdns/pdns_rec_unauth
@@ -47,8 +47,8 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo tcp.value `rec_control get unauthorized-tcp`
-echo udp.value `rec_control get unauthorized-udp`
-echo unexpected.value `rec_control get unexpected-packets`
+echo tcp.value "$(rec_control get unauthorized-tcp)"
+echo udp.value "$(rec_control get unauthorized-udp)"
+echo unexpected.value "$(rec_control get unexpected-packets)"
 
 exit 0

--- a/plugins/pdns/pdns_rec_unauth
+++ b/plugins/pdns/pdns_rec_unauth
@@ -9,13 +9,15 @@
 #    echo '[pdns_rec_*]' >/etc/munin/plugin-conf.d/pdns_rec
 #    echo 'user root' >>/etc/munin/plugin-conf.d/pdns_rec
 
+rec_control="/usr/bin/rec_control"
+
 if [ "$1" = "autoconf" ]; then
-	if [ -e /usr/bin/rec_control ]; then
+	if [ -e "$rec_control" ]; then
 		echo yes
 		exit 0
 	else
-		echo no
-		exit 1
+		echo "no (missing $rec_control)"
+		exit 0
 	fi
 fi
 
@@ -47,8 +49,8 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo tcp.value "$(rec_control get unauthorized-tcp)"
-echo udp.value "$(rec_control get unauthorized-udp)"
-echo unexpected.value "$(rec_control get unexpected-packets)"
+echo tcp.value "$($rec_control get unauthorized-tcp)"
+echo udp.value "$($rec_control get unauthorized-udp)"
+echo unexpected.value "$($rec_control get unexpected-packets)"
 
 exit 0

--- a/plugins/pdns/pdns_rel
+++ b/plugins/pdns/pdns_rel
@@ -9,16 +9,17 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/usr/bin/pdns_control show"
+pdns_control="/usr/bin/pdns_control"
+command="$pdns_control show"
 state_file=$MUNIN_PLUGSTATE/pdns_rel.state
 
 if [ "$1" = "autoconf" ]; then
-        if [ -e /usr/bin/pdns_control ]; then
+        if [ -e "$pdns_control" ]; then
                 echo yes
                 exit 0
         else
-                echo no
-                exit 1
+                echo "no (missing $pdns_control)"
+                exit 0
         fi
 fi
 

--- a/plugins/pdns/pdns_rel
+++ b/plugins/pdns/pdns_rel
@@ -9,12 +9,17 @@
 #%# family=auto
 #%# capabilities=autoconf
 
-command="/etc/init.d/pdns show"
+command="/usr/bin/pdns_control show"
 state_file=$MUNIN_PLUGSTATE/pdns_rel.state
 
 if [ "$1" = "autoconf" ]; then
-        echo yes
-        exit 0
+        if [ -e /usr/bin/pdns_control ]; then
+                echo yes
+                exit 0
+        else
+                echo no
+                exit 1
+        fi
 fi
 
 if [ "$1" = "config" ]; then
@@ -31,17 +36,19 @@ if [ "$1" = "config" ]; then
         exit 0
 fi
 
-hits=$($command packetcache-hit | awk -F= '{print $2}')
-queries=$($command udp-queries | awk -F= '{print $2}')
-old_hits=$(cat $state_file | head -n1)
-old_queries=$(cat $state_file | tail -n1)
+hits=$($command packetcache-hit)
+queries=$($command udp-queries)
+if [ -f $state_file ]; then
+        old_hits=$(cat $state_file | head -n1)
+        old_queries=$(cat $state_file | tail -n1)
+fi
 
 if [ -f $state_file ] && [ $(ls -l --time-style=+%s $state_file | awk '{print $6}') -gt $(date --date="7 minutes ago" +%s) ] ; then
-	d_hits=$(($hits - $old_hits))
-	d_queries=$(($queries - $old_queries))
-	if [ $d_queries -gt 0 ] ; then
-	   echo packetcache_hitrate.value $(( $d_hits * 100 / $d_queries ))
-	fi
+        d_hits=$(($hits - $old_hits))
+        d_queries=$(($queries - $old_queries))
+        if [ $d_queries -gt 0 ] ; then
+           echo packetcache_hitrate.value $(( $d_hits * 100 / $d_queries ))
+        fi
 fi
 
 echo $hits > $state_file

--- a/plugins/pdns/pdns_rel
+++ b/plugins/pdns/pdns_rel
@@ -38,18 +38,18 @@ fi
 
 hits=$($command packetcache-hit)
 queries=$($command udp-queries)
-if [ -f $state_file ]; then
-        old_hits=$(cat $state_file | head -n1)
-        old_queries=$(cat $state_file | tail -n1)
+if [ -f "$state_file" ]; then
+        old_hits=$(head -n1 "$state_file")
+        old_queries=$(tail -n1 "$state_file")
 fi
 
-if [ -f $state_file ] && [ $(ls -l --time-style=+%s $state_file | awk '{print $6}') -gt $(date --date="7 minutes ago" +%s) ] ; then
-        d_hits=$(($hits - $old_hits))
-        d_queries=$(($queries - $old_queries))
+if [ -f "$state_file" ] && [ "$(stat --format=%Y "$state_file")" -gt "$(date --date="7 minutes ago" +%s)" ] ; then
+        d_hits=$((hits - old_hits))
+        d_queries=$((queries - old_queries))
         if [ $d_queries -gt 0 ] ; then
-           echo packetcache_hitrate.value $(( $d_hits * 100 / $d_queries ))
+           echo packetcache_hitrate.value $(( d_hits * 100 / d_queries ))
         fi
 fi
 
-echo $hits > $state_file
-echo $queries >> $state_file
+echo "$hits" > "$state_file"
+echo "$queries" >> "$state_file"


### PR DESCRIPTION
The init script is not usable on systems using systemd (e.g. Debian stretch).

autoconf is also made conditional on the existence of the executable to not enable the plugin on systems where pdns is not installed.