### PR TITLE
Fixed autoconf on http_request_time

### DIFF
--- a/plugins/http/http_request_time
+++ b/plugins/http/http_request_time
@@ -90,7 +90,7 @@ if ( defined $ARGV[0] and $ARGV[0] eq "autoconf" )
 	my $ua = LWP::UserAgent->new(timeout => $timeout);
 
 	foreach my $url (keys %URLS) {
-		my $response = $ua->request(HTTP::Request->new('GET',$url));
+		my $response = $ua->request(HTTP::Request->new('GET',$URLS{$url}{'url'}));
                 if ($response->is_success) {
                 	next;
                 }


### PR DESCRIPTION
Previously it would error since the $url variable is
the array key isn't the url to check it's a santized version