### PR TITLE
Fix reporting of 'Permanent Generation' / Metaspace (for java<8)

### DIFF
--- a/plugins/jvm/jstat__heap
+++ b/plugins/jvm/jstat__heap
@@ -124,6 +124,11 @@ print_stats() {
                 S1F = $idx["S1C"] - $idx["S1U"];
                 EF  = $idx["EC"]  - $idx["EU"];
                 OF  = $idx["OC"]  - $idx["OU"];
+                # Java <8 has Permanent Generation (PU,PC columns), while >=8 has/names it Metaspace (MU,MC)
+                if (idx["MU"] == "") {
+                    idx["MU"] = idx["PU"];
+                    idx["MC"] = idx["PC"];
+                }
                 MF  = $idx["MC"]  - $idx["MU"];
                 print "Eden_Used.value " $idx["EU"] * 1024;
                 print "Eden_Free.value " EF * 1024;


### PR DESCRIPTION
Fix regression in last commit. While it added auto-detection of changing
column position it did not take into account the known change from
Java 7 > 8.

Java <8 had the Permanent Generation region which jstat columns PU, PC
While Java >=8 now has a Metaspace region (for similar purpose) with
jstat columns MU,MC.

Add re-add detection for that change to fix reporting of the values.

To simplify code uses the MU,MC labels internally and when MU,MC are
not found in jstat output it fills those with PU,PC values.

Note:
- Not really supper happy with needing to add that if but i did not find a really clean solution
- Detection now based on MU column present in jstat output instead of java>8

Tested now with running jvm + jstat binary both from same jvm with
- jvm oracle 1.5 and openjdk 1.7  (both having PU,PC)
- openjdk 8 and 11 (both having MU,MC) columns

Note:
- Apart unchanged as before: Label in graph + fieldname in output are left on 'Permanent Generation' as before
- As changing that dynamically would be again java version checking or another jstat call just to figure out which to use in the 'config command 