### PR TITLE
Update for extra fields in newer kernels

### DIFF
--- a/plugins/disk/linux_diskstat_
+++ b/plugins/disk/linux_diskstat_
@@ -490,8 +490,8 @@ sub read_sysfs {
 
         my @elems = split /\s+/, $line;
 
-        croak "'$stats_file' doesn't contain exactly 11 values. Aborting"
-          if ( @elems != 11 );
+        croak "'$stats_file' doesn't contain exactly 11 or 15 values. Aborting"
+          if ( @elems != 11 && @elems != 15 );
 
         # Translate the devicename back before storing the information
         $cur_device =~ tr#!#/#;


### PR DESCRIPTION
The fields have changed from 11 or 15 on recent kernels but does not effect what the plugin gathers. 
See 5.4 https://www.kernel.org/doc/html/v5.4/block/stat.html versus 4.16 https://mjmwired.net/kernel/Documentation/block/stat.txt