### PR TITLE
silly bug: writecycles must be calculated from *written* bytes

### DIFF
--- a/plugins/disk/nvme
+++ b/plugins/disk/nvme
@@ -267,7 +267,7 @@ EOF
         my $info = $list->{$_};
 
         # The unit size reported is 1000 blocks.
-        my $cycles = $info->{smart}->{data_units_read} * 512_000 / $info->{capacity};
+        my $cycles = $info->{smart}->{data_units_written} * 512_000 / $info->{capacity};
         print "$_.value $cycles\n";
     }
 }


### PR DESCRIPTION
This fixes issue #1127