### PR TITLE
Fix du-2 to use clean_fieldname()

### DIFF
--- a/plugins/disk/du-2
+++ b/plugins/disk/du-2
@@ -91,12 +91,12 @@ if( (defined $ARGV[0]) && ($ARGV[0] eq "config") ) {
     while(defined (my $bar = <FILE>)) {
         if ($bar =~ m/(\d+)\s+(.+)/) {
             my $dir = $2;
-            clean_path(\$dir);
-            print "$dir.label $dir\n";
+            my $clean_dir = clean_fieldname($dir);
+            print "$clean_dir.label $dir\n";
             if ($foo++) {
-                print "$dir.draw STACK\n";
+                print "$clean_dir.draw STACK\n";
             } else {
-                print "$dir.draw AREA\n";
+                print "$clean_dir.draw AREA\n";
             }
         }
     }
@@ -110,8 +110,7 @@ open (FILE, "<", $CACHEFILE) or munin_exit_fail();
 while(defined (my $foo = <FILE>)) {
     if ($foo =~ m/(\d+)\s+(.+)/) {
         my ($field, $value) = ($2, $1);
-        clean_path(\$field);
-        print $field, ".value ", $value, "\n";
+        print clean_fieldname($field), ".value ", $value, "\n";
     }
 }
 close(FILE);


### PR DESCRIPTION
Update du-2 to fix "No .label provided" error by using clean_fieldname().

Before:
![munin-du-2](https://user-images.githubusercontent.com/292191/38026910-76bc0c18-327d-11e8-9356-7108498917a0.png)
After:
![munin-du-2-fixed](https://user-images.githubusercontent.com/292191/38026917-7b91a702-327d-11e8-8f92-55cca35c453a.png)
