### PR TITLE
hwmon: recognize frequencies

### DIFF
--- a/plugins/sensors/hwmon
+++ b/plugins/sensors/hwmon
@@ -94,6 +94,13 @@ my %sensors = (
 		       graph_args => "--base 1000 -l 0",
 		       denominator => 1000000 # microWatts -> Watts
 		      },
+	     freq => {
+		      inputs => [],
+		      title => "Frequencies",
+		      vlabel => "Hz",
+		      graph_args => "--base 1000 -l 0",
+		      denominator => 1
+		     },
 	     humidity => {
 			  inputs => [],
 			  title => "Humidity",


### PR DESCRIPTION
Discovered thanks to an RX 570, which can show sclk and mclk via /sys/class/hwmon.