### PR TITLE
Remove of deprecated api calls as of 0.9.7

### DIFF
--- a/plugins/rtorrent/rtom_allsessions_mem
+++ b/plugins/rtorrent/rtom_allsessions_mem
@@ -66,7 +66,7 @@ my @ports       = split /,/, $ENV{"port"} || "";
 # detect rtorrent version
 use version;
 my %rtorrent_version;
-sub get_socket_version {
+sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
@@ -91,7 +91,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		} else {
@@ -99,7 +99,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
 		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		}

--- a/plugins/rtorrent/rtom_allsessions_mem
+++ b/plugins/rtorrent/rtom_allsessions_mem
@@ -27,7 +27,6 @@
 #       ip              rTorrent's ip address                   - using scgi_port       - needed, when "src" is NOT set to "socket"
 #       port            rTorrent's scgi port (scgi_port)        - using scgi_port       - needed, when "src" is NOT set to "socket"
 #       category        Change graph category
-#       api             use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -36,7 +35,6 @@
 #       env.src socket
 #       env.socket /home/user/torrent/.socket/rpc.socket,/home/user/torrent/.socket/rpc.socket
 #       env.category Category
-#       env.api current
 #
 #       [rtom_allsessions_*]
 #       user username
@@ -64,16 +62,41 @@ my $src         = $ENV{"src"} || "";
 my @sockets     = split /,/, $ENV{"socket"} || "";
 my $ip          = $ENV{"ip"} || "127.0.0.1";
 my @ports       = split /,/, $ENV{"port"} || "";
-my $api         = $ENV{"api"} || "current";
+
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
+}
 
 my $mem         = 0;
 my $pattern     = qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
