### PR TITLE
plugins/puppet/puppet_runtime: fix formatting

### DIFF
--- a/plugins/puppet/puppet_runtime
+++ b/plugins/puppet/puppet_runtime
@@ -15,9 +15,9 @@
 
 # reports how long the puppet agent took to apply the catalog
 def get_runtime
-  logfile = ENV['puppet_logfile'] || '/var/log/messages'
+  logfile = ENV["puppet_logfile"] || "/var/log/messages"
   t = Time.now
-  dateformat = ENV['puppet_logformat'] || "^%b %d"
+  dateformat = ENV["puppet_logformat"] || "^%b %d"
   today = t.strftime(dateformat)
   File.open(logfile).grep(/#{today}/).grep(/Finished catalog run in/).reverse_each do |line|
     if line =~ /in (.*) seconds/
@@ -28,18 +28,17 @@ def get_runtime
 end
 
 case ARGV[0]
-	when 'config'
-    puts "graph_category other"
-    puts "graph_args --base 1000 -l 0"
-    puts "graph_scale no"
-    puts "graph_title puppet catalog run time"
-    puts "graph_vlabel Seconds"
-    puts "runtime.label Catalog application time"
-		exit 0
-	when 'autoconf'
-		puts "yes"
-		exit 0
-	else
-  		get_runtime
+when "config"
+  puts "graph_category other"
+  puts "graph_args --base 1000 -l 0"
+  puts "graph_scale no"
+  puts "graph_title puppet catalog run time"
+  puts "graph_vlabel Seconds"
+  puts "runtime.label Catalog application time"
+  exit 0
+when "autoconf"
+  puts "yes"
+  exit 0
+else
+  get_runtime
 end
-


### PR DESCRIPTION
Used [rufo](https://github.com/ruby-formatter/rufo) to correct the formatting (it had a mix of tabs and spaces).