### PR TITLE
Change shebang of systemd/systemd_units from sh to bash

### DIFF
--- a/plugins/systemd/systemd_units
+++ b/plugins/systemd/systemd_units
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # -*- sh -*-
 
 : << =cut


### PR DESCRIPTION
Running it with sh results in this error:

```
/etc/munin/plugins/systemd_units: 109: /etc/munin/plugins/systemd_units: Bad substitution
```