### PR TITLE
change dependency from gawk to awk

### DIFF
--- a/plugins/zfs/zpool_iostat
+++ b/plugins/zfs/zpool_iostat
@@ -60,7 +60,7 @@ fi
 zlines=$("$ZPOOL_BIN" iostat -v | wc -l | sed 's/ //g')
 iostats=$("$ZPOOL_BIN" iostat -v 1 1 | tail "-$zlines")
 zlist=$(echo "$iostats" \
-	| gawk '/alloc/ {next}; /avail/ {next}; /raid/ {next}; /mirror/ {next};
+	| awk '/alloc/ {next}; /avail/ {next}; /raid/ {next}; /mirror/ {next};
 		{ if ( $4 >=0 ) print $1}' \
 	| tr ' ' '\n')
 
@@ -71,9 +71,9 @@ get_device_iostat_column() {
 	local stat_column="$2"
 	# convert all numeric values into kB
 	echo "$iostats" \
-		| gawk '{ if ($1 == "'"$device_label"'") print $'"$stat_column"'; }' \
-		| gawk '/M/ {print strtonum($1)*1000};
-			/K/ {print strtonum($1)};
+		| awk '{ if ($1 == "'"$device_label"'") print $'"$stat_column"'; }' \
+		| awk '/M/ {print int($1)*1000};
+			/K/ {print int($1)};
 			/[0-9]$/ {print int($1)/1000}'
 }
 


### PR DESCRIPTION
As default installation of FreeBSD does not include gawk, change the dependency from gawk to awk will be nice for some platforms other than Linux.