### PR TITLE
Add Missing Bracket

### DIFF
--- a/templates/munstrap/templates/munin-overview.tmpl
+++ b/templates/munstrap/templates/munin-overview.tmpl
@@ -53,7 +53,7 @@
                     <TMPL_UNLESS NAME="MULTIGRAPH">
                       <li <TMPL_IF NAME="__LAST__">class="last"</TMPL_IF>>
                       <a href="<TMPL_VAR NAME="URL">"><TMPL_VAR ESCAPE="HTML" NAME="NAME"></a>
-                      <TMPL_IF NAME="COMPARE"> 
+                      <TMPL_IF NAME="COMPARE"> [
                         <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-day.html">day</a> 
                         <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-week.html">week</a> 
                         <a href="<TMPL_VAR NAME="R_PATH">/<TMPL_LOOP NAME="PATH"><TMPL_IF NAME="pathname"><TMPL_VAR ESCAPE="URL" NAME="PATHNAME">/</TMPL_IF></TMPL_LOOP>comparison-month.html">month</a> 


### PR DESCRIPTION
Adds the missing bracket `[` to ensure that brackets show up after groups when hosts are grouped together.