### PR TITLE
Fix Odd number of elements in hash at linux_diskstat_ line 321

### DIFF
--- a/plugins/disk/linux_diskstat_
+++ b/plugins/disk/linux_diskstat_
@@ -498,7 +498,7 @@ sub read_sysfs {
         $cur_device =~ tr#!#/#;
 
         # Faking missing diskstats values
-        unshift @elems, ( '', '', $cur_device );
+        unshift @elems, ( -1, -1, $cur_device );
 
         push @lines, \@elems;
 


### PR DESCRIPTION
Reading from /sys/block/*/stat does not provide the disk major and minor
numbers (versus reading from /proc/diskstats). When saving the disk data
back to a temp state file, these empty values for the disk major and
minor numbers get turned into undef values on state restore.

On the line: `my ( $prev_time, %prev_diskstat ) = restore_state();`

`%prev_diskstat` will 'slurp' up all returned values from the function
call (converting the list into key value pairs) but if one of last
values is from the major or minor number (which will be undef), the key
(major or minor) will be sent but the undef value will not be
sent. Hence this results in an attempted hash assignment where one of
the key values pairs is missing a value and thus the 'Odd number of
elements in hash assignment ' warning is thrown.