### PR TITLE
jenkins: Added support for jobs folders

### DIFF
--- a/plugins/jenkins/jenkins_
+++ b/plugins/jenkins/jenkins_
@@ -28,6 +28,7 @@ env.port 		Jenkins Port
 env.context		Jenkins Context path
 env.user 		User for the API Tokent
 env.apiToken 	Jenkins API Token (see https://wiki.jenkins-ci.org/display/JENKINS/Authenticating+scripted+clients)
+env.jobDepth    How far into job "folders" should the plugin check for jobs
 
 Example:
 
@@ -61,25 +62,13 @@ my $port = ($ENV{'port'} || '4040');
 my $user = ($ENV{'user'} || '');
 my $apiToken = ($ENV{'apiToken'} || '');
 my $context = ($ENV{'context'} || '');
+my $jobDepth = ($ENV{'jobDepth'} || 1);
 my $wgetBin = "/usr/bin/wget";
 
 my $type = basename($0);
 $type =~ s/jenkins_//;
 
-my %states = (
-	'blue' =>'stable',
-	'blue_anime' =>'stable',
-	'yellow'=>'unstable',
-	'yellow_anime'=>'unstable',
-	'red'=>'failing',
-	'red_anime'=>'failing',
-	'disabled'=>'disabled',
-	'notbuilt' => 'disabled',
-	'notbuilt_anime' =>'disabled',
-	'aborted'=>'failing',
-	'aborted_anime'=>'failing'
-);
-my %counts = ('stable' => 0, 'unstable'=>0, 'failing'=>0, 'disabled'=>0);
+our %counts = ('stable' => 0, 'unstable'=>0, 'failing'=>0, 'disabled'=>0);
 
 if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
 	if( $type eq "results" ) {
@@ -130,17 +119,15 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
 	# CODE
 	my $auth = ( $user ne "" and $apiToken ne ""  ? " --auth-no-challenge --user=$user --password=$apiToken" : "" );
 	my $cmd = "$wgetBin $auth -qO- $url:$port$context";  
+	my $tree = 'jobs[name,color]';
+	for (2..$jobDepth) {
+		$tree = "jobs[name,color,$tree]";
+	}
 	
 	if( $type eq "results" ) {
-		my $result = `$cmd/api/json`;
+		my $result = `$cmd'/api/json?depth=$jobDepth&tree=$tree'`;
 		my $parsed = decode_json($result);
-		foreach my $cur(@{$parsed->{'jobs'}}) {
-			if (defined $states{$cur->{'color'}}) {
-				$counts{$states{$cur->{'color'}}} += 1;
-			} else {
-				warn "Ignoring unknown color " . $cur->{'color'} . "\n"
-			}
-		}
+		parse_results($parsed->{'jobs'});
 		
 		foreach my $status (keys %counts) {
 			print "build_$status.value $counts{$status}\n";
@@ -149,14 +136,9 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
 	}
 	
 	if( $type eq "running" ) {
-		my $count = 0;
-		my $result = `$cmd/api/json`;
+		my $result = `$cmd'/api/json?depth=$jobDepth&tree=$tree'`;
 		my $parsed = decode_json($result);
-		foreach my $cur(@{$parsed->{'jobs'}}) {
-			if( $cur->{'color'} =~ /anime$/ ) {
-				$count += 1;
-			}
-		}
+		my $count = parse_running_builds($parsed->{'jobs'});
 		print "build_running.value ", $count, "\n";
 		exit;	
 	}
@@ -166,5 +148,43 @@ if ( exists $ARGV[0] and $ARGV[0] eq "config" ) {
 		my $parsed = decode_json($result);	
 		print "build_count.value ", scalar( @{$parsed->{'items'}} ), "\n";
 		exit;
+	}
+}
+
+
+sub parse_running_builds {
+	my $builds = shift;
+	my $count = 0;
+	foreach my $cur (@{$builds}) {
+		if( defined($cur->{'jobs'}) ) {
+			$count += parse_running_builds($cur->{'jobs'});
+		} elsif( defined ($cur->{'color'}) and $cur->{'color'} =~ /anime$/ ) {
+			$count += 1;
+		}
+	}
+	return $count;
+}
+
+sub parse_results {
+	my $builds = shift;
+	my %states = (
+		'blue' =>'stable',
+		'blue_anime' =>'stable',
+		'yellow'=>'unstable',
+		'yellow_anime'=>'unstable',
+		'red'=>'failing',
+		'red_anime'=>'failing',
+		'aborted'=>'failing',
+		'aborted_anime'=>'failing',
+		'disabled'=>'disabled',
+		'notbuilt_anime' =>'disabled',
+	);
+
+	foreach my $cur(@{$builds}) {
+		if( defined($cur->{'jobs'}) ) {
+			parse_results($cur->{'jobs'});
+		} elsif( defined($cur->{'color'}) and defined($states{$cur->{'color'}}) ) {
+			$counts{$states{$cur->{'color'}}} += 1;
+		}
 	}
 }


### PR DESCRIPTION
Newer versions of Jenkins have support for grouping jobs into "folders",
for example when using a multibranch setup, the main "job" will actually
be a folder containing a job for each branch.

This changeset adds a "jobDepth" parameter that can be used to control
how far down the folder tree to report on.