### PR TITLE
fix uptime_bsd. compile time is not included since FreeBSD 12.0

### DIFF
--- a/plugins/bsd/uptime_bsd
+++ b/plugins/bsd/uptime_bsd
@@ -48,7 +48,7 @@ use Date::Parse;
 my $kern=`sysctl -n kern.version`;
 $kern=~ /:\s+(.*\S)\s+\w+\@/;
 #print "Compile: $1\n";
-$kern=str2time($1);
+$kern= $1 ? str2time($1) : undef;
 
 my $boot=`sysctl -n kern.boottime`; # OpenBSD will return seconds from the epoch
 if ($ostype ne "OpenBSD") {
@@ -59,5 +59,5 @@ if ($ostype ne "OpenBSD") {
 
 my $now=time;
 
-print "compile.value ",($now-$kern)/60/60/24,"\n";
+print "compile.value ",($now-$kern)/60/60/24,"\n" if $kern;
 print "uptime.value ",($now-$boot)/60/60/24,"\n";


### PR DESCRIPTION
compile time is not included since FreeBSD 12.0-RELEESE due to Reproducible Builds.

https://wiki.freebsd.org/ReproducibleBuilds/Base
https://reviews.freebsd.org/D4347

sysctl output samples:

% (11.2-RELEASE) sysctl kern.version
kern.version: FreeBSD 11.2-RELEASE-p10 #0: Mon May 13 21:20:50 UTC 2019
    root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC

% (12.0-RELEASE) sysctl kern.version
kern.version: FreeBSD 12.0-RELEASE-p7 GENERIC