### PR TITLE
[plugins/disk/] Add plugins to monitor btrfs pools on a per device base

### DIFF
--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -11,7 +11,10 @@ btrfs_device_stats - Script to monitor btrfs device statistics
 =head1 CONFIGURATION
 
 Simply create a symlink in your plugins directory like with any other plugin.
-No configuration needed.
+Must be run as root.
+
+[btrfs_device_stats]
+user root
 
 =head2 DEFAULT CONFIGURATION
 
@@ -24,7 +27,7 @@ No configuration needed.
 =head1 MAGIC MARKERS
 
  #%# family=auto
- #%# capabilities=autoconf suggest
+ #%# capabilities=autoconf
 
 =head1 LICENSE
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -80,7 +80,6 @@ def munin_values(fs):
     devices = fs.devices()
     
     for this_device in devices:
-        this_dev_info = fs.dev_info(this_device.devid)
         this_dev_stat = fs.dev_stats(this_device.devid, False)
         
         corruption_errs = this_dev_stat.corruption_errs

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -1,5 +1,39 @@
 #!/usr/bin/env python3
-#
+
+
+"""
+=pod
+
+=head1 NAME
+
+btrfs_device_stats - Script to monitor btrfs device statistics
+
+=head1 CONFIGURATION
+
+Simply create a symlink in your plugins directory like with any other plugin.
+No configuration needed.
+
+=head2 DEFAULT CONFIGURATION
+
+=head1 BUGS
+
+=head1 AUTHOR
+
+2019, HaseHarald
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf suggest
+
+=head1 LICENSE
+
+LGPLv3
+
+=cut
+"""
+
+
 # This file contains a munin-plugin to gather btrfs statistics per device.
 #
 # This is free software: you can redistribute it and/or modify

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -1,0 +1,140 @@
+#!/usr/bin/python3 
+#
+# This file contains a munin-plugin to gather btrfs statistics per device.
+#
+# This is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this plugin.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import btrfs
+import sys
+
+
+def munin_config(fs):
+    fsid = str(fs.fsid).replace('-', '_')
+    print("multigraph btrfs_device_stats_" + fsid)
+    print("graph_args --base 1000 -l 0")
+    print("graph_vlabel total btrfs attribute value")
+    print("graph_title btrfs total device stats for " + fs.path)
+    print("graph_category disk")
+    print("graph_info This graph shows the total stats of devices used by btrfs")
+    
+    print("corruption_errs_total.label Corruption Errors")
+    print("flush_errs_total.label Flush Errors")
+    print("generation_errs_total.label Generation Errors")
+    print("read_errs_total.label Read Errors")
+    print("write_errs_total.label Write Errors")
+    print("nr_items_total.label Nr. of Items")
+    print("flags_total.label Nr. of Flags")
+    
+    print("")
+    
+    devices = fs.devices()
+    for this_device in devices:
+        this_dev_info = fs.dev_info(this_device.devid)
+        this_dev_name = this_dev_info.path.replace('/dev/', '')
+        print("multigraph btrfs_device_stats_" + fsid + "." + str(this_device.devid))
+        print("graph_args --base 1000 -l 0")
+        print("graph_vlabel btrfs attribute value")
+        print("graph_title btrfs device stats for " + this_dev_name)
+        print("graph_category disk")
+        print("graph_info This graph shows stats of devices used by btrfs")
+        
+        print("corruption_errs.label Corruption Errors")
+        print("corruption_errs.warming 1")
+        print("flush_errs.label Flush Errors")
+        print("flush_errs.warming 1")
+        print("generation_errs.label Generation Errors")
+        print("generation_errs.warming 1")
+        print("read_errs.label Read Errors")
+        print("read_errs.warming 1")
+        print("write_errs.label Write Errors")
+        print("write_errs.warming 1")
+        print("nr_items.label Nr. of Items")
+        print("flags.label Nr. of Flags")
+        print("flags.warming 1")
+        
+        print("")
+
+
+def munin_values(fs):
+    corruption_errs_total = 0
+    flush_errs_total = 0
+    generation_errs_total = 0
+    read_errs_total = 0
+    write_errs_total = 0
+    nr_items_total = 0
+    flags_total = 0
+    
+    fsid = str(fs.fsid).replace('-', '_')
+    devices = fs.devices()
+    
+    for this_device in devices:
+        this_dev_info = fs.dev_info(this_device.devid)
+        this_dev_name = this_dev_info.path.replace('/dev/', '')
+        this_dev_stat = fs.dev_stats(this_device.devid, False)
+        
+        corruption_errs = this_dev_stat.corruption_errs
+        flush_errs = this_dev_stat.flush_errs
+        generation_errs = this_dev_stat.generation_errs
+        read_errs = this_dev_stat.read_errs
+        write_errs = this_dev_stat.write_errs
+        nr_items = this_dev_stat.nr_items
+        flags = this_dev_stat.flags
+        
+        corruption_errs_total = corruption_errs_total + corruption_errs
+        flush_errs_total = flush_errs_total + flush_errs
+        generation_errs_total = generation_errs_total + generation_errs
+        read_errs_total = read_errs_total + read_errs
+        write_errs_total = write_errs_total + write_errs
+        nr_items_total = nr_items_total + nr_items
+        flags_total = flags_total + flags
+        
+        print("multigraph btrfs_device_stats_" + fsid + "." + str(this_device.devid))
+        
+        print("corruption_errs.value " + str(corruption_errs))
+        print("flush_errs.value " + str(flush_errs))
+        print("generation_errs.value " + str(generation_errs))
+        print("read_errs.value " + str(read_errs))
+        print("write_errs.value " + str(write_errs))
+        print("nr_items.value " + str(nr_items))
+        print("flags.value " + str(flags))
+        
+        print("")
+    
+    print("multigraph btrfs_device_stats_" + fsid)
+    
+    print("corruption_errs_total.value " + str(corruption_errs_total))
+    print("flush_errs_total.value " + str(flush_errs_total))
+    print("generation_errs_total.value " + str(generation_errs_total))
+    print("read_errs_total.value " + str(read_errs_total))
+    print("write_errs_total.value " + str(write_errs_total))
+    print("nr_items_total.value " + str(nr_items_total))
+    print("flags_total.value " + str(flags_total))
+    
+    print("")
+
+
+def main():
+    for path in btrfs.utils.mounted_filesystem_paths():
+        with btrfs.FileSystem(path) as fs:
+            if len(sys.argv) > 1 and sys.argv[1] == "config":
+                munin_config(fs)
+            else:
+                munin_values(fs)
+
+
+if __name__ == "__main__":
+    main()
+
+exit(0)

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # This file contains a munin-plugin to gather btrfs statistics per device.
 #
