### PR TITLE
murmur_users PHP 7 support

### DIFF
--- a/plugins/voip/murmur_users
+++ b/plugins/voip/murmur_users
@@ -95,7 +95,7 @@ if(isset($argv[1]) && $argv[1] == "config")
 // do the magic
 if(!$limit || ($limit >=5000 ) || $limit <= 0) $limit = 5000;
 $out = shell_exec("tail -n ".$limit." \"".$logfile."\"");
-$fp = split("\n",$out);
+$fp = explode("\n",$out);
 if(!count(@$fp)) {
 	fwrite(STDOUT, "0\n");
 	return 1;


### PR DESCRIPTION
`split` was deprecated in PHP 5.3.0 and removed in PHP 7.0.0, `explode`
is a drop-in replacement.