### PR TITLE
Plugin postfix-rbl-blocked-mails: various improvements

### DIFF
--- a/plugins/postfix/postfix-rbl-blocked-mails
+++ b/plugins/postfix/postfix-rbl-blocked-mails
@@ -4,7 +4,8 @@
 # Monitor blocked Mails during Postfix RBL Scan, included Spamhaus, Spamcop, Manitu, MSRBL, NJABL
 
 
-LOGFILE=${logfile:-/var/log/mail.log}	# Allow user to specify logfile through env.logfile
+# Allow user to specify logfile through env.logfile
+LOGFILE=${logfile:-/var/log/mail.log}
 DATE=`date '+%b %e %H'`
 MAXLABEL=20
 
@@ -18,17 +19,16 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 if [ "$1" = "config" ]; then
-
-        echo 'graph_title RBL Counter'
-        echo 'graph_category mail'
-        echo 'graph_args --base 1000 -l 0'
-        echo 'graph_vlabel block during RBL'
-        echo 'spamhaus.label Blocked by Spamhaus.org'
-	echo 'spamcop.label Blocked by Spamcop'
-        echo 'manitu.label Blocked by manitu.net'
-	echo 'msrbl.label Blocked by msrbl.net'
-	echo 'njabl.label Blocked by njabl.org'
-	exit 0
+    echo 'graph_title RBL Counter'
+    echo 'graph_category mail'
+    echo 'graph_args --base 1000 -l 0'
+    echo 'graph_vlabel block during RBL'
+    echo 'spamhaus.label Blocked by Spamhaus.org'
+    echo 'spamcop.label Blocked by Spamcop'
+    echo 'manitu.label Blocked by manitu.net'
+    echo 'msrbl.label Blocked by msrbl.net'
+    echo 'njabl.label Blocked by njabl.org'
+    exit 0
 fi
 
 

--- a/plugins/postfix/postfix-rbl-blocked-mails
+++ b/plugins/postfix/postfix-rbl-blocked-mails
@@ -9,6 +9,15 @@ LOGFILE=${logfile:-/var/log/mail.log}
 DATE=`date '+%b %e %H'`
 MAXLABEL=20
 
+
+get_blocked_by_domain_count() {
+    local escaped_domain
+    # escape dots - for a proper regular expression
+    escaped_domain=$(echo "$1" | sed 's/\./\\./g')
+    grep -c "$DATE.*blocked using [^ ]*${escaped_domain}" "$LOGFILE"
+}
+
+
 if [ "$1" = "autoconf" ]; then
     if [ -r "$LOGFILE" ]; then
         echo yes
@@ -32,14 +41,8 @@ if [ "$1" = "config" ]; then
 fi
 
 
-echo -en "spamhaus.value "
-echo $(grep "blocked using sbl-xbl.spamhaus.org" $LOGFILE | grep "$DATE" | wc -l)
-echo -en "spamcop.value "
-echo $(grep "blocked using bl.spamcop.net" $LOGFILE | grep "$DATE" | wc -l)
-echo -en "manitu.value "
-echo $(grep "blocked using ix.dnsbl.manitu.net" $LOGFILE | grep "$DATE" | wc -l)
-echo -en "msrbl.value "
-echo $(grep "blocked using combined.rbl.msrbl.net" $LOGFILE | grep "$DATE" | wc -l)
-echo -en "njabl.value "
-echo $(grep "blocked using combined.njabl.org" $LOGFILE | grep "$DATE" | wc -l)
-
+printf 'spamhaus.value %s\n' "$(get_blocked_by_domain_count "sbl-xbl.spamhaus.org")"
+printf 'spamcop.value %s\n' "$(get_blocked_by_domain_count "bl.spamcop.net")"
+printf 'manitu.value %s\n' "$(get_blocked_by_domain_count "ix.dnsbl.manitu.net")"
+printf 'msrbl.value %s\n' "$(get_blocked_by_domain_count "combined.rbl.msrbl.net")"
+printf 'njabl.value %s\n' "$(get_blocked_by_domain_count "combined.njabl.org")"

--- a/plugins/postfix/postfix-rbl-blocked-mails
+++ b/plugins/postfix/postfix-rbl-blocked-mails
@@ -41,8 +41,13 @@ if [ "$1" = "config" ]; then
 fi
 
 
-printf 'spamhaus.value %s\n' "$(get_blocked_by_domain_count "sbl-xbl.spamhaus.org")"
-printf 'spamcop.value %s\n' "$(get_blocked_by_domain_count "bl.spamcop.net")"
-printf 'manitu.value %s\n' "$(get_blocked_by_domain_count "ix.dnsbl.manitu.net")"
-printf 'msrbl.value %s\n' "$(get_blocked_by_domain_count "combined.rbl.msrbl.net")"
-printf 'njabl.value %s\n' "$(get_blocked_by_domain_count "combined.njabl.org")"
+# sbl-xbl.spamhaus.org or zen.spamhaus.org
+printf 'spamhaus.value %s\n' "$(get_blocked_by_domain_count "spamhaus.org")"
+# bl.spamcop.net
+printf 'spamcop.value %s\n' "$(get_blocked_by_domain_count "spamcop.net")"
+# ix.dnsbl.manitu.net
+printf 'manitu.value %s\n' "$(get_blocked_by_domain_count "manitu.net")"
+# combined.rbl.msrbl.net
+printf 'msrbl.value %s\n' "$(get_blocked_by_domain_count "msrbl.net")"
+# combined.njabl.org
+printf 'njabl.value %s\n' "$(get_blocked_by_domain_count "njabl.org")"

--- a/plugins/postfix/postfix-rbl-blocked-mails
+++ b/plugins/postfix/postfix-rbl-blocked-mails
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Made by Stefan Bühler, Switzerland
 # Monitor blocked Mails during Postfix RBL Scan, included Spamhaus, Spamcop, Manitu, MSRBL, NJABL
@@ -6,8 +6,7 @@
 
 # Allow user to specify logfile through env.logfile
 LOGFILE=${logfile:-/var/log/mail.log}
-DATE=`date '+%b %e %H'`
-MAXLABEL=20
+DATE=$(date '+%b %e %H')
 
 
 get_blocked_by_domain_count() {

--- a/plugins/postfix/postfix-rbl-blocked-mails
+++ b/plugins/postfix/postfix-rbl-blocked-mails
@@ -9,12 +9,12 @@ DATE=`date '+%b %e %H'`
 MAXLABEL=20
 
 if [ "$1" = "autoconf" ]; then
-	if [[ -r $LOGFILE ]]; then
-	        echo yes
-	else
-		echo no
-	fi
-        exit 0
+    if [ -r "$LOGFILE" ]; then
+        echo yes
+    else
+        echo "no (log file not found: $LOGFILE)"
+    fi
+    exit 0
 fi
 
 if [ "$1" = "config" ]; then


### PR DESCRIPTION
* style cleanup
* reduce code duplication
* use only top-level-domains of RBL providers for identification

See #928