@@ -28,7 +28,7 @@ def munin_config(fs):
     print("graph_title btrfs total device stats for " + fs.path)
     print("graph_category disk")
     print("graph_info This graph shows the total stats of devices used by btrfs")
-    
+
     print("corruption_errs_total.label Corruption Errors")
     print("flush_errs_total.label Flush Errors")
     print("generation_errs_total.label Generation Errors")
@@ -36,9 +36,9 @@ def munin_config(fs):
     print("write_errs_total.label Write Errors")
     print("nr_items_total.label Nr. of Items")
     print("flags_total.label Nr. of Flags")
-    
+
     print("")
-    
+
     devices = fs.devices()
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
@@ -49,7 +49,7 @@ def munin_config(fs):
         print("graph_title btrfs device stats for " + this_dev_name)
         print("graph_category disk")
         print("graph_info This graph shows stats of devices used by btrfs")
-        
+
         print("corruption_errs.label Corruption Errors")
         print("corruption_errs.warming 1")
         print("flush_errs.label Flush Errors")
@@ -63,7 +63,7 @@ def munin_config(fs):
         print("nr_items.label Nr. of Items")
         print("flags.label Nr. of Flags")
         print("flags.warming 1")
-        
+
         print("")
 
 
@@ -75,13 +75,13 @@ def munin_values(fs):
     write_errs_total = 0
     nr_items_total = 0
     flags_total = 0
