### PR TITLE
avoid blocking in http_responsecode

### DIFF
--- a/plugins/http/http_responsecode
+++ b/plugins/http/http_responsecode
@@ -12,11 +12,13 @@ http_responsecode - Is the site up?
 The following environment variables are used
 
  sites       - Sites to check
+ max_time    - Timeout for each site check - defaults to 5 seconds
 
 Configuration example
 
  [http_responsecode]
   env.sites example.com example2.de
+  env.max_time 5
 
 =head1 AUTHOR
 
@@ -63,6 +65,6 @@ fi
 for site in $sites; do
     export siteid=`echo $site | sed 's/[^a-z]*//g'`
     echo -n "$siteid.value "
-    curl --write-out %{http_code} --silent --output /dev/null ${site}
+    curl --write-out %{http_code} --max-time "${max_time:-5}" --silent --output /dev/null "${site}"
     echo
 done


### PR DESCRIPTION
Just in case there is a firewall dropping packages, this plugin
would block until the plugin timeout is reached. This change introduces
the possibility to configure a much lower individual timeout.