### PR TITLE
multi_tcp_ping: enable service_check by default

### DIFF
--- a/plugins/ping/multi_tcp_ping
+++ b/plugins/ping/multi_tcp_ping
@@ -105,6 +105,7 @@ sub ping_host {
 
     $p=Net::Ping->new("tcp", $defaults{timeout});
     $p->hires();
+    $p->service_check(1);
     $p->{port_num} = $host->[1] || $defaults{port};
 
     ($ret, $time, $ip) = $p->ping($host->[0]);


### PR DESCRIPTION
By default, Net::Ping will report a good attempt even when the remote end returns "connection refused". By enabling service_check, the connection must have been established.
See https://perldoc.perl.org/Net/Ping.html#Functions