### PR TITLE
Remove double quote for env.driftfile variable

### DIFF
--- a/plugins/chrony/chrony_drift
+++ b/plugins/chrony/chrony_drift
@@ -21,7 +21,7 @@ The following configuration parameters are used by this plugin:
 =head2 DEFAULT CONFIGURATION
 
  [chrony_drift]
- env.driftfile "/var/lib/chrony/chrony.drift"
+ env.driftfile /var/lib/chrony/chrony.drift
 
 =head1 USAGE
 


### PR DESCRIPTION
Information concerning how to use variable env.driftfile is wrong. Specifying these variable as is in plugin-conf.d/00-defaults not work if double quote is used. 