### PR TITLE
Fix broken link in plugin README

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -24,7 +24,7 @@ Please note, that this repository is not supposed to be a dumping site for rando
 1. check if a similar plugin exists and if it can be extended/changed instead of adding a new plugin
     * please avoid code copies - they are a maintenance burden
 2. add [documentation](http://guide.munin-monitoring.org/en/latest/develop/documenting.html#plugin-documentation) including configuration, author, license and [magic markers](http://guide.munin-monitoring.org/en/latest/architecture/syntax.html#magic-markers)
-3. pick a suitable [category](guide.munin-monitoring.org/en/latest/reference/graph-category.html)
+3. pick a suitable [category](http://guide.munin-monitoring.org/en/latest/reference/graph-category.html)
 5. use style check tools for the language of the plugin (e.g. `shellcheck` for shell and `flake8` for Python)
 6. pick a suitable [name and location](#Plugin_name_and_location)
 7. bonus:


### PR DESCRIPTION
Missing protocol caused it to link to a nonexistent place on github.