### PR TITLE
Exit when retrieving updates fails.

### DIFF
--- a/plugins/other/pacman_pending_updates
+++ b/plugins/other/pacman_pending_updates
@@ -54,7 +54,7 @@ EOM
 		;;
 
 	*)
-		updates="$(checkupdates)" || exit
+		updates="$(checkupdates)" || echo "updates.value U" && exit
 		if [ -n "$updates" ]; then
 			echo "updates.value $(echo "$updates" | wc -l)"
 			echo "updates.extinfo $(echo "$updates" | paste -s -d,)"

--- a/plugins/other/pacman_pending_updates
+++ b/plugins/other/pacman_pending_updates
@@ -25,7 +25,7 @@ This plugin will draw one line: the number of updates pending.
 
 =head1 VERSION
 
-  1.1.0
+  1.1.1
 
 =head1 AUTHOR
 
@@ -54,7 +54,7 @@ EOM
 		;;
 
 	*)
-		updates="$(checkupdates)"
+		updates="$(checkupdates)" || exit
 		if [ -n "$updates" ]; then
 			echo "updates.value $(echo "$updates" | wc -l)"
 			echo "updates.extinfo $(echo "$updates" | paste -s -d,)"


### PR DESCRIPTION
Previously, when retrieving update counts failed, the plugin reported no updates. This is incorrect. With this patch, the plugin should properly report UNKNOWN.

No additional error handling is needed, since `checkupdates` reports a clear error message when it fails.