-my $line        = "";
-if ($api =~ /pre09/) {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>get_memory_usage</methodName></methodCall>";
-} else {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>pieces.memory.current</methodName></methodCall>";
-}
+my $function	= rtorrent_version_lower_than('0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
+my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function</methodName></methodCall>";
 my $llen        = length $line;
 my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen        = length $header;

--- a/plugins/rtorrent/rtom_allsessions_mem
+++ b/plugins/rtorrent/rtom_allsessions_mem
@@ -65,49 +65,70 @@ my @ports       = split /,/, $ENV{"port"} || "";
 
 # detect rtorrent version
 use version;
-my $rtorrent_version;
-sub rtorrent_version_lower_than {
-	if (not length $rtorrent_version){
-		if ( ( defined $src ) && ( $src eq "socket" ) ) {
-			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		} else {
-			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+my %rtorrent_version;
+sub get_socket_version {
+	my $version;
+	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+	my $llen	= length $line_version;
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen	= length $header;
+	$line_version= "${hlen}:${header},${line_version}";
+	print SOCK $line_version;
+	flush SOCK;
+	my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+	while ( $line = <SOCK> ) {
+		if ( $line =~ /$pattern/ ) {
+			$version = $1;
 		}
-		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
-		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-		my $hlen	= length $header;
-		$line_version= "${hlen}:${header},${line_version}";
-		print SOCK $line_version;
-		flush SOCK;
-		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
-		while ( $line = <SOCK> ) {
-			if ( $line =~ /$pattern/ ) {
-				$rtorrent_version = $1;
-			}
-		}
-		close (SOCK);
 	}
-	return version->parse($rtorrent_version) < version->parse($_[0]);
+	close (SOCK);
+	$rtorrent_version{$_[0]} = $version;
 }
+sub rtorrent_version_lower_than {
+	if (keys %rtorrent_version == 0 && not defined $_[0]){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+		  for $socket (@sockets)
+		  {
+		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		} else {
+		  for $port (@ports)
+		  {
+		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		}
+	}
+	if(defined $_[1]){
+		return version->parse($rtorrent_version{$_[0]}) < version->parse($_[1]);
+	}
+}
+# init rtorrent_version
+rtorrent_version_lower_than();
 
-my $mem         = 0;
 my $pattern     = qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
-my $function	= rtorrent_version_lower_than('0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
-my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function</methodName></methodCall>";
-my $llen        = length $line;
-my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-my $hlen        = length $header;
+my $mem         = 0;
+sub construct_line {
+	my $function	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
+	my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function</methodName></methodCall>";
+	my $llen        = length $line;
+	my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen        = length $header;
+	$line = "${hlen}:${header},${line}";
+	return $line;
+}
 
 if ( ( defined $src ) && ( $src eq "socket" ) ) {
   for $socket (@sockets)
   {
     socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
     connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-    my $line = "${hlen}:${header},${line}";
-    print SOCK $line;
+    print SOCK construct_line($socket);
     flush SOCK;
     while ( $line = <SOCK> ) {
       if ( $line =~ /$pattern/ ) {
@@ -121,8 +142,7 @@ if ( ( defined $src ) && ( $src eq "socket" ) ) {
   {
     socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
     connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-    my $line = "${hlen}:${header},${line}";
-    print SOCK $line;
+    print SOCK construct_line($port);
     flush SOCK;
     while ( $line = <SOCK> ) {
       if ( $line =~ /$pattern/ ) {

--- a/plugins/rtorrent/rtom_allsessions_mem
+++ b/plugins/rtorrent/rtom_allsessions_mem
@@ -91,7 +91,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_rtorrent_version $port;
+		    get_rtorrent_version $socket;
 		    close (SOCK);
 		  }
 		} else {

--- a/plugins/rtorrent/rtom_allsessions_peers
+++ b/plugins/rtorrent/rtom_allsessions_peers
@@ -75,44 +75,64 @@ my @ports       = split /,/, $ENV{"port"} || "";
 
 # detect rtorrent version
 use version;
-my $rtorrent_version;
-sub rtorrent_version_lower_than {
-	if (not length $rtorrent_version){
-		if ( ( defined $src ) && ( $src eq "socket" ) ) {
-			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		} else {
-			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+my %rtorrent_version;
+sub get_socket_version {
+	my $version;
+	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+	my $llen	= length $line_version;
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen	= length $header;
+	$line_version= "${hlen}:${header},${line_version}";
+	print SOCK $line_version;
+	flush SOCK;
+	my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+	while ( $line = <SOCK> ) {
+		if ( $line =~ /$pattern/ ) {
+			$version = $1;
 		}
-		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
-		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-		my $hlen	= length $header;
-		$line_version= "${hlen}:${header},${line_version}";
-		print SOCK $line_version;
-		flush SOCK;
-		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
-		while ( $line = <SOCK> ) {
-			if ( $line =~ /$pattern/ ) {
-				$rtorrent_version = $1;
-			}
-		}
-		close (SOCK);
 	}
-	return version->parse($rtorrent_version) < version->parse($_[0]);
+	close (SOCK);
+	$rtorrent_version{$_[0]} = $version;
 }
-
+sub rtorrent_version_lower_than {
+	if (keys %rtorrent_version == 0 && not defined $_[0]){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+		  for $socket (@sockets)
+		  {
+		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		} else {
+		  for $port (@ports)
+		  {
+		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		}
+	}
+	if(defined $_[1]){
+		return version->parse($rtorrent_version{$_[0]}) < version->parse($_[1]);
+	}
+}
+# init rtorrent_version
+rtorrent_version_lower_than();
 
 my $pattern  = qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
 my $tpattern  = qr/[0-9A-F]{20}/;
-
-my $function_multicall	= rtorrent_version_lower_than('0.9.0') ? 'd.multicall' : 'd.multicall2';
-my $function_hash	= rtorrent_version_lower_than('0.9.0') ? 'd.get_hash=' : 'd.hash=';
-my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
-my $llen  = length $line;
-my $header  = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-my $hlen  = length $header;
+sub construct_line {
+	my $function_multicall	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.multicall' : 'd.multicall2';
+	my $function_hash	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.get_hash=' : 'd.hash=';
+	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
+	my $llen  = length $line;
+	my $header  = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen  = length $header;
+	$line = "${hlen}:${header},${line}";
+	return $line;
+}
 
 my $tor = 0;
 my $tot = 0;
@@ -123,14 +143,12 @@ my $ppline = "";
 my $out = 0;
 my $pla = 0;
 
-
 if ( ( defined $src ) && ( $src eq "socket" ) ) {
   for $socket (@sockets)
   {
     socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
     connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-    my $line = "${hlen}:${header},${line}";
-    print SOCK $line;
+    print SOCK construct_line($socket);
     flush SOCK;
     while ( $line = <SOCK> ) {
       if ( $line =~ /$tpattern/ ) {
@@ -154,8 +172,7 @@ if ( ( defined $src ) && ( $src eq "socket" ) ) {
   {
     socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
     connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-    my $line = "${hlen}:${header},${line}";
-    print SOCK $line;
+    print SOCK construct_line($port);
     flush SOCK;
     while ( $line = <SOCK> ) {
       if ( $line =~ /$tpattern/ ) {

--- a/plugins/rtorrent/rtom_allsessions_peers
+++ b/plugins/rtorrent/rtom_allsessions_peers
@@ -25,7 +25,6 @@
 #  src           "socket" when using scgi_socket, or anything else when using scgi_port
 #  socket        rTorrent's rpc socket (scgi_local)  - using scgi_local  - needed, when "src" is set to "socket"
 #  category      Change graph category
-#  api           use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -34,7 +33,6 @@
 #       env.src socket
 #       env.socket /home/user/torrent/.socket/rpc.socket,/home/user/torrent/.socket/rpc.socket
 #       env.category Category
-#       env.api current
 #
 #       [rtom_allsessions_*]
 #       user username
@@ -74,17 +72,44 @@ my $src         = $ENV{"src"} || "";
 my @sockets     = split /,/, $ENV{"socket"} || "";
 my $ip          = $ENV{"ip"} || "127.0.0.1";
 my @ports       = split /,/, $ENV{"port"} || "";
-my $api         = $ENV{"api"} || "current";
+
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
+}
+
 
 my $pattern  = qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
 my $tpattern  = qr/[0-9A-F]{20}/;
 
-my $line        = "";
-if ($api =~ /pre09/) {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>d.get_hash=</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
-} else {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall2</methodName><params><param><value><string></string></value></param><param><value><string>main</string></value></param><param><value><string>d.hash=</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
-}
+my $function_multicall	= rtorrent_version_lower_than('0.9.0') ? 'd.multicall' : 'd.multicall2';
+my $function_hash	= rtorrent_version_lower_than('0.9.0') ? 'd.get_hash=' : 'd.hash=';
+my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
 my $llen  = length $line;
 my $header  = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen  = length $header;

--- a/plugins/rtorrent/rtom_allsessions_peers
+++ b/plugins/rtorrent/rtom_allsessions_peers
@@ -76,7 +76,7 @@ my @ports       = split /,/, $ENV{"port"} || "";
 # detect rtorrent version
 use version;
 my %rtorrent_version;
-sub get_socket_version {
+sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
@@ -101,7 +101,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		} else {
@@ -109,7 +109,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
 		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		}

--- a/plugins/rtorrent/rtom_allsessions_peers
+++ b/plugins/rtorrent/rtom_allsessions_peers
@@ -101,7 +101,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_rtorrent_version $port;
+		    get_rtorrent_version $socket;
 		    close (SOCK);
 		  }
 		} else {

--- a/plugins/rtorrent/rtom_allsessions_peers
+++ b/plugins/rtorrent/rtom_allsessions_peers
@@ -125,8 +125,9 @@ my $pattern  = qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value
 my $tpattern  = qr/[0-9A-F]{20}/;
 sub construct_line {
 	my $function_multicall	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.multicall' : 'd.multicall2';
+	my $function_multicall_arg      = rtorrent_version_lower_than($_[0], '0.9.0') ? '' : '<param><value><string></string></value></param>';
 	my $function_hash	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.get_hash=' : 'd.hash=';
-	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
+	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
 	my $llen  = length $line;
 	my $header  = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 	my $hlen  = length $header;

--- a/plugins/rtorrent/rtom_allsessions_spdd
+++ b/plugins/rtorrent/rtom_allsessions_spdd
@@ -36,7 +36,6 @@
 #       src             "socket" when using scgi_socket, or anything else when using scgi_port
 #       socket          rTorrent's rpc socket (scgi_local)      - using scgi_local      - needed, when "src" is set to "socket"
 #       diff            "yes" for using bps for upload and Bps for download, or anything else for using Bps for both
-#       api             use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 #
 # Configuration example
@@ -46,7 +45,6 @@
 #       env.src socket
 #       env.socket /home/user/torrent/.socket/rpc.socket,/home/user/torrent/.socket/rpc.socket
 #       env.category Category
-#       env.api pre09
 #
 #       [rtom_allsessions_*]
 #       user username
@@ -88,15 +86,42 @@ my $src         = $ENV{"src"} || "";
 my @sockets     = split /,/, $ENV{"socket"} || "";
 my $ip          = $ENV{"ip"} || "127.0.0.1";
 my @ports       = split /,/, $ENV{"port"} || "";
-my $api         = $ENV{"api"} || "current";
 
-my $pattern     = qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
-my $line        = "";
-if ($api =~ /pre09/) {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>get_up_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_down_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_upload_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_download_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
-} else {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>throttle.global_up.total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_down.total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_up.max_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_down.max_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
 }
+my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $function_totalup	= rtorrent_version_lower_than('0.9.0') ? 'get_up_total' : 'throttle.global_up.total';
+my $function_totaldown	= rtorrent_version_lower_than('0.9.0') ? 'get_down_total' : 'throttle.global_down.total';
+my $function_rateup	= rtorrent_version_lower_than('0.9.0') ? 'get_upload_rate' : 'throttle.global_up.max_rate';
+my $function_ratedown	= rtorrent_version_lower_than('0.9.0') ? 'get_download_rate' : 'throttle.global_down.max_rate';
+my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_rateup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_ratedown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
 
 my $llen        = length $line;
 my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";

--- a/plugins/rtorrent/rtom_allsessions_spdd
+++ b/plugins/rtorrent/rtom_allsessions_spdd
@@ -90,7 +90,7 @@ my @ports       = split /,/, $ENV{"port"} || "";
 # detect rtorrent version
 use version;
 my %rtorrent_version;
-sub get_socket_version {
+sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
@@ -115,7 +115,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		} else {
@@ -123,7 +123,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
 		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		}

--- a/plugins/rtorrent/rtom_allsessions_spdd
+++ b/plugins/rtorrent/rtom_allsessions_spdd
@@ -89,43 +89,66 @@ my @ports       = split /,/, $ENV{"port"} || "";
 
 # detect rtorrent version
 use version;
-my $rtorrent_version;
-sub rtorrent_version_lower_than {
-	if (not length $rtorrent_version){
-		if ( ( defined $src ) && ( $src eq "socket" ) ) {
-			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		} else {
-			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+my %rtorrent_version;
+sub get_socket_version {
+	my $version;
+	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+	my $llen	= length $line_version;
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen	= length $header;
+	$line_version= "${hlen}:${header},${line_version}";
+	print SOCK $line_version;
+	flush SOCK;
+	my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+	while ( $line = <SOCK> ) {
+		if ( $line =~ /$pattern/ ) {
+			$version = $1;
 		}
-		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
-		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-		my $hlen	= length $header;
-		$line_version= "${hlen}:${header},${line_version}";
-		print SOCK $line_version;
-		flush SOCK;
-		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
-		while ( $line = <SOCK> ) {
-			if ( $line =~ /$pattern/ ) {
-				$rtorrent_version = $1;
-			}
-		}
-		close (SOCK);
 	}
-	return version->parse($rtorrent_version) < version->parse($_[0]);
+	close (SOCK);
+	$rtorrent_version{$_[0]} = $version;
 }
-my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
-my $function_totalup	= rtorrent_version_lower_than('0.9.0') ? 'get_up_total' : 'throttle.global_up.total';
-my $function_totaldown	= rtorrent_version_lower_than('0.9.0') ? 'get_down_total' : 'throttle.global_down.total';
-my $function_rateup	= rtorrent_version_lower_than('0.9.0') ? 'get_upload_rate' : 'throttle.global_up.max_rate';
-my $function_ratedown	= rtorrent_version_lower_than('0.9.0') ? 'get_download_rate' : 'throttle.global_down.max_rate';
-my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_rateup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_ratedown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
+sub rtorrent_version_lower_than {
+	if (keys %rtorrent_version == 0 && not defined $_[0]){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+		  for $socket (@sockets)
+		  {
+		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		} else {
+		  for $port (@ports)
+		  {
+		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		}
+	}
+	if(defined $_[1]){
+		return version->parse($rtorrent_version{$_[0]}) < version->parse($_[1]);
+	}
+}
+# init rtorrent_version
+rtorrent_version_lower_than();
 
-my $llen        = length $line;
-my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-my $hlen        = length $header;
+my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+sub construct_line {
+	my $function_totalup	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_up_total' : 'throttle.global_up.total';
+	my $function_totaldown	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_down_total' : 'throttle.global_down.total';
+	my $function_rateup	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_upload_rate' : 'throttle.global_up.max_rate';
+	my $function_ratedown	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_download_rate' : 'throttle.global_down.max_rate';
+	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_rateup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_ratedown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
+
+	my $llen        = length $line;
+	my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen        = length $header;
+	$line = "${hlen}:${header},${line}";
+	return $line;
+}
 
 my $up = -1;
 my $down = -1;
@@ -135,8 +158,7 @@ if ( ( defined $src ) && ( $src eq "socket" ) ) {
   {
     socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
     connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-    my $line = "${hlen}:${header},${line}";
-    print SOCK $line;
+    print SOCK construct_line($socket);
     flush SOCK;
     my $up_tmp = -1;
     my $down_tmp = -1;
@@ -159,8 +181,7 @@ if ( ( defined $src ) && ( $src eq "socket" ) ) {
   {
     socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
     connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-    my $line = "${hlen}:${header},${line}";
-    print SOCK $line;
+    print SOCK construct_line($port);
     flush SOCK;
     my $up_tmp = -1;
     my $down_tmp = -1;

--- a/plugins/rtorrent/rtom_allsessions_spdd
+++ b/plugins/rtorrent/rtom_allsessions_spdd
@@ -115,7 +115,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_rtorrent_version $port;
+		    get_rtorrent_version $socket;
 		    close (SOCK);
 		  }
 		} else {

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -25,7 +25,6 @@
 #       src             "socket" when using scgi_socket, or anything else when using scgi_port
 #       socket          rTorrent's rpc socket (scgi_local)      - using scgi_local      - needed, when "src" is set to "socket"
 #       category        Change graph category
-#       api             use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -34,13 +33,11 @@
 #       env.src socket
 #       env.socket /home/user/torrent/.socket/rpc.socket,/home/user/torrent/.socket/rpc.socket
 #       env.category Category
-#       env.api current
 #
 #       [rtom_allsessions_*]
 #       user username
 #       env.port 5000,5001,5002,5003
 #       env.category Category
-#       env.api pre09
 #
 #%# family=auto
 
@@ -79,18 +76,48 @@ my $src         = $ENV{"src"} || "";
 my @sockets     = split /,/, $ENV{"socket"} || "";
 my $ip          = $ENV{"ip"} || "127.0.0.1";
 my @ports       = split /,/, $ENV{"port"} || "";
-my $api         = $ENV{"api"} || "current";
+
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
+}
+
 
 my $pattern     = qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 
+my $function_multicall;
+my $function_hash;
+
 foreach ( @views ) {
   my $num = 0;
-  my $line = "";
-  if ($api =~ /pre09/) {
-    $line = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>d.get_hash=</string></value></param></params></methodCall>";
-  } else {
-    $line = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall2</methodName><params><param><value><string></string></value></param><param><value><string>${_}</string></value></param><param><value><string>d.hash=</string></value></param></params></methodCall>";
-  }
+	$function_multicall	= rtorrent_version_lower_than('0.9.0')? 'd.multicall' : 'd.multicall2';
+	$function_hash	= rtorrent_version_lower_than('0.9.0')? 'd.get_hash=' : 'd.hash=';
+	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
   my $llen = length $line;
   my $header = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
   my $hlen = length $header;

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -80,7 +80,7 @@ my @ports       = split /,/, $ENV{"port"} || "";
 # detect rtorrent version
 use version;
 my %rtorrent_version;
-sub get_socket_version {
+sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
@@ -105,7 +105,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		} else {
@@ -113,7 +113,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
 		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-		    get_socket_version $port;
+		    get_rtorrent_version $port;
 		    close (SOCK);
 		  }
 		}

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -79,59 +79,74 @@ my @ports       = split /,/, $ENV{"port"} || "";
 
 # detect rtorrent version
 use version;
-my $rtorrent_version;
-sub rtorrent_version_lower_than {
-	if (not length $rtorrent_version){
-		if ( ( defined $src ) && ( $src eq "socket" ) ) {
-			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		} else {
-			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+my %rtorrent_version;
+sub get_socket_version {
+	my $version;
+	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+	my $llen	= length $line_version;
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen	= length $header;
+	$line_version= "${hlen}:${header},${line_version}";
+	print SOCK $line_version;
+	flush SOCK;
+	my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+	while ( $line = <SOCK> ) {
+		if ( $line =~ /$pattern/ ) {
+			$version = $1;
 		}
-		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
-		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-		my $hlen	= length $header;
-		$line_version= "${hlen}:${header},${line_version}";
-		print SOCK $line_version;
-		flush SOCK;
-		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
-		while ( $line = <SOCK> ) {
-			if ( $line =~ /$pattern/ ) {
-				$rtorrent_version = $1;
-			}
-		}
-		close (SOCK);
 	}
-        if(defined $_[0]){
-                return version->parse($rtorrent_version) < version->parse($_[0]);
-        }
+	close (SOCK);
+	$rtorrent_version{$_[0]} = $version;
+}
+sub rtorrent_version_lower_than {
+	if (keys %rtorrent_version == 0 && not defined $_[0]){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+		  for $socket (@sockets)
+		  {
+		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		} else {
+		  for $port (@ports)
+		  {
+		    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+		    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		    get_socket_version $port;
+		    close (SOCK);
+		  }
+		}
+	}
+	if(defined $_[1]){
+		return version->parse($rtorrent_version{$_[0]}) < version->parse($_[1]);
+	}
 }
 # init rtorrent_version
 rtorrent_version_lower_than();
 
 my $pattern     = qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 
-my $function_multicall;
-my $function_hash;
+sub construct_line {
+	my $function_multicall	= rtorrent_version_lower_than($_[0], '0.9.0')? 'd.multicall' : 'd.multicall2';
+	my $function_hash	= rtorrent_version_lower_than($_[0], '0.9.0')? 'd.get_hash=' : 'd.hash=';
+	my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
+	my $llen = length $line;
+	my $header = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $hlen = length $header;
+	$line = "${hlen}:${header},${line}";
+	return $line;
+}
 
 foreach ( @views ) {
   my $num = 0;
-	$function_multicall	= rtorrent_version_lower_than('0.9.0')? 'd.multicall' : 'd.multicall2';
-	$function_hash	= rtorrent_version_lower_than('0.9.0')? 'd.get_hash=' : 'd.hash=';
-	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
-  my $llen = length $line;
-  my $header = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
-  my $hlen = length $header;
 
   if ( ( defined $src ) && ( $src eq "socket" ) ) {
     for $socket (@sockets)
     {
       socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
       connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-      my $line = "${hlen}:${header},${line}";
-      print SOCK $line;
+      print SOCK construct_line($socket);
       flush SOCK;
       while ( $line = <SOCK> ) {
         if ( $line =~ /$pattern/ ) {
@@ -145,8 +160,7 @@ foreach ( @views ) {
     {
       socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
       connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-      my $line = "${hlen}:${header},${line}";
-      print SOCK $line;
+      print SOCK construct_line($port);
       flush SOCK;
       while ( $line = <SOCK> ) {
         if ( $line =~ /$pattern/ ) {

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -104,9 +104,12 @@ sub rtorrent_version_lower_than {
 		}
 		close (SOCK);
 	}
-	return version->parse($rtorrent_version) < version->parse($_[0]);
+        if(defined $_[0]){
+                return version->parse($rtorrent_version) < version->parse($_[0]);
+        }
 }
-
+# init rtorrent_version
+rtorrent_version_lower_than();
 
 my $pattern     = qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -128,9 +128,10 @@ rtorrent_version_lower_than();
 my $pattern     = qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 
 sub construct_line {
-	my $function_multicall	= rtorrent_version_lower_than($_[0], '0.9.0')? 'd.multicall' : 'd.multicall2';
-	my $function_hash	= rtorrent_version_lower_than($_[0], '0.9.0')? 'd.get_hash=' : 'd.hash=';
-	my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
+	my $function_multicall	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.multicall' : 'd.multicall2';
+	my $function_multicall_arg	= rtorrent_version_lower_than($_[0], '0.9.0') ? '' : '<param><value><string></string></value></param>';
+	my $function_hash	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.get_hash=' : 'd.hash=';
+	my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
 	my $llen = length $line;
 	my $header = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 	my $hlen = length $header;

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -105,7 +105,7 @@ sub rtorrent_version_lower_than {
 		  {
 		    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
 		    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-		    get_rtorrent_version $port;
+		    get_rtorrent_version $socket;
 		    close (SOCK);
 		  }
 		} else {

--- a/plugins/rtorrent/rtom_mem
+++ b/plugins/rtorrent/rtom_mem
@@ -27,6 +27,7 @@
 #	ip		rTorrent's ip address			- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
+#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -63,10 +64,16 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
+my $api         = $ENV{"api"} || "current";
 
 my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $line        = "";
+if ($api =~ /pre09/) {
+  $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>get_memory_usage</methodName></methodCall>";
+} else {
+  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>pieces.memory.current</methodName></methodCall>";
+}
 
-my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>get_memory_usage</methodName></methodCall>";
 my $llen	= length $line;
 my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen	= length $header;

--- a/plugins/rtorrent/rtom_mem
+++ b/plugins/rtorrent/rtom_mem
@@ -27,7 +27,6 @@
 #	ip		rTorrent's ip address			- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
-#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -64,16 +63,40 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
-my $api         = $ENV{"api"} || "current";
 
-my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
-my $line        = "";
-if ($api =~ /pre09/) {
-  $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>get_memory_usage</methodName></methodCall>";
-} else {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>pieces.memory.current</methodName></methodCall>";
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
 }
 
+my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $function	= rtorrent_version_lower_than('0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
+my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function</methodName></methodCall>";
 my $llen	= length $line;
 my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen	= length $header;

--- a/plugins/rtorrent/rtom_peers
+++ b/plugins/rtorrent/rtom_peers
@@ -27,6 +27,7 @@
 #	ip		rTorrent's ip address			- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
+#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -74,11 +75,17 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
+my $api         = $ENV{"api"} || "current";
 
 my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
 my $tpattern	= qr/[0-9A-F]{20}/;
 
-my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>d.get_hash=</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
+my $line        = "";
+if ($api =~ /pre09/) {
+  $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>d.get_hash=</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
+} else {
+  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall2</methodName><params><param><value><string></string></value></param><param><value><string>main</string></value></param><param><value><string>d.hash=</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
+}
 my $llen	= length $line;
 my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen	= length $header;

--- a/plugins/rtorrent/rtom_peers
+++ b/plugins/rtorrent/rtom_peers
@@ -27,7 +27,6 @@
 #	ip		rTorrent's ip address			- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
-#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -75,17 +74,43 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
-my $api         = $ENV{"api"} || "current";
+
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
+}
 
 my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
 my $tpattern	= qr/[0-9A-F]{20}/;
 
-my $line        = "";
-if ($api =~ /pre09/) {
-  $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>d.get_hash=</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
-} else {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall2</methodName><params><param><value><string></string></value></param><param><value><string>main</string></value></param><param><value><string>d.hash=</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
-}
+my $function_multicall	= rtorrent_version_lower_than('0.9.0') ? 'd.multicall' : 'd.multicall2';
+my $function_hash	= rtorrent_version_lower_than('0.9.0') ? 'd.get_hash=' : 'd.hash=';
+my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
 my $llen	= length $line;
 my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen	= length $header;

--- a/plugins/rtorrent/rtom_peers
+++ b/plugins/rtorrent/rtom_peers
@@ -109,8 +109,9 @@ my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>
 my $tpattern	= qr/[0-9A-F]{20}/;
 
 my $function_multicall	= rtorrent_version_lower_than('0.9.0') ? 'd.multicall' : 'd.multicall2';
+my $function_multicall_arg      = rtorrent_version_lower_than('0.9.0') ? '' : '<param><value><string></string></value></param>';
 my $function_hash	= rtorrent_version_lower_than('0.9.0') ? 'd.get_hash=' : 'd.hash=';
-my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
+my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
 my $llen	= length $line;
 my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen	= length $header;

--- a/plugins/rtorrent/rtom_spdd
+++ b/plugins/rtorrent/rtom_spdd
@@ -39,6 +39,7 @@
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
 #	diff		"yes" for using bps for upload and Bps for download, or anything else for using Bps for both
+#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 #
 # Configuration example
@@ -102,10 +103,17 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
+my $api         = $ENV{"api"} || "current";
 
 my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
 
-my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>get_up_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_down_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_upload_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_download_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
+my $line        = "";
+if ($api =~ /pre09/) {
+  $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>get_up_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_down_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_upload_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_download_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
+} else {
+  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>throttle.global_up.total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_down.total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_up.max_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_down.max_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
+}
+
 my $llen	= length $line;
 my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 my $hlen	= length $header;

--- a/plugins/rtorrent/rtom_spdd
+++ b/plugins/rtorrent/rtom_spdd
@@ -39,7 +39,6 @@
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
 #	diff		"yes" for using bps for upload and Bps for download, or anything else for using Bps for both
-#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 #
 # Configuration example
@@ -103,16 +102,43 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
-my $api         = $ENV{"api"} || "current";
 
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
+}
 my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
 
-my $line        = "";
-if ($api =~ /pre09/) {
-  $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>get_up_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_down_total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_upload_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>get_download_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
-} else {
-  $line         = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>throttle.global_up.total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_down.total</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_up.max_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>throttle.global_down.max_rate</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
-}
+my $function_totalup	= rtorrent_version_lower_than('0.9.0') ? 'get_up_total' : 'throttle.global_up.total';
+my $function_totaldown	= rtorrent_version_lower_than('0.9.0') ? 'get_down_total' : 'throttle.global_down.total';
+my $function_rateup	= rtorrent_version_lower_than('0.9.0') ? 'get_upload_rate' : 'throttle.global_up.max_rate';
+my $function_ratedown	= rtorrent_version_lower_than('0.9.0') ? 'get_download_rate' : 'throttle.global_down.max_rate';
+my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_rateup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_ratedown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
 
 my $llen	= length $line;
 my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";

--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -106,8 +106,12 @@ sub rtorrent_version_lower_than {
 		}
 		close (SOCK);
 	}
-	return version->parse($rtorrent_version) < version->parse($_[0]);
+	if(defined $_[0]){
+		return version->parse($rtorrent_version) < version->parse($_[0]);
+	}
 }
+# init rtorrent_version
+rtorrent_version_lower_than();
 
 my $pattern	= qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 

--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -121,6 +121,7 @@ my $header;
 my $hlen;
 
 my $function_multicall;
+my $function_multicall_arg;
 my $function_hash;
 
 my $num;
@@ -134,8 +135,9 @@ foreach ( @views ) {
 	}
 
 	$function_multicall	= rtorrent_version_lower_than('0.9.0')? 'd.multicall' : 'd.multicall2';
+	$function_multicall_arg	= rtorrent_version_lower_than($_[0], '0.9.0') ? '' : '<param><value><string></string></value></param>';
 	$function_hash	= rtorrent_version_lower_than('0.9.0')? 'd.get_hash=' : 'd.hash=';
-	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
+	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
 
 	$llen	= length $line;
 	$header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";

--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -27,7 +27,6 @@
 #	ip		rTorrent's ip address			- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
-#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -79,7 +78,36 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
-my $api         = $ENV{"api"} || "current";
+
+# detect rtorrent version
+use version;
+my $rtorrent_version;
+sub rtorrent_version_lower_than {
+	if (not length $rtorrent_version){
+		if ( ( defined $src ) && ( $src eq "socket" ) ) {
+			socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
+			connect( SOCK, sockaddr_un( $socket ) ) or die $!;
+		} else {
+			socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
+			connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
+		}
+		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
+		my $llen	= length $line_version;
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $hlen	= length $header;
+		$line_version= "${hlen}:${header},${line_version}";
+		print SOCK $line_version;
+		flush SOCK;
+		my $pattern	= qr/<value><string>([0-9.]+)<\/string><\/value>/;
+		while ( $line = <SOCK> ) {
+			if ( $line =~ /$pattern/ ) {
+				$rtorrent_version = $1;
+			}
+		}
+		close (SOCK);
+	}
+	return version->parse($rtorrent_version) < version->parse($_[0]);
+}
 
 my $pattern	= qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 
@@ -87,6 +115,9 @@ my $line;
 my $llenmy;
 my $header;
 my $hlen;
+
+my $function_multicall;
+my $function_hash;
 
 my $num;
 foreach ( @views ) {
@@ -98,11 +129,10 @@ foreach ( @views ) {
 		connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
 	}
 
-	if ($api =~ /pre09/) {
-		$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>d.get_hash=</string></value></param></params></methodCall>";
-	} else {
-		$line = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall2</methodName><params><param><value><string></string></value></param><param><value><string>${_}</string></value></param><param><value><string>d.hash=</string></value></param></params></methodCall>";
-	}
+	$function_multicall	= rtorrent_version_lower_than('0.9.0')? 'd.multicall' : 'd.multicall2';
+	$function_hash	= rtorrent_version_lower_than('0.9.0')? 'd.get_hash=' : 'd.hash=';
+	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
+
 	$llen	= length $line;
 	$header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 	$hlen	= length $header;

--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -27,6 +27,7 @@
 #	ip		rTorrent's ip address			- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	port		rTorrent's scgi port (scgi_port)	- using scgi_port	- needed, when "src" is NOT set to "socket"
 #	category        Change graph category
+#	api		use "pre09" (pre 0.9.0) or "current" (0.9.0+, the default) API calls
 #
 # Configuration example
 #
@@ -78,6 +79,7 @@ my $src 	= $ENV{"src"} || "";
 my $ip		= $ENV{"ip"} || "127.0.0.1";
 my $port	= $ENV{"port"} || "5000";
 my $socket	= $ENV{"socket"} || "";
+my $api         = $ENV{"api"} || "current";
 
 my $pattern	= qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 
@@ -96,7 +98,11 @@ foreach ( @views ) {
 		connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
 	}
 
-	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>d.get_hash=</string></value></param></params></methodCall>";
+	if ($api =~ /pre09/) {
+		$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall</methodName><params><param><value><string>${_}</string></value></param><param><value><string>d.get_hash=</string></value></param></params></methodCall>";
+	} else {
+		$line = "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>d.multicall2</methodName><params><param><value><string></string></value></param><param><value><string>${_}</string></value></param><param><value><string>d.hash=</string></value></param></params></methodCall>";
+	}
 	$llen	= length $line;
 	$header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
 	$hlen	= length $header;

--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -135,7 +135,7 @@ foreach ( @views ) {
 	}
 
 	$function_multicall	= rtorrent_version_lower_than('0.9.0')? 'd.multicall' : 'd.multicall2';
-	$function_multicall_arg	= rtorrent_version_lower_than($_[0], '0.9.0') ? '' : '<param><value><string></string></value></param>';
+	$function_multicall_arg	= rtorrent_version_lower_than('0.9.0') ? '' : '<param><value><string></string></value></param>';
 	$function_hash	= rtorrent_version_lower_than('0.9.0')? 'd.get_hash=' : 'd.hash=';
 	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
 


### PR DESCRIPTION
Aligning rtorrent rtrom_ modules same way as rtom_allsessions_ which was done in munin-monitoring/contrib#921:
In version 0.9.7 deprecated xmlrpc calls were dropped. The added files contain the needed changes for version 0.9.7+ of rtorrent.

Fixes: https://github.com/rakshasa/rtorrent/issues/757