### PR TITLE
Generate cache file if missing

### DIFF
--- a/plugins/disk/du-2
+++ b/plugins/disk/du-2
@@ -107,15 +107,16 @@ if( (defined $ARGV[0]) && ($ARGV[0] eq "config") ) {
 }
 
 ##### fetch
-open (FILE, "<", $CACHEFILE) or munin_exit_fail();
-while(defined (my $foo = <FILE>)) {
-    if ($foo =~ m/(\d+)\s+(.+)/) {
-        my ($field, $value) = ($2, $1);
-        clean_path(\$field);
-        print clean_fieldname($field), ".value ", $value, "\n";
+if (open (FILE, "<", $CACHEFILE)) {
+    while(defined (my $foo = <FILE>)) {
+        if ($foo =~ m/(\d+)\s+(.+)/) {
+            my ($field, $value) = ($2, $1);
+            clean_path(\$field);
+            print clean_fieldname($field), ".value ", $value, "\n";
+        }
     }
+    close(FILE);
 }
-close(FILE);
 daemonize();
 
 #


### PR DESCRIPTION
Don't exit with error if cache file is missing, instead refrain from sending values and daemonize() in an attempt to generate one.
Invocation using 'config' before generation is successful will fail, as mentioned in #914, but configuration will get picked up as soon as it is present.