### PR TITLE
currency/bitcoin: fix graph category name typo

### DIFF
--- a/plugins/currency/bitcoin/bitcoind_
+++ b/plugins/currency/bitcoin/bitcoind_
@@ -125,7 +125,7 @@ def main():
         return True
 
     if command == 'config':
-        print('graph_category htc')
+        print('graph_category btc')
         print('graph_title Bitcoin %s' % labels[0])
         print('graph_vlabel %s' % labels[1])
         for label in line_labels:

--- a/plugins/currency/bitcoin/btcguild_hashrate_
+++ b/plugins/currency/bitcoin/btcguild_hashrate_
@@ -28,7 +28,7 @@ if command == 'config':
     print("graph_title BTCGuild Hashrate")
     print("graph_args --upper-limit 3000 -l 0")
     print("graph_vlabel MHash/s")
-    print("graph_category htc")
+    print("graph_category btc")
     for worker in workers:
         label = workers[worker]['worker_name']
         print(label + ".label " + label)

--- a/plugins/currency/bitcoin/slush_hashrate_
+++ b/plugins/currency/bitcoin/slush_hashrate_
@@ -25,7 +25,7 @@ if command == 'config':
     print "graph_title Slush Hashrate"
     print "graph_args --upper-limit 3000 -l 0"
     print "graph_vlabel MHash/s"
-    print "graph_category htc"
+    print "graph_category btc"
     for worker in workers:
         label = worker.replace(".","_")
         print label + ".label " +label

--- a/plugins/currency/bitcoin/slush_reward_
+++ b/plugins/currency/bitcoin/slush_reward_
@@ -24,7 +24,7 @@ if command == 'config':
     print "graph_title Slush Rewards"
     print "graph_args -l 0"
     print "graph_vlabel BTC"
-    print "graph_category htc"
+    print "graph_category btc"
     print "unconfirmed_reward.label Unconfirmed Reward"
     print "estimated_reward.label Estimeated Reward"
     print "confirmed_reward.label Confirmed Reward"


### PR DESCRIPTION
Fix "htc" typo to "btc".