### PR TITLE
Change commit and rollback types to "COUNTER"

### DIFF
--- a/plugins/postgresql/postgresql_transactions
+++ b/plugins/postgresql/postgresql_transactions
@@ -33,10 +33,12 @@ if [ "$1" = "config" ]; then
 
    echo 'commits.label commits'
    echo 'commits.min 0'
+   echo 'commits.type COUNTER'
    echo 'commits.info Number of transaction commits.'
 
    echo 'rollbacks.label rollbacks'
    echo 'rollbacks.min 0'
+   echo 'rollbacks.type COUNTER'
    echo 'rollbacks.info Number of transaction rollbacks.'
    exit 0
 fi


### PR DESCRIPTION
By doing this, Munin knows to take the difference of each request, thereby showing you a true commit and rollback "per minute"

Before:
![screen shot 2017-10-03 at 08 27 28](https://user-images.githubusercontent.com/1809451/31112577-c4be49ce-a814-11e7-94b4-6091b93837a0.png)

After:
![screen shot 2017-10-03 at 08 27 35](https://user-images.githubusercontent.com/1809451/31112581-ca95a34c-a814-11e7-925e-cb1208eb9c32.png)
