### PR TITLE
Add specific updates to extinfo field.

### DIFF
--- a/plugins/other/pacman_pending_updates
+++ b/plugins/other/pacman_pending_updates
@@ -14,12 +14,6 @@ All systems with pacman as their package manager.
 
 The plugin needs no additional configuration and works out of the box.
 
-It is possible to add warnings for certain numbers of updates pending. The
-following will send a warning when there are more than 10 updates pending.
-
-  [pacman_pending_updates]
-  env.PENDING_UPDATES_WARNING :10
-
 =head1 INTERPRETATION
 
 This plugin will draw one line: the number of updates pending.
@@ -53,9 +47,6 @@ graph_category security
 updates.label updates
 updates.info Current number of pending updates
 EOM
-		if [[ -n $PENDING_UPDATES_WARNING ]]; then
-			echo updates.warning $PENDING_UPDATES_WARNING
-		fi
 		;;
 
 	autoconf)
@@ -63,13 +54,13 @@ EOM
 		;;
 
 	*)
-		tmpfile=$(mktemp)
-		updates=$(checkupdates | tee "$tmpfile" | wc -l)
-		echo updates.value $updates
-		if [ $updates -gt 0 ]; then
-			echo updates.extinfo $(paste -s -d, "$tmpfile")
+		updates="$(checkupdates)"
+		if [ -n "$updates" ]; then
+			echo "updates.value $(echo "$updates" | wc -l)"
+			echo "updates.extinfo $(echo "$updates" | paste -s -d,)"
+		else
+			echo updates.value 0
 		fi
-		rm "$tmpfile"
 		;;
 esac
 

--- a/plugins/other/pacman_pending_updates
+++ b/plugins/other/pacman_pending_updates
@@ -31,7 +31,7 @@ This plugin will draw one line: the number of updates pending.
 
 =head1 VERSION
 
-  1.0.0
+  1.1.0
 
 =head1 AUTHOR
 
@@ -63,7 +63,13 @@ EOM
 		;;
 
 	*)
-		echo updates.value $(checkupdates | wc -l)
+		tmpfile=$(mktemp)
+		updates=$(checkupdates | tee "$tmpfile" | wc -l)
+		echo updates.value $updates
+		if [ $updates -gt 0 ]; then
+			echo updates.extinfo $(paste -s -d, "$tmpfile")
+		fi
+		rm "$tmpfile"
 		;;
 esac
 


### PR DESCRIPTION
As the title says, this update adds information about which updates are pending to the extinfo field. This makes warnings much more informational, since it tells you whether you really need to update now or if you can wait for a while.