### PR TITLE
Update ntp_packets

### DIFF
--- a/plugins/ntp/ntp_packets
+++ b/plugins/ntp/ntp_packets
@@ -86,6 +86,8 @@ stats = dict()
 stats_output = subprocess.check_output([cmd, '-c', 'iostats', '-c', 'sysstats'],
                                        universal_newlines=True).splitlines()
 
+# Split the cmd output into key/value pairs
+# Lines that can't be splitted into 2 individual elements by delimiter ':' will be skipped
 for line in stats_output:
     if len(line.split(':')) == 2:
         stats[line.split(':')[0]] = int(line.split(':')[1])

--- a/plugins/ntp/ntp_packets
+++ b/plugins/ntp/ntp_packets
@@ -87,7 +87,8 @@ stats_output = subprocess.check_output([cmd, '-c', 'iostats', '-c', 'sysstats'],
                                        universal_newlines=True).splitlines()
 
 for line in stats_output:
-    stats[line.split(':')[0]] = int(line.split(':')[1])
+    if len(line.split(':')) == 2:
+        stats[line.split(':')[0]] = int(line.split(':')[1])
 
 print('received.value ' + str(stats['received packets']))
 print('sent.value ' + str(stats['packets sent']))


### PR DESCRIPTION
With Debian 10 the command "ntpq -c iostats -c sysstats" produces one empty line.
The additional if condition tackles this.

Traceback (most recent call last):
  File "/etc/munin/plugins/ntp_packets", line 91, in <module>
    stats[line.split(':')[0]] = int(line.split(':')[1])
IndexError: list index out of range