### PR TITLE
Fix "TabError: inconsistent use of tabs and spaces in indentation"

### DIFF
--- a/plugins/tor/tor_
+++ b/plugins/tor/tor_
@@ -29,7 +29,7 @@ user toranon # or any other user/group that is running tor
 group toranon
 env.torcachefile 'munin_tor_country_stats.json'
 env.torconnectmethod 'port'
-env.torgeoippath "/usr/share/GeoIP/GeoIP.dat"
+env.torgeoippath '/usr/share/GeoIP/GeoIP.dat'
 env.tormaxcountries 15
 env.torport 9051
 env.torsocket '/var/run/tor/control'
@@ -40,7 +40,7 @@ user toranon # or any other user/group that is running tor
 group toranon
 env.torcachefile 'munin_tor_country_stats.json'
 env.torconnectmethod 'socket'
-env.torgeoippath "/usr/share/GeoIP/GeoIP.dat"
+env.torgeoippath '/usr/share/GeoIP/GeoIP.dat'
 env.tormaxcountries 15
 env.torport 9051
 env.torsocket '/var/run/tor/control'
@@ -70,7 +70,7 @@ except ImportError:
 
 default_torcachefile = 'munin_tor_country_stats.json'
 default_torconnectmethod = 'port'
-default_torgeoippath = "/usr/share/GeoIP/GeoIP.dat"
+default_torgeoippath = '/usr/share/GeoIP/GeoIP.dat'
 default_tormaxcountries = 15
 default_torport = 9051
 default_torsocket = '/var/run/tor/control'
@@ -445,10 +445,10 @@ class TorRouters(TorPlugin):
                 sys.exit(1)
             else:
                 routers = response.split('\n')
-	        onr = 0
-		for router in routers:
-		    if router[0] == "r":
-	               onr += 1
+                onr = 0
+                for router in routers:
+                    if router[0] == "r":
+                        onr += 1
 
                 print('routers.value {}'.format(onr))
 


### PR DESCRIPTION
1. Fixes

```
munin-run tor_bandwidth 
  File "/etc/munin/plugins/tor_bandwidth", line 448
    onr = 0
          ^
TabError: inconsistent use of tabs and spaces in indentation
```
2. Use single quotes consistently also for GeoIP.dat filename