### PR TITLE
fix the bird plugin to work with perl 5.28

### DIFF
--- a/plugins/bird/bird
+++ b/plugins/bird/bird
@@ -62,8 +62,8 @@ sub get_stats {
         ) or die $!;
 
     my ($protocol,$name);
-    while (<$bird_ctl>) {
-        given($_) {
+    while (my $var = <$bird_ctl>) {
+        given($var) {
             when (/1002-(\w+)\s+(\w+)\s+.*/) {
                 ($name, $protocol) = ($1,$2);
                 next unless $protocol ~~ $protocols;


### PR DESCRIPTION
this is required to make the bird plugin to work with perl 5.28 