### PR TITLE
certificate_file_expiry: add pattern support for CERT env variable

### DIFF
--- a/plugins/ssl/certificate_file_expiry
+++ b/plugins/ssl/certificate_file_expiry
@@ -18,7 +18,7 @@ For letsencrypt certificates
 
  [certificate_file_expiry]
  user root
- env.CERTS x509:/etc/letsencrypt/live/domain1.example.com/cert.pem x509:/etc/letsencrypt/live/domain2.example.com/cert.pem
+ env.CERTS x509:/etc/letsencrypt/live/*/cert.pem
 
 Warning and Critical levels can also be configured with env variables like this:
 
@@ -28,6 +28,14 @@ Warning and Critical levels can also be configured with env variables like this:
  env.warning 5:
  # critical when certificate will be invalid within 1 day
  env.critical 1:
+
+env.CERTS should be a space separated list of patterns prefixed by the type of certificate to check and a colon. All types of
+certificates that openssl supports as standard commands and have a validity output are supported (e.g. x509, crl).
+File patterns can be a single file (e.g. /etc/openvpn/easy-rsa/keys/crl.pem) or a pattern that matches multiple files
+(e.g. /etc/letsencrypt/live/*/cert.pem).
+
+env.warning and env.critical are configurable values for the warning and critical levels according to
+http://munin-monitoring.org/wiki/fieldname.warning and http://munin-monitoring.org/wiki/fieldname.critical
 
 =head1 Dependencies
 
@@ -46,29 +54,31 @@ GPLv2
 . "$MUNIN_LIBDIR/plugins/plugin.sh"
 
 if [ "$1" = "config" ] ; then
-	echo "graph_title Certificate validity"
-	echo "graph_args --logarithmic --base 1000"
-	echo "graph_vlabel certificate validity in days"
-	echo "graph_category security"
+  echo "graph_title Certificate validity"
+  echo "graph_args --logarithmic --base 1000"
+  echo "graph_vlabel certificate validity in days"
+  echo "graph_category security"
 fi
 
 now=$(date +%s)
 warning=${warning:-5:}
 critical=${critical:-1:}
 for cert in ${CERTS}; do
-	cert_type=${cert%:*}
-	cert_file=${cert#*:}
-	cert_name=$(clean_fieldname "$cert_file")
-	if [ "$1" = "config" ] ; then
-		echo "${cert_name}.label ${cert_file}"
-		print_warning "$cert_name"
-		print_critical "$cert_name"
-	elif [ "$1" = "" ] ; then
-		validity=$(/usr/bin/openssl "$cert_type" -text -noout -in "$cert_file" | grep -E '(Next Update|Not After)')
-		validity=${validity#*:}
-		validity=$(date --date="$validity" +%s)
-		validity=$((validity - now))
-		validity=$(echo "$validity" | awk '{ print ($1 / 86400) }')
-		echo "${cert_name}.value $validity"
-	fi
+  cert_type=${cert%:*}
+  cert_pattern=${cert#*:}
+  for cert_file in $cert_pattern; do
+    cert_name=$(clean_fieldname "$cert_file")
+    if [ "$1" = "config" ] ; then
+      echo "${cert_name}.label ${cert_file}"
+      print_warning "$cert_name"
+      print_critical "$cert_name"
+    elif [ "$1" = "" ] ; then
+      validity=$(/usr/bin/openssl "$cert_type" -text -noout -in "$cert_file" | grep -E '(Next Update|Not After)')
+      validity=${validity#*:}
+      validity=$(date --date="$validity" +%s)
+      validity=$((validity - now))
+      validity=$(echo "$validity" | awk '{ print ($1 / 86400) }')
+      echo "${cert_name}.value $validity"
+    fi
+  done
 done


### PR DESCRIPTION
It became tedious to maintain our env.CERT values so i added support for patterns to the plugin. Now it's easier to support a bunch of certs that are saved in a certain pattern (e.g. letsencrypt certs or crls for multiple vpns)

Info @wt-io-it