### PR TITLE
Ubiquity Plugin: login error fix

### DIFF
--- a/plugins/ubiquiti/unifi_api
+++ b/plugins/ubiquiti/unifi_api
@@ -1113,7 +1113,7 @@ sub fetch_data {
 	$curl->setopt($curl->CURLOPT_SSL_VERIFYHOST, (( $APIconfig{"ssl_verify_host"} =~ m/no/i ) ? 0 : 2) );
 	$curl->setopt($curl->CURL_SSLVERSION_TLSv1, 1);
 	$curl->setopt($curl->CURLOPT_URL, $APIPoint{'login'});
-	$curl->setopt($curl->CURLOPT_POSTFIELDS, q[{'username':'] . $APIconfig{"user"} . q[', 'password':'] . $APIconfig{"pass"} . q['}] );
+	$curl->setopt($curl->CURLOPT_POSTFIELDS, q[{"username":"] . $APIconfig{"user"} . q[", "password":"] . $APIconfig{"pass"} . q["}] );
 	$curl->setopt($curl->CURLOPT_WRITEDATA, \$APIResponse{'login'});
 	$retcode = $curl->perform;
 


### PR DESCRIPTION
new controllers require the use of double quoted string to login, thanks to @fongd for catching this.