### PR TITLE
asterisk: turn output into debug-only lines

### DIFF
--- a/plugins/asterisk/asterisk
+++ b/plugins/asterisk/asterisk
@@ -88,17 +88,19 @@ sub asterisk_command {
   # Response: (Error|Follows|Success)
   $line = $socket->getline;
   if ($line !~ /^Response: Success\r?\n$/) {
-    while ( $line = $socket->getline and $line !~ /^\r?\n$/ ) {}
+    while ( $line = $socket->getline and $line !~ /^\r?\n$/ ) {
+      print STDERR "COMMAND: Ignoring unwanted line: $line" if $Munin::Plugin::DEBUG;
+    }
     return undef;
   }
 
   # Message: Command output follows
   $line = $socket->getline;
-  print STDERR "Command: got response: $line\n";
+  print STDERR "COMMAND got response: $line" if $Munin::Plugin::DEBUG;
 
   # Until we get the --END COMMAND-- marker, it's the command's output.
   while ( $line = $socket->getline and $line =~ /^Output:/ ) {
-  print STDERR "Command: got response: $line\n";
+    print STDERR "COMMAND: got response: $line" if $Munin::Plugin::DEBUG;
     # Don't keep the "Output: " part of the response
     substr($line, 0, 8, '');
     $reply .= $line;


### PR DESCRIPTION
I apparently forgot to clear out two lines of debugging output from the
script before submitting a pull request.

Those lines of output are super useful for debugging whenever things are
not working as expected (e.g. asterisk has changed its output). So it'll
be more productive to keep them around but only output them if
MUNIN_DEBUG is set.

This is a fixup for d66fef2 which was already merged.