-    
+
     fsid = str(fs.fsid).replace('-', '_')
     devices = fs.devices()
-    
+
     for this_device in devices:
         this_dev_stat = fs.dev_stats(this_device.devid, False)
-        
+
         corruption_errs = this_dev_stat.corruption_errs
         flush_errs = this_dev_stat.flush_errs
         generation_errs = this_dev_stat.generation_errs
@@ -89,7 +89,7 @@ def munin_values(fs):
         write_errs = this_dev_stat.write_errs
         nr_items = this_dev_stat.nr_items
         flags = this_dev_stat.flags
-        
+
         corruption_errs_total = corruption_errs_total + corruption_errs
         flush_errs_total = flush_errs_total + flush_errs
         generation_errs_total = generation_errs_total + generation_errs
@@ -97,9 +97,9 @@ def munin_values(fs):
         write_errs_total = write_errs_total + write_errs
         nr_items_total = nr_items_total + nr_items
         flags_total = flags_total + flags
-        
+
         print("multigraph btrfs_device_stats_" + fsid + "." + str(this_device.devid))
-        
+
         print("corruption_errs.value " + str(corruption_errs))
         print("flush_errs.value " + str(flush_errs))
         print("generation_errs.value " + str(generation_errs))
@@ -107,11 +107,11 @@ def munin_values(fs):
         print("write_errs.value " + str(write_errs))
         print("nr_items.value " + str(nr_items))
         print("flags.value " + str(flags))
-        
+
         print("")
-    
+
     print("multigraph btrfs_device_stats_" + fsid)
-    
+
     print("corruption_errs_total.value " + str(corruption_errs_total))
     print("flush_errs_total.value " + str(flush_errs_total))
     print("generation_errs_total.value " + str(generation_errs_total))
@@ -119,7 +119,7 @@ def munin_values(fs):
     print("write_errs_total.value " + str(write_errs_total))
     print("nr_items_total.value " + str(nr_items_total))
     print("flags_total.value " + str(flags_total))
-    
+
     print("")
 
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 
+#!/usr/bin/python3
 #
 # This file contains a munin-plugin to gather btrfs statistics per device.
 #
@@ -81,7 +81,6 @@ def munin_values(fs):
     
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
-        this_dev_name = this_dev_info.path.replace('/dev/', '')
         this_dev_stat = fs.dev_stats(this_device.devid, False)
         
         corruption_errs = this_dev_stat.corruption_errs

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -1,5 +1,39 @@
 #!/usr/bin/env python3
