### PR TITLE
[plugins/nextcloud_] Only use one call to JQ to parse and report the …

### DIFF
--- a/plugins/nextcloud/nextcloud_
+++ b/plugins/nextcloud/nextcloud_
@@ -79,7 +79,7 @@ case $1 in
 	    if [ ! -x "$(command -v curl)" ]; then
 		    echo "no (curl not found)"
 	    elif [ ! -x "$(command -v jq)" ]; then
-		    echo "no (jq not found)"exit 0
+		    echo "no (jq not found)"
 	    else
 		    fetch_url -I -u "${USERNAME}:${PASSWORD}" -I "${SCHEME}${DOMAIN}${API_PATH}" \
 			    | grep -iq "Content-Type: application/json" \

--- a/plugins/nextcloud/nextcloud_
+++ b/plugins/nextcloud/nextcloud_
@@ -18,7 +18,7 @@ Nexcloud instances
 Requires installed curl and jq, a command-line json processor.
 
 This is a wildcard plugin. To monitor a nextcloud instance, link
-nextcloud_<nextcloud-domain> to this file. You can even append a port 
+nextcloud_<nextcloud-domain> to this file. You can even append a port
 (:8443) to the file if needed. For example,
 
   ln -s /usr/share/munin/plugins/nextcloud_ \
@@ -26,20 +26,21 @@ nextcloud_<nextcloud-domain> to this file. You can even append a port
 
 Set username and password in your munin-node configuration
 
- [nextcloud_cloud.domain.tld]
- env.username <nexcloud_user>
- env.password <nextcloud_password>
- env.api_path <default: /ocs/v2.php/apps/serverinfo/api/v1/info>
- env.scheme <default: https>
- env.timeout <default: 2s>
- env.updates_warning <default: 1>
+	[nextcloud_cloud.domain.tld]
+	env.username <nexcloud_user>
+	env.password <nextcloud_password>
+	env.api_path <default: /ocs/v2.php/apps/serverinfo/api/v1/info>
+	env.scheme <default: https>
+	env.timeout <default: 2s>
+	env.updates_warning <default: 1>
 
 It's advised to set an app password (for this plugin) in your nextcloud 
 instance and not to use the "real" password of your nextcloud user.
 
 =head1 AUTHOR
 
