### PR TITLE
Fixed warnings generated by total_by_process_

### DIFF
--- a/plugins/system/total_by_process_
+++ b/plugins/system/total_by_process_
@@ -32,7 +32,7 @@ $scriptname =~ s|.*/||;
 my $fieldname = ($scriptname =~ /^total_by_process_(.*)_(.*)/) ? $1 : undef;
 my $fieldtype = ($scriptname =~ /^total_by_process_(.*)_(.*)/) ? $2 : undef;
 
-if (@ARGV and $ARGV[1] eq "suggest")
+if (defined($ARGV[0]) and $ARGV[0] eq "suggest")
 {
 	system("ps L | cut -d' ' -f1");
 	exit(0);
@@ -86,7 +86,7 @@ foreach my $process (keys %total_by_process)
 
 close(PS);
 
-if (@ARGV and $ARGV[1] == "config")
+if (defined($ARGV[0]) and $ARGV[0] eq "config")
 {
 	print <<END;
 graph_title $fieldname by Process


### PR DESCRIPTION
Fixed the following:

* Argument "config" isn't numeric in numeric eq (==) at line 89.
* Use of uninitialized value $ARGV[1] in string eq at line 35