### PR TITLE
docker_cpu: fix data for container names starting with numbers

### DIFF
--- a/plugins/docker/docker_cpu
+++ b/plugins/docker/docker_cpu
@@ -62,10 +62,13 @@ for my $i (1 .. $#containers)
    my @fields = split / +/, $containers[$i];
    my $id = $fields[0];
    my $name = $fields[$#fields];
+   my $label = $name;
    # manage container name containing arithmetic operators and dots. E.g, my-container.
    $name =~ s/[-\+*\/\.]/_/g;
    # truncate container name with "," character.
    $name =~ s/,.*//g;
+   # prefix if container starts with 0-9
+   $name =~ s/^([0-9])/c$1/;
    if (open(my $file, '<', "/sys/fs/cgroup/cpuacct/docker/$id/cpuacct.usage"))
    {
       my $total_cpu_ns = <$file>;
@@ -75,7 +78,7 @@ for my $i (1 .. $#containers)
       {
          my @ncpu = split / /, <$file>;
          close $file;
-         push @result, {'name'=>$name, 'total_cpu_ns'=>$total_cpu_ns, 'ncpu'=>$#ncpu};
+         push @result, {'name'=>$name, 'label'=>$label, 'total_cpu_ns'=>$total_cpu_ns, 'ncpu'=>$#ncpu};
       }
    }
 }
@@ -100,7 +103,7 @@ if (defined $ARGV[0] and $ARGV[0] eq "config")
 
    foreach(@result)
    {
-      print "$$_{'name'}.label $$_{'name'}\n";
+      print "$$_{'name'}.label $$_{'label'}\n";
       print "$$_{'name'}.draw LINE2\n";
       print "$$_{'name'}.min 0\n";
       print "$$_{'name'}.type DERIVE\n";

--- a/plugins/docker/docker_cpu
+++ b/plugins/docker/docker_cpu
@@ -86,9 +86,9 @@ for my $i (1 .. $#containers)
 if (defined $ARGV[0] and $ARGV[0] eq "config")
 {
    my $nanoSecondsInSecond=1000000000;
-   my $graphlimit = $result[0]{'ncpu'};
+   my $graphlimit = 1;
    foreach(@result){
-      if ($$_{'ncpu'} > $graphlimit){
+      if ($$_{'ncpu'} || 1 > $graphlimit){
          $graphlimit = $$_{'ncpu'};
       }
    }


### PR DESCRIPTION
This fixes an issue with docker_cpu when your container names start with integers (e.g. because you found it a good idea to prefix them with the CI_PIPELINE_ID ;-) )

munin-node output
```
155222_110_testyaml_nginx_1.cdef 155222_110_testyaml_nginx_1,1000000000,/
```

gets transfered to when calling rrd
```
...
DEF:a06259ff28d9f69b=/var/lib/munin/redacted/redacted-docker_cpu-_55222_110_testyaml_nginx_1-d.rrd:42:MAX
DEF:i06259ff28d9f69b=/var/lib/munin/redacted/redacted-docker_cpu-_55222_110_testyaml_nginx_1-d.rrd:42:MIN
DEF:g06259ff28d9f69b=/var/lib/munin/redacted/redacted-docker_cpu-_55222_110_testyaml_nginx_1-d.rrd:42:AVERAGE
...
CDEF:a27dc539c2004686=155222_110_testyaml_nginx_1,1000000000,/
CDEF:i27dc539c2004686=155222_110_testyaml_nginx_1,1000000000,/
CDEF:g27dc539c2004686=155222_110_testyaml_nginx_1,1000000000,/
...
```

and causes an error there (logged in munin-graph.log):
```
2020/07/23 15:18:03 [WARNING] Could not draw graph "/var/cache/munin/www/redacted/redacted/docker_cpu-day.png": /var/cache/munin/www/redacted/redacted/docker_cpu-day.png
2020/07/23 15:18:03 [RRD ERROR] Unable to graph /var/cache/munin/www/redacted/redacted/docker_cpu-year.png : don't understand '155262_110_testyaml_nginx_1,1000000000,/'
2020/07/23 15:18:03 [RRD ERROR] rrdtool 'graph' '/var/cache/munin/www/redacted/redacted/docker_cpu-year.png' \
        '--title' \
        'Docker container CPU usage - by year' \
        '--start' \
        '-400d' \
        '--base' \
        '1000' \
        '-r' \
        '--lower-limit' \
```

this looks like a munin(-graph?) bug (not replacing the name in CDEF correctly when it started with a number originally), but i guess it's best to not start the names with numbers (and i have no clue how to fix it in munin).

Info @wt-io-it