### PR TITLE
Improve kvm_* plugins

### DIFF
--- a/plugins/libvirt/kvm_cpu
+++ b/plugins/libvirt/kvm_cpu
@@ -52,6 +52,7 @@ def clean_vm_name(vm_name):
     if suffix:
         vm_name = re.sub(suffix,'',vm_name)
 
+    # proxmox uses kvm with -name parameter
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:

--- a/plugins/libvirt/kvm_cpu
+++ b/plugins/libvirt/kvm_cpu
@@ -52,6 +52,13 @@ def clean_vm_name(vm_name):
     if suffix:
         vm_name = re.sub(suffix,'',vm_name)
 
+    parts = vm_name.split('\x00')
+    if (parts[0].endswith('kvm')):
+        try:
+            return parts[parts.index('-name')+1]
+        except ValueError:
+            pass
+
     return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
 
 def detect_kvm():

--- a/plugins/libvirt/kvm_io
+++ b/plugins/libvirt/kvm_io
@@ -33,12 +33,11 @@ graph_args --base 1024
         print "%s_read.label %s" % (vm, vm)
         print "%s_read.type COUNTER" % vm
         print "%s_read.min 0" % vm
-        print "%s_read.draw LINE1" % vm
         print "%s_read.info I/O used by virtual machine %s" % (vm, vm)
+        print "%s_read.graph no" % vm
         print "%s_write.label %s" % (vm, vm)
         print "%s_write.type COUNTER" % vm
         print "%s_write.min 0" % vm
-        print "%s_write.draw LINE1" % vm
         print "%s_write.negative %s_read" % (vm, vm)
         print "%s_write.info I/O used by virtual machine %s" % (vm, vm)
 
@@ -51,14 +50,12 @@ def clean_vm_name(vm_name):
     suffix = os.getenv('vmsuffix')
     if suffix:
         vm_name = re.sub(suffix,'',vm_name)
-
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:
             return parts[parts.index('-name')+1]
         except ValueError:
             pass
-
     return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
 
 def fetch(vms):

--- a/plugins/libvirt/kvm_io
+++ b/plugins/libvirt/kvm_io
@@ -50,6 +50,7 @@ def clean_vm_name(vm_name):
     suffix = os.getenv('vmsuffix')
     if suffix:
         vm_name = re.sub(suffix,'',vm_name)
+    # proxmox uses kvm with -name parameter
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:

--- a/plugins/libvirt/kvm_io
+++ b/plugins/libvirt/kvm_io
@@ -52,6 +52,13 @@ def clean_vm_name(vm_name):
     if suffix:
         vm_name = re.sub(suffix,'',vm_name)
 
+    parts = vm_name.split('\x00')
+    if (parts[0].endswith('kvm')):
+        try:
+            return parts[parts.index('-name')+1]
+        except ValueError:
+            pass
+
     return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
 
 def fetch(vms):

--- a/plugins/libvirt/kvm_mem
+++ b/plugins/libvirt/kvm_mem
@@ -49,6 +49,13 @@ def clean_vm_name(vm_name):
     if suffix:
         vm_name = re.sub(suffix,'',vm_name)
 
+    parts = vm_name.split('\x00')
+    if (parts[0].endswith('kvm')):
+        try:
+            return parts[parts.index('-name')+1]
+        except ValueError:
+            pass
+
     return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
 
 def fetch(vms):

--- a/plugins/libvirt/kvm_mem
+++ b/plugins/libvirt/kvm_mem
@@ -49,6 +49,7 @@ def clean_vm_name(vm_name):
     if suffix:
         vm_name = re.sub(suffix,'',vm_name)
 
+    # proxmox uses kvm with -name parameter
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:

--- a/plugins/libvirt/kvm_net
+++ b/plugins/libvirt/kvm_net
@@ -82,12 +82,11 @@ def config(vm_names):
         print("%s_in.label %s" % (vm, vm))
         print("%s_in.type COUNTER" % vm)
         print("%s_in.min 0" % vm)
-        print("%s_in.draw LINE2" % vm)
+        print("%s_in.graph no" % vm)
         print("%s_out.negative %s_in" % (vm, vm))
         print("%s_out.label %s" % (vm, vm))
         print("%s_out.type COUNTER" % vm)
         print("%s_out.min 0" % vm)
-        print("%s_out.draw LINE2" % vm)
 
 
 def clean_vm_name(vm_name):
@@ -100,14 +99,12 @@ def clean_vm_name(vm_name):
     suffix = os.getenv("vmsuffix")
     if suffix:
         vm_name = re.sub(suffix, "", vm_name)
-
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:
             return parts[parts.index('-name')+1]
         except ValueError:
             pass
-
     return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
 
 

--- a/plugins/libvirt/kvm_net
+++ b/plugins/libvirt/kvm_net
@@ -100,6 +100,14 @@ def clean_vm_name(vm_name):
     suffix = os.getenv("vmsuffix")
     if suffix:
         vm_name = re.sub(suffix, "", vm_name)
+
+    parts = vm_name.split('\x00')
+    if (parts[0].endswith('kvm')):
+        try:
+            return parts[parts.index('-name')+1]
+        except ValueError:
+            pass
+
     return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
 
 

--- a/plugins/libvirt/kvm_net
+++ b/plugins/libvirt/kvm_net
@@ -99,6 +99,7 @@ def clean_vm_name(vm_name):
     suffix = os.getenv("vmsuffix")
     if suffix:
         vm_name = re.sub(suffix, "", vm_name)
+    # proxmox uses kvm with -name parameter
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:


### PR DESCRIPTION
This fixes the label (vm names) for vms startet via kvm. This was tested on a host running Proxmox VE. In addition I've removed the draw parameter to unify the graphs and removed the duplicate graph from kvm_io and kvm_net.