### PR TITLE
during DELAYED/PENDING resyncs mark reshape/recovery percent as unkno…

### DIFF
--- a/plugins/disk/raid
+++ b/plugins/disk/raid
@@ -120,7 +120,7 @@ while (@text) {
         elsif ($action =~ /check|resync/) {
             if ($proc < 0) {
                 # array is on DELAYED or PENDING, further info is unknown
-                $rpct = 0;
+                $rpct = "U";
                 $cpct = 0;
             }
             else {


### PR DESCRIPTION
…wn instead of 0

this prevent the raid plugin from going critical during a routine checks/resyncs

@mittyorz as you last refactored this check, what do you think about this change?

(alternatively we could compute the status from /sys/devices/virtual/block/md127/md/reshape_position and /sys/devices/virtual/block/md127/md/reshape_direction i guess)

info @wt-io-it