-#
+
+
+"""
+=pod
+
+=head1 NAME
+
+btrfs_device_usage - Script to monitor usage of btrfs devices
+
+=head1 CONFIGURATION
+
+Simply create a symlink in your plugins directory like with any other plugin.
+No configuration needed.
+
+=head2 DEFAULT CONFIGURATION
+
+=head1 BUGS
+
+=head1 AUTHOR
+
+2019, HaseHarald
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf suggest
+
+=head1 LICENSE
+
+LGPLv3
+
+=cut
+"""
+
+
 # This file contains a munin-plugin to gather btrfs statistics per device.
 #
 # This is free software: you can redistribute it and/or modify

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -1,0 +1,96 @@
+#!/usr/bin/python3 
+#
+# This file contains a munin-plugin to gather btrfs statistics per device.
+#
+# This is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this plugin.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import btrfs
+import sys
+
+def munin_config(fs):
+    fsid = str(fs.fsid).replace('-', '_')
+    
+    print("multigraph btrfs_device_usage_byte_" + fsid)
+    print("graph_title btrfs usage by device in bytes on " + fs.path)
+    print("graph_args --base 1024 -l 0")
+    print("graph_scale yes")
+    print("graph_vlabel bytes")
+    print("graph_category disk")
+    print("graph_info This graph shows bytes used by btrfs on every device")
+    
+    devices = fs.devices()
+    for this_device in devices:
+        this_dev_info = fs.dev_info(this_device.devid)
+        this_dev_name = this_dev_info.path.replace('/dev/', '')
+        print("btrfs_bytes_"+ fsid + "_" + str(this_device.devid) + ".label " + this_dev_name)
+    
+    print("")
+    
+    print("multigraph btrfs_device_usage_percent_" + fsid)
+    print("graph_title btrfs usage by device in percent on " + fs.path)
+    print("graph_args --base 1000 -l 0")
+    print("graph_scale no")
+    print("graph_vlabel %")
+    print("graph_category disk")
+    print("graph_info This graph shows percentage used by btrfs on every device. Maesured in percentage of device capacity.")
+    
+    devices = fs.devices()
+    for this_device in devices:
+        this_dev_info = fs.dev_info(this_device.devid)
+        this_dev_name = this_dev_info.path.replace('/dev/', '')
+        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".label " + this_dev_name)
+        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".warning 95")
+        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".critical 98")
+    
+    print("")
+
+def munin_values(fs):
+    fsid = str(fs.fsid).replace('-', '_')
+    devices = fs.devices()
+    
+    print("multigraph btrfs_device_usage_byte_" + fsid)
+    
+    for this_device in devices:
+        this_dev_info = fs.dev_info(this_device.devid)
+        print("btrfs_bytes_"+ fsid + "_" + str(this_device.devid) + ".value " + str(this_dev_info.bytes_used))
+    
+    print("")
+    
+    # Reset device iterator
+    devices = fs.devices()
+    
+    print("multigraph btrfs_device_usage_percent_" + fsid)
+    
+    for this_device in devices:
+        this_dev_info = fs.dev_info(this_device.devid)
+        usage = 100.0 * this_dev_info.bytes_used / this_dev_info.total_bytes
+        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".value " + str(round(usage, 2)))
+    
+    print("")
+    
+
+def main():
+    for path in btrfs.utils.mounted_filesystem_paths():
+        with btrfs.FileSystem(path) as fs:
+            if len(sys.argv) > 1 and sys.argv[1] == "config":
+                munin_config(fs)
+            else:
+                munin_values(fs)
+
+
+if __name__ == "__main__":
+    main()
+
+exit(0)

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # This file contains a munin-plugin to gather btrfs statistics per device.
 #
@@ -22,7 +22,7 @@ import sys
 
 def munin_config(fs):
     fsid = str(fs.fsid).replace('-', '_')
-    
+
     print("multigraph btrfs_device_usage_byte_" + fsid)
     print("graph_title btrfs usage by device in bytes on " + fs.path)
     print("graph_args --base 1024 -l 0")
@@ -30,16 +30,16 @@ def munin_config(fs):
     print("graph_vlabel bytes")
     print("graph_category disk")
     print("graph_info This graph shows bytes used by btrfs on every device")
-    
+
     devices = fs.devices()
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
         print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
-            ".label " + this_dev_name)
-    
+              ".label " + this_dev_name)
+
     print("")
-    
+
     print("multigraph btrfs_device_usage_percent_" + fsid)
     print("graph_title btrfs usage by device in percent on " + fs.path)
     print("graph_args --base 1000 -l 0")
@@ -47,46 +47,46 @@ def munin_config(fs):
     print("graph_vlabel %")
     print("graph_category disk")
     print("graph_info This graph shows percentage used by btrfs on every \
-            device. Maesured in percentage of device capacity.")
-    
+          device. Maesured in percentage of device capacity.")
+
     devices = fs.devices()
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
         print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
-            ".label " + this_dev_name)
+              ".label " + this_dev_name)
         print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".warning 95")
         print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".critical 98")
-    
+
     print("")
 
 
 def munin_values(fs):
     fsid = str(fs.fsid).replace('-', '_')
     devices = fs.devices()
-    
+
     print("multigraph btrfs_device_usage_byte_" + fsid)
-    
+
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
-            ".value " + str(this_dev_info.bytes_used))
-    
+              ".value " + str(this_dev_info.bytes_used))
+
     print("")
-    
+
     # Reset device iterator
     devices = fs.devices()
-    
+
     print("multigraph btrfs_device_usage_percent_" + fsid)
