### PR TITLE
Improved docker_ performance when getting CPU/Memory stats

### DIFF
--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -50,6 +50,7 @@ https://docs.docker.com/compose/reference/envvars/):
 import os
 import sys
 import docker
+from multiprocessing import Process, Queue
 
 
 def print_containers_status(client):
@@ -84,9 +85,26 @@ def print_containers_status(client):
     print('dead.value', dead)
 
 
-def print_containers_cpu(client):
+def get_container_stats(container, q):
+    q.put(container.stats(stream=False))
+
+
+def parallel_container_stats(client):
+    proc_list = []
+    stats = {}
     for container in client.containers.list():
-        stats = container.stats(stream=False)
+        q = Queue()
+        p = Process(target=get_container_stats, args=(container, q))
+        proc_list.append({'proc': p, 'queue': q, 'container': container})
+        p.start()
+    for proc in proc_list:
+        proc['proc'].join()
+        stats[proc['container']] = proc['queue'].get()
+    return stats.items()
+
+
+def print_containers_cpu(client):
+    for container, stats in parallel_container_stats(client):
         cpu_count = len(stats["cpu_stats"]["cpu_usage"]["percpu_usage"])
         cpu_percent = 0.0
         cpu_delta = float(stats["cpu_stats"]["cpu_usage"]["total_usage"]) \
@@ -99,9 +117,8 @@ def print_containers_cpu(client):
 
 
 def print_containers_memory(client):
-    for container in client.containers.list():
-        stats = container.stats(stream=False)['memory_stats']
-        print(container.name + '.value', stats['stats']['total_rss'])
+    for container, stats in parallel_container_stats(client):
+        print(container.name + '.value', stats['memory_stats']['stats']['total_rss'])
 
 
 def main():


### PR DESCRIPTION
Added parallel processing using python's muliprocessing module
to fork a new process each for each docker container when gathering
stats.

This vastly improves performance since using a for loop the script
blocks until the stats are returned.

When I ran the docker_cpu plugin without this change it would timeout. I have 43 containers running on the host in question and it would take about 90 seconds. With this improvement it takes 2-3.