### PR TITLE
Change regex to match "prepend" pattern in postfix/policyd-spf-python plugin

### DIFF
--- a/plugins/postfix/policyd-spf-python
+++ b/plugins/postfix/policyd-spf-python
@@ -69,7 +69,7 @@ fi
 #
 
 function get_log_count() {
-	egrep "policyd-spf\[[0-9]+\]: $1;" "$LOGFILE" | grep "$(date '+%b %e')" | wc -l
+	egrep "policyd-spf\[[0-9]+\]:(.*) $1" "$LOGFILE" | grep "$(date '+%b %e')" | wc -l
 }
 
 PASS=$(get_log_count "Pass")


### PR DESCRIPTION
By default `policyd-spf-python` generate this output in `/var/log.mail.info`:
```
Apr 29 14:14:22 localhost policyd-spf[25915]: prepend Received-SPF: Pass (mailfrom) identity=mailfrom; client-ip=REDACTED; helo=example.com; envelope-from=example@example.com; receiver=<UNKNOWN>
```
This regex change can match also when `prepend Received-SPF` is present.