### PR TITLE
libvirt/kvm_*: Simpler regex to match VM name

### DIFF
--- a/plugins/libvirt/kvm_cpu
+++ b/plugins/libvirt/kvm_cpu
@@ -68,7 +68,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*guest=([a-zA-Z0-9.-_-]*).*$",r"\1", cmdline.readline()))
     return result
 
 def list_pids():

--- a/plugins/libvirt/kvm_io
+++ b/plugins/libvirt/kvm_io
@@ -85,7 +85,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*guest=([a-zA-Z0-9.-_-]*).*$",r"\1", cmdline.readline()))
     return result
 
 def list_pids():

--- a/plugins/libvirt/kvm_mem
+++ b/plugins/libvirt/kvm_mem
@@ -82,7 +82,7 @@ def find_vm_names(pids):
     result = {}
     for pid in pids:
         cmdline = open("/proc/%s/cmdline" % pid, "r")
-        result[pid] = clean_vm_name(re.sub(r"^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$",r"\1", cmdline.readline()))
+        result[pid] = clean_vm_name(re.sub(r"^.*guest=([a-zA-Z0-9.-_-]*).*$",r"\1", cmdline.readline()))
     return result
 
 def list_pids():


### PR DESCRIPTION
On Debian Stretch the cmdline is something like:
`qemu-system-x86_64-enable-kvm-nameguest=vmname,debug-threads=on-S-[…]`
Without null characters:
`qemu-system-x86_64 -enable-kvm -name guest=vmname,debug-threads=on[…]`

We need to match only `guest=vmname`, so the regex
`^.*guest=([a-zA-Z0-9.-_-]*).*$` is simpler and match the VM name.
The previous regex `^.*-name\x00([a-zA-Z0-9.-_-]*)\x00\-.*$` was not matching it.

BTW, It seems that `\x00` does not match correctly null characters so I removed it.

