### PR TITLE
asterisk: the confbridge graph is in the wrong category

### DIFF
--- a/plugins/asterisk/asterisk
+++ b/plugins/asterisk/asterisk
@@ -209,7 +209,7 @@ if ($confbridge_enabled == '1') {
 multigraph asterisk_confbridge
 graph_title Asterisk ConfBridge statistics
 graph_args --base 1000 -l 0
-graph_category asterisk
+graph_category voip
 users.label Connected users
 conferences.label Active conferences
 END


### PR DESCRIPTION
This was a copy/paste error that slipped by unnoticed :\

this is hopefully my last PR for this plugin for some time