### PR TITLE
Plugin timesync_status: add support for 'fetch' command

### DIFF
--- a/plugins/systemd/timesync_status
+++ b/plugins/systemd/timesync_status
@@ -132,9 +132,9 @@ def config():
 
 
 if __name__ == '__main__':
-    if len(sys.argv) == 1 or sys.argv[1] == 'fetch':
-        retrieve()
-    elif sys.argv[1] == 'config':
+    if len(sys.argv) > 1 and sys.argv[1] == 'config':
         config()
-    elif sys.argv[1] == 'autoconf':
+    elif len(sys.argv) > 1 and sys.argv[1] == 'autoconf':
         autoconf()
+    else:
+        retrieve()

--- a/plugins/systemd/timesync_status
+++ b/plugins/systemd/timesync_status
@@ -132,7 +132,7 @@ def config():
 
 
 if __name__ == '__main__':
-    if len(sys.argv) == 1:
+    if len(sys.argv) == 1 or sys.argv[1] == 'fetch':
         retrieve()
     elif sys.argv[1] == 'config':
         config()


### PR DESCRIPTION
My installation of munin server (version 2.0.49) executes plugins with "fetch" command instead of an empty command line.