### PR TITLE
[docker_] Fake functools.cached_property for Python<3.8

### DIFF
--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -77,7 +77,13 @@ This section has been reverse-engineered from git logs
 import os
 import sys
 import re
-from functools import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    # If cached_property is not available,
+    # just use the property decorator, without caching
+    # This is for backward compatibility with Python<3.8
+    cached_property = property
 from multiprocessing import Process, Queue
 
 


### PR DESCRIPTION
Fixes: #1116
Signed-off-by: Olivier Mehani <shtrom@ssji.net>