### PR TITLE
Fix state saving in loggrepx_ plugin

### DIFF
--- a/plugins/logs/loggrepx_
+++ b/plugins/logs/loggrepx_
@@ -150,7 +150,7 @@ function fetch() {
         echo "$var_prefix.value $matches"
 
         # Push onto next state
-        nextstate+=("${var}_lines=$curlines")
+        nextstate+=("${var_prefix}_lines=$curlines")
     done 3< <(echo "$LOGFILES")
 
     # Write state to munin statefile


### PR DESCRIPTION
The pattern under which the data was saved was different than the pattern under the data was loaded on the next run. The reason being an undefined variable that evaluates to the empty string. The result was that the number of matching lines reported was for the whole logfile instead of the time since the last run.