### PR TITLE
Remove quotes in plugin env parameters

### DIFF
--- a/plugins/tor/tor_
+++ b/plugins/tor/tor_
@@ -27,23 +27,23 @@ The default configuration is below
 [tor_*]
 user toranon # or any other user/group that is running tor
 group toranon
-env.torcachefile 'munin_tor_country_stats.json'
-env.torconnectmethod 'port'
-env.torgeoippath '/usr/share/GeoIP/GeoIP.dat'
+env.torcachefile munin_tor_country_stats.json
+env.torconnectmethod port
+env.torgeoippath /usr/share/GeoIP/GeoIP.dat
 env.tormaxcountries 15
 env.torport 9051
-env.torsocket '/var/run/tor/control'
+env.torsocket /var/run/tor/control
 
 To make it connect through a socket modify this way
 [tor_*]
 user toranon # or any other user/group that is running tor
 group toranon
-env.torcachefile 'munin_tor_country_stats.json'
-env.torconnectmethod 'socket'
-env.torgeoippath '/usr/share/GeoIP/GeoIP.dat'
+env.torcachefile munin_tor_country_stats.json
+env.torconnectmethod socket
+env.torgeoippath /usr/share/GeoIP/GeoIP.dat
 env.tormaxcountries 15
 env.torport 9051
-env.torsocket '/var/run/tor/control'
+env.torsocket /var/run/tor/control
 
 =head1 COPYRIGHT
 MIT License


### PR DESCRIPTION
Setting
`env.torconnectmethod 'port'`
leads to the error:
```
munin-run tor_bandwidth 
env.torconnectmethod contains an invalid value. Please specify either 'port' or 'socket'.
```
Removing the quotes solves that, because the quotes are part of the variable value.
["There is no need to quote the variable content."](http://guide.munin-monitoring.org/en/stable-2.0/plugin/use.html)