-    
+
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         usage = 100.0 * this_dev_info.bytes_used / this_dev_info.total_bytes
         print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
-            ".value " + str(round(usage, 2)))
-    
+              ".value " + str(round(usage, 2)))
+
     print("")
-    
+
 
 def main():
     for path in btrfs.utils.mounted_filesystem_paths():

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -11,7 +11,10 @@ btrfs_device_usage - Script to monitor usage of btrfs devices
 =head1 CONFIGURATION
 
 Simply create a symlink in your plugins directory like with any other plugin.
-No configuration needed.
+Must be run as root.
+
+[btrfs_device_usage]
+user root
 
 =head2 DEFAULT CONFIGURATION
 
@@ -24,7 +27,7 @@ No configuration needed.
 =head1 MAGIC MARKERS
 
  #%# family=auto
- #%# capabilities=autoconf suggest
+ #%# capabilities=autoconf
 
 =head1 LICENSE
 

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -35,8 +35,8 @@ def munin_config(fs):
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
-        print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) + \
-                ".label " + this_dev_name)
+        print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
+            ".label " + this_dev_name)
     
     print("")
     
@@ -53,8 +53,8 @@ def munin_config(fs):
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
-        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + \
-                ".label " + this_dev_name)
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
+            ".label " + this_dev_name)
         print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".warning 95")
         print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".critical 98")
     
@@ -69,8 +69,8 @@ def munin_values(fs):
     
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
-        print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) + \
-                ".value " + str(this_dev_info.bytes_used))
+        print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
+            ".value " + str(this_dev_info.bytes_used))
     
     print("")
     
@@ -82,8 +82,8 @@ def munin_values(fs):
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         usage = 100.0 * this_dev_info.bytes_used / this_dev_info.total_bytes
-        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + \
-                ".value " + str(round(usage, 2)))
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
+            ".value " + str(round(usage, 2)))
     
     print("")
     

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 
+#!/usr/bin/python3
 #
 # This file contains a munin-plugin to gather btrfs statistics per device.
 #
@@ -19,6 +19,7 @@
 import btrfs
 import sys
 
+
 def munin_config(fs):
     fsid = str(fs.fsid).replace('-', '_')
     
@@ -34,7 +35,8 @@ def munin_config(fs):
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
-        print("btrfs_bytes_"+ fsid + "_" + str(this_device.devid) + ".label " + this_dev_name)
+        print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) + \
+                ".label " + this_dev_name)
     
     print("")
     
@@ -44,17 +46,20 @@ def munin_config(fs):
     print("graph_scale no")
     print("graph_vlabel %")
     print("graph_category disk")
-    print("graph_info This graph shows percentage used by btrfs on every device. Maesured in percentage of device capacity.")
+    print("graph_info This graph shows percentage used by btrfs on every \
+            device. Maesured in percentage of device capacity.")
     
     devices = fs.devices()
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
-        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".label " + this_dev_name)
-        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".warning 95")
-        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".critical 98")
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + \
+                ".label " + this_dev_name)
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".warning 95")
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".critical 98")
     
     print("")
+
 
 def munin_values(fs):
     fsid = str(fs.fsid).replace('-', '_')
@@ -64,7 +69,8 @@ def munin_values(fs):
     
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
-        print("btrfs_bytes_"+ fsid + "_" + str(this_device.devid) + ".value " + str(this_dev_info.bytes_used))
+        print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) + \
+                ".value " + str(this_dev_info.bytes_used))
     
     print("")
     
@@ -76,7 +82,8 @@ def munin_values(fs):
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         usage = 100.0 * this_dev_info.bytes_used / this_dev_info.total_bytes
-        print("btrfs_percent_"+ fsid + "_" + str(this_device.devid) + ".value " + str(round(usage, 2)))
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + \
+                ".value " + str(round(usage, 2)))
     
     print("")
     


### PR DESCRIPTION
Graph the usage (in bytes and percent) and the device statistics (mainly error counters) of the devices in a btrfs pool.

I've written these plugins to scratch my own itch and have been using them for about a year now. They work great for me, but that doesn't mean they are perfect.