### PR TITLE
arris-tg3442: Remove newlines from cookie

### DIFF
--- a/plugins/router/arris-tg3442
+++ b/plugins/router/arris-tg3442
@@ -79,11 +79,10 @@ base64.encodebytes(b'{ "unique":"280oaPSLiF", "family":"852", "modelname":"TG249
                    '"name":"technician", "tech":true, "moca":0, "wifi":5, "conType":"WAN", '
                    '"gwWan":"f", "DefPasswdChanged":"YES" }').decode()
 """
-CREDENTIAL_COOKIE = """eyAidW5pcXVlIjoiMjgwb2FQU0xpRiIsICJmYW1pbHkiOiI4NTIiLCAibW9kZWxuYW1lIjoiVEcy
-NDkyTEctODUiLCAibmFtZSI6InRlY2huaWNpYW4iLCAidGVjaCI6dHJ1ZSwgIm1vY2EiOjAsICJ3
-aWZpIjo1LCAiY29uVHlwZSI6IldBTiIsICJnd1dhbiI6ImYiLCAiRGVmUGFzc3dkQ2hhbmdlZCI6
-IllFUyIgfQ==
-"""
+CREDENTIAL_COOKIE = "eyAidW5pcXVlIjoiMjgwb2FQU0xpRiIsICJmYW1pbHkiOiI4NTIiLCAibW9kZWxuYW1lIjoiVEcy"\
+    "NDkyTEctODUiLCAibmFtZSI6InRlY2huaWNpYW4iLCAidGVjaCI6dHJ1ZSwgIm1vY2EiOjAsICJ3"\
+    "aWZpIjo1LCAiY29uVHlwZSI6IldBTiIsICJnd1dhbiI6ImYiLCAiRGVmUGFzc3dkQ2hhbmdlZCI6"\
+    "IllFUyIgfQ=="
 
 
 def login(session, url, username, password):


### PR DESCRIPTION
Fixes #1025