-Copyright (C) 2020 Sebastian L. (https://momou.ch)
+Copyright (C) 2020 Sebastian L. (https://momou.ch),
+		   Olivier Mehani <shtrom+munin@ssji.net>
 
 =head1 LICENSE
 
@@ -64,22 +65,9 @@ DOMAIN="${0##*nextcloud_}"
 SCHEME="${scheme:-https}://"
 TIMEOUT="${timeout:-2}"
 UPDATES_WARNING="${updates_warning:-1}"
-CLEANDOMAIN="$(clean_fieldname "$DOMAIN")"
+CLEANDOMAIN="$(clean_fieldname "${DOMAIN}")"
 USERNAME="${username:-}"
 PASSWORD="${password:-}"
-
-print_json_data() {
-    local FIRST="$1"
-    local VALUE="U"
-    shift 1
-    test -z "$FIRST" && echo "missing data for 'print_json_data "" $*'">&2
-    for KEY in "$@"; do
-        if [ -n "$FIRST" ]; then
-		VALUE=$(echo "$FIRST" | jq -cr ".$KEY")
-	fi
-        echo "$KEY.value $VALUE"
-   done
-}
 
 fetch_url () {
     curl -s -f -m "${TIMEOUT}" "$@"
@@ -93,18 +81,18 @@ case $1 in
 	    elif [ ! -x "$(command -v jq)" ]; then
 		    echo "no (jq not found)"exit 0
 	    else
-		    fetch_url -I -u "$USERNAME:$PASSWORD" -I "${SCHEME}${DOMAIN}${API_PATH}" \
+		    fetch_url -I -u "${USERNAME}:${PASSWORD}" -I "${SCHEME}${DOMAIN}${API_PATH}" \
 			    | grep -iq "Content-Type: application/json" \
 			    && echo "yes" \
-			    || echo "no (invalid or empty response from nextlcoud serverinfo api)"
+			    || echo "no (invalid or empty response from nextcloud serverinfo api)"
 	    fi
 	    exit 0
 	    ;;
    config)
 
 cat << EOM
-multigraph nextcloud_users_$CLEANDOMAIN
-graph_title Nextcloud users on $DOMAIN
+multigraph nextcloud_users_${CLEANDOMAIN}
+graph_title Nextcloud users on ${DOMAIN}
 graph_args --base 1000 -l 0
 graph_printf %.0lf
 graph_vlabel connected users
@@ -122,8 +110,8 @@ last24hours.min 0
 num_users.label number of users
 num_users.info total number of users
 num_users.min 0
-multigraph nextcloud_files_$CLEANDOMAIN
-graph_title Nextcloud files on $DOMAIN
+multigraph nextcloud_files_${CLEANDOMAIN}
+graph_title Nextcloud files on ${DOMAIN}
 graph_args --base 1000 -l 0
 graph_printf %.0lf
 graph_vlabel number of files
@@ -132,8 +120,8 @@ graph_category cloud
 num_files.label number of files
 num_files.info current number of files
 num_files.min 0
-multigraph nextcloud_shares_$CLEANDOMAIN
-graph_title Nextcloud shares on $DOMAIN
+multigraph nextcloud_shares_${CLEANDOMAIN}
+graph_title Nextcloud shares on ${DOMAIN}
 graph_args --base 1000 -l 0
 graph_printf %.0lf
 graph_vlabel number of shares
@@ -166,8 +154,8 @@ num_fed_shares_sent.min 0
 num_fed_shares_received.label federated shares received
 num_fed_shares_received.info current total of federated shares received
 num_fed_shares_received.min 0
-multigraph nextcloud_dbsize_$CLEANDOMAIN
-graph_title Nextcloud database size on $DOMAIN
+multigraph nextcloud_dbsize_${CLEANDOMAIN}
+graph_title Nextcloud database size on ${DOMAIN}
 graph_args --base 1024 -l 0
 graph_vlabel size in bytes
 graph_info database database size in bytes
@@ -176,8 +164,8 @@ db_size.label database size in bytes
 db_size.info database size in bytes
 db_size.draw AREA
 db_size.min 0
-multigraph nextcloud_storages_$CLEANDOMAIN
-graph_title Nextcloud storages on $DOMAIN
+multigraph nextcloud_storages_${CLEANDOMAIN}
+graph_title Nextcloud storages on ${DOMAIN}
 graph_args --base 1000 -l 0
 graph_printf %.0lf
 graph_vlabel number
@@ -195,8 +183,8 @@ num_storages_home.min 0
 num_storages_other.label number of other storages
 num_storages_other.info current number of other storages
 num_storages_other.min 0
-multigraph nextcloud_apps_$CLEANDOMAIN
-graph_title Nextcloud apps on $DOMAIN
+multigraph nextcloud_apps_${CLEANDOMAIN}
+graph_title Nextcloud apps on ${DOMAIN}
 graph_args --base 1000 -l 0
 graph_printf %.0lf
 graph_vlabel apps
@@ -215,37 +203,44 @@ EOM
 
 esac
 
-# Get JSON data
-JSONSTATS=$(
-	fetch_url -u "$USERNAME:$PASSWORD" "${SCHEME}${DOMAIN}${API_PATH}" | sed 's/\\/\\\\/g' | jq -cr ".ocs.data" 2>&1
-)
-USERS=$(echo "$JSONSTATS" | jq -cr ".activeUsers")
-STORAGE=$(echo "$JSONSTATS" | jq -cr ".nextcloud.storage")
-SHARES=$(echo "$JSONSTATS" | jq -cr ".nextcloud.shares")
 DBSIZE=$(echo "$JSONSTATS" | jq -cr ".server.database.size")
-APPS=$(echo "$JSONSTATS" | jq -cr ".nextcloud.system.apps")
 
 # users
-echo "multigraph nextcloud_users_$CLEANDOMAIN"
-print_json_data "$USERS" last5minutes last1hour last24hours
-print_json_data "$STORAGE" num_users
+fetch_url -u "${USERNAME}:${PASSWORD}" "${SCHEME}${DOMAIN}${API_PATH}" \
+	| sed 's/\\/\\\\/g' \
+	| jq -r '.ocs.data
+		| @text "
+multigraph nextcloud_users_'${CLEANDOMAIN}'
+last5minutes \(.activeUsers.last5minutes)
+last1hour \(.activeUsers.last1hour)
+last24hours \(.activeUsers.last24hours)
+num_users \(.nextcloud.storage.num_users)
 
-# files
-echo "multigraph nextcloud_files_$CLEANDOMAIN"
-print_json_data "$STORAGE" num_files
+multigraph nextcloud_files_'${CLEANDOMAIN}'
+num_files \(.nextcloud.storage.num_files)
 
-# storages
-echo "multigraph nextcloud_storages_$CLEANDOMAIN"
-print_json_data "$STORAGE" num_storages num_storages_local num_storages_home num_storages_other
+multigraph nextcloud_storages_'${CLEANDOMAIN}'
+num_storages \(.nextcloud.storage.num_storages)
+num_storages_local \(.nextcloud.storage.num_storages_local)
+num_storages_home \(.nextcloud.storage.num_storages_home)
+num_storages_other \(.nextcloud.storage.num_storages_other)
 
-# shares
-echo "multigraph nextcloud_shares_$CLEANDOMAIN"
-print_json_data "$SHARES" num_shares num_shares_user num_shares_groups num_shares_link num_shares_mail num_shares_room num_shares_link_no_password num_fed_shares_sent num_fed_shares_received
+multigraph nextcloud_shares_'${CLEANDOMAIN}'
+num_shares \(.nextcloud.shares.num_shares)
+num_shares_user \(.nextcloud.shares.num_shares_user)
+num_shares_groups \(.nextcloud.shares.num_shares_groups)
+num_shares_link \(.nextcloud.shares.num_shares_link)
+num_shares_mail \(.nextcloud.shares.num_shares_mail)
+num_shares_room \(.nextcloud.shares.num_shares_room)
+num_shares_link_no_password \(.nextcloud.shares.num_shares_link_no_password)
+num_fed_shares_sent \(.nextcloud.shares.num_fed_shares_sent)
+num_fed_shares_received \(.nextcloud.shares.num_fed_shares_received)
 
-# dbsize
-echo "multigraph nextcloud_dbsize_$CLEANDOMAIN"
-echo "db_size.value $DBSIZE"
+multigraph nextcloud_dbsize_'${CLEANDOMAIN}'
+db_size \(.server.database.size)
 
-# apps
-echo "multigraph nextcloud_apps_$CLEANDOMAIN"
-print_json_data "$APPS" num_installed num_updates_available
+multigraph nextcloud_apps_'${CLEANDOMAIN}'
+num_installed \(.nextcloud.system.apps.num_installed)
+num_updates_available \(.nextcloud.system.apps.num_updates_available)
+"' \
+	| sed 's/ null$/ U/'


### PR DESCRIPTION
…info

Signed-off-by: Olivier Mehani <shtrom@ssji.net>

tl;dr: Use a single call to `jq` to format the whole output, rather than one per data point.

This greatly improves the performance of the plugin. Here's a before/after test (replacing the `curl` call with canned data, to only test the processing part).
* Before: ```sudo -u munin munin-run nextcloud_example.com  1.89s user 0.11s system 98% cpu 2.022 total```
* After: ```sudo -u munin munin-run nextcloud_example.com  0.29s user 0.03s system 93% cpu 0.337 total```