### PR TITLE
[dm_cache_] support volumes with multiple dashes

### DIFF
--- a/plugins/disk/dm_cache_occupancy_
+++ b/plugins/disk/dm_cache_occupancy_
@@ -50,7 +50,10 @@ GPLv2
 
 CVOL=${0##*dm_cache_occupancy_}
 #workaround for http://munin-monitoring.org/ticket/1236
-CVOL=${CVOL/____/-}
+while [[ $CVOL == *"____"* ]]
+do
+	CVOL=${CVOL/____/-}
+done
 
 case $1 in
 	autoconf)

--- a/plugins/disk/dm_cache_statistics_
+++ b/plugins/disk/dm_cache_statistics_
@@ -50,7 +50,10 @@ GPLv2
 
 CVOL=${0##*dm_cache_statistics_}
 #workaround for http://munin-monitoring.org/ticket/1236
-CVOL=${CVOL/____/-}
+while [[ $CVOL == *"____"* ]]
+do
+	CVOL=${CVOL/____/-}
+done
 
 case $1 in
 	autoconf)


### PR DESCRIPTION
Promox is creating logical volumes with names like `vm--100--disk--0`