### PR TITLE
Nginx error: log files may be empty

### DIFF
--- a/plugins/nginx/nginx_error
+++ b/plugins/nginx/nginx_error
@@ -122,9 +122,13 @@ http_codes[503]='Service Unavailable'
 do_fetch () {
   local count status_code
   declare -A line_counts
-  while read -r count status_code; do
+  values="$(awk '{print $9}' "$log" | sort | uniq -c)"
+  # Log files may be empty due to logrotation
+  if [ -n "$values" ]; then
+    while read -r count status_code; do
       line_counts[$status_code]=$count
-  done <<< "$(awk '{print $9}' "$log" | sort | uniq -c)"
+    done <<< "$values"
+  fi
 
   for status_code in "${!http_codes[@]}"; do
     echo "error${status_code}.value ${line_counts[$status_code]:-0}"


### PR DESCRIPTION
@sumpfralle in the commit https://github.com/munin-monitoring/contrib/commit/0e864944d76b19278d82a602aca850c0d91ac51a forgot the fix merged in https://github.com/munin-monitoring/contrib/pull/813 

The log files may be empty, and without this fix this error occurs:
```
Error output from nginx_error_phpMyAdmin:
    /etc/munin/plugins/nginx_error_phpMyAdmin: line 126: line_counts[$status_code]: bad array subscript
```