### PR TITLE
cpu and memory plugins for OSX

### DIFF
--- a/plugins/cpu/cpu_osx
+++ b/plugins/cpu/cpu_osx
@@ -12,7 +12,7 @@ cpu - Plugin to measure cpu on osx.
 =head1 NOTES
 
 This plugin runs the top command once per interval, to discover the current value of CPU usage on OSX.
-The result is scaled to # of CPU's, so a 4 core machine will reach 400% utilization (unless $scaleto100 is set to "yes").
+The result is scaled to # of CPU's, so a 4 core machine will reach 400% utilization (unless $scaleto100 is set to "yes", in which case the maximum will be 100%).
 
 Contributions are welcome to convert the plugin to use a long running counter such as /proc/stat in Linux.
 
@@ -32,7 +32,7 @@ if [ "$1" = "autoconf" ]; then
         echo yes
         exit 0
     else
-        echo no
+        echo "no (uname does not report 'Darwin')"
         exit 0
     fi
 fi

--- a/plugins/cpu/cpu_osx
+++ b/plugins/cpu/cpu_osx
@@ -1,0 +1,75 @@
+#!/bin/sh
+# -*- sh -*-
+
+# shellcheck disable=SC2046
+
+: << =cut
+
+=head1 NAME
+
+cpu - Plugin to measure cpu on osx.
+
+=head1 NOTES
+
+This plugin runs the top command once per interval, to discover the current value of CPU usage on OSX.
+The result is scaled to # of CPU's, so a 4 core machine will reach 400% utilization.
+Contributions are welcome to convert the plugin to use a long running counter such as /proc/stat in Linux.
+
+=head1 LICENSE
+
+GPLv2
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+NCPU=$(sysctl hw.ncpu | cut -d" " -f2)
+
+if [ "$1" = "autoconf" ]; then
+        echo yes
+        exit 0
+fi
+
+scaleto100=""
+
+if [ "$1" = "config" ]; then
+        # Linux had NCPU=$(egrep '^cpu[0-9]+ ' /proc/stat | wc -l)
+        if [ "$scaleto100" = "yes" ]; then
+                graphlimit=100
+        else
+                graphlimit=$(echo "$NCPU"*100 | bc)
+        fi
+        echo 'graph_title CPU usage'
+        echo "graph_order system user idle"
+        echo "graph_args --base 1000 -r --lower-limit 0 --upper-limit $graphlimit"
+        echo 'graph_scale no'
+        echo 'graph_vlabel %'
+        echo 'graph_category system'
+        echo 'system.label system'
+        echo 'system.draw AREA'
+        echo 'system.min 0'
+        echo "system.info CPU time spent by the kernel in system activities"
+        echo 'user.label user'
+        echo 'user.draw STACK'
+        echo 'user.min 0'
+        echo 'user.info CPU time spent by normal programs and daemons'
+        echo 'idle.label idle'
+        echo 'idle.draw STACK'
+        echo 'idle.min 0'
+        echo 'idle.info Idle CPU time'
+
+        exit 0
+fi
+
+# The second cpu reading is more accurate than the first, so "-l 2":
+TOPINFO=$(top -l 2 | grep "CPU usage: " | tail -n 1)
+
+CPU_USER=$(echo "$TOPINFO" | awk '/CPU usage: / { print substr($3, 1, length($3)-1) }')
+CPU_SYS=$(echo "$TOPINFO" | awk '/CPU usage: / { print substr($5, 1, length($5)-1) }') 
+CPU_IDLE=$(echo "$TOPINFO" | awk '/CPU usage: / { print substr($7, 1, length($7)-1) }') 
+echo "system.value" $( echo "$NCPU"*"$CPU_SYS"/1 | bc)
+echo "user.value" $( echo "$NCPU"*"$CPU_USER"/1 | bc)
+echo "idle.value" $( echo "$NCPU"*"$CPU_IDLE"/1 | bc)

--- a/plugins/cpu/cpu_osx
+++ b/plugins/cpu/cpu_osx
@@ -12,7 +12,8 @@ cpu - Plugin to measure cpu on osx.
 =head1 NOTES
 
 This plugin runs the top command once per interval, to discover the current value of CPU usage on OSX.
-The result is scaled to # of CPU's, so a 4 core machine will reach 400% utilization.
+The result is scaled to # of CPU's, so a 4 core machine will reach 400% utilization (unless $scaleto100 is set to "yes").
+
 Contributions are welcome to convert the plugin to use a long running counter such as /proc/stat in Linux.
 
 =head1 LICENSE
@@ -26,22 +27,26 @@ GPLv2
 
 =cut
 
-NCPU=$(sysctl hw.ncpu | cut -d" " -f2)
-
 if [ "$1" = "autoconf" ]; then
+    if [ "$(uname)" = "Darwin" ]; then
         echo yes
         exit 0
+    else
+        echo no
+        exit 0
+    fi
 fi
 
-scaleto100=""
+scaleto100=${scaleto100:-}
+
+if [ "$scaleto100" = "yes" ]; then
+    NCPU="1"
+else
+    NCPU=$(sysctl hw.ncpu | cut -d" " -f2)
+fi
 
 if [ "$1" = "config" ]; then
-        # Linux had NCPU=$(egrep '^cpu[0-9]+ ' /proc/stat | wc -l)
-        if [ "$scaleto100" = "yes" ]; then
-                graphlimit=100
-        else
-                graphlimit=$(echo "$NCPU"*100 | bc)
-        fi
+        graphlimit=$(( NCPU*100 ))
         echo 'graph_title CPU usage'
         echo "graph_order system user idle"
         echo "graph_args --base 1000 -r --lower-limit 0 --upper-limit $graphlimit"
@@ -70,6 +75,6 @@ TOPINFO=$(top -l 2 | grep "CPU usage: " | tail -n 1)
 CPU_USER=$(echo "$TOPINFO" | awk '/CPU usage: / { print substr($3, 1, length($3)-1) }')
 CPU_SYS=$(echo "$TOPINFO" | awk '/CPU usage: / { print substr($5, 1, length($5)-1) }') 
 CPU_IDLE=$(echo "$TOPINFO" | awk '/CPU usage: / { print substr($7, 1, length($7)-1) }') 
-echo "system.value" $( echo "$NCPU"*"$CPU_SYS"/1 | bc)
-echo "user.value" $( echo "$NCPU"*"$CPU_USER"/1 | bc)
-echo "idle.value" $( echo "$NCPU"*"$CPU_IDLE"/1 | bc)
+echo "system.value" $(echo "$NCPU" "$CPU_SYS" | awk '{print($1 * $2)}')
+echo "user.value" $(echo "$NCPU" "$CPU_USER" | awk '{print($1 * $2)}')
+echo "idle.value" $(echo "$NCPU" "$CPU_IDLE" | awk '{print($1 * $2)}')

--- a/plugins/memory/memory_osx
+++ b/plugins/memory/memory_osx
@@ -1,0 +1,74 @@
+#!/bin/sh
+# -*- sh -*-
+
+# shellcheck disable=SC2046
+
+: << =cut
+
+=head1 NAME
+
+memory - Plugin to measure memory on osx.
+
+=head1 NOTES
+
+This plugin runs the top command once per interval, to discover memory usage on OSX.
+Contributions are welcome to collect additional memory regions, if possible, such as buffers and caches.
+
+=head1 LICENSE
+
+GPLv2
+
+=head1 MAGIC MARKERS
+
+ #%# family=auto
+ #%# capabilities=autoconf
+
+=cut
+
+TOTALMEM=$(sysctl hw.memsize | cut -d" " -f2)
+graphlimit=$(echo "$TOTALMEM"/1048576 | bc)
+
+dehumanise() {
+    echo "$1" | sed -e "s/K/*1024/g;s/M/*1024*1024/;s/G/*1024*1024*1024/;s/T/*1024*1024*1024*1024/" | bc
+}
+dehumanise_to_M() {
+    echo "$1" | sed -e "s/K/\/1024/g;s/M//;s/G/*1024/;s/T/*1024*1024/" | bc
+}
+
+if [ "$1" = "autoconf" ]; then
+        echo yes
+        exit 0
+fi
+
+if [ "$1" = "config" ]; then
+        echo 'graph_title Memory'
+        echo "graph_order used wired unused"
+        echo "graph_args --base 1024 -r --lower-limit 0 --upper-limit $graphlimit"
+        echo 'graph_scale no'
+        echo 'graph_vlabel MB'
+        echo 'graph_category system'
+        echo 'used.label used (not incl. wired)'
+        echo 'used.draw AREA'
+        echo 'used.min 0'
+        echo "used.info Used memory, not including wired, in MB"
+        echo 'wired.label wired'
+        echo 'wired.draw STACK'
+        echo 'wired.min 0'
+        echo 'wired.info Wired memory, in MB'
+        # echo 'unused.label unused'
+        # echo 'unused.draw STACK'
+        # echo 'unused.min 0'
+        # echo 'unused.info Unused memory, in MB'
+
+        exit 0
+fi
+
+# Note: while it's possible to show all three values "used", "wired", "unused", the sum total often differs by around 1% from an exact 100% value.
+# This makes the top of the chart uneven, and can be solved by omitting "unused" which will be implied.
+TOPINFO=$(top -l 1 | grep "PhysMem: ")
+MEM_USED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($2, 1, length($2)) }')
+MEM_WIRED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($4, 2, length($4)-1) }') 
+# MEM_UNUSED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($6, 1, length($6)) }') 
+echo "used.value" $(echo $(dehumanise_to_M "$MEM_USED") - $(dehumanise_to_M "$MEM_WIRED") | bc)
+echo "wired.value" $(dehumanise_to_M "$MEM_WIRED" | bc)
+# echo "unused.value" $(dehumanise_to_M "$MEM_UNUSED" | bc)

--- a/plugins/memory/memory_osx
+++ b/plugins/memory/memory_osx
@@ -25,20 +25,22 @@ GPLv2
 
 =cut
 
-TOTALMEM=$(sysctl hw.memsize | cut -d" " -f2)
-graphlimit=$(echo "$TOTALMEM"/1048576 | bc)
-
-dehumanise() {
-    echo "$1" | sed -e "s/K/*1024/g;s/M/*1024*1024/;s/G/*1024*1024*1024/;s/T/*1024*1024*1024*1024/" | bc
-}
-dehumanise_to_M() {
-    echo "$1" | sed -e "s/K/\/1024/g;s/M//;s/G/*1024/;s/T/*1024*1024/" | bc
-}
-
 if [ "$1" = "autoconf" ]; then
+    if [ "$(uname)" = "Darwin" ]; then
         echo yes
         exit 0
+    else
+        echo no
+        exit 0
+    fi
 fi
+
+TOTALMEM=$(sysctl hw.memsize | cut -d" " -f2)
+graphlimit=$(( TOTALMEM/1048576 ))
+
+dehumanise_to_M() {
+    echo "$1" | sed -e "s/K/\/1024/g;s/M//;s/G/*1024/;s/T/*1024*1024/"
+}
 
 if [ "$1" = "config" ]; then
         echo 'graph_title Memory'
@@ -55,20 +57,12 @@ if [ "$1" = "config" ]; then
         echo 'wired.draw STACK'
         echo 'wired.min 0'
         echo 'wired.info Wired memory, in MB'
-        # echo 'unused.label unused'
-        # echo 'unused.draw STACK'
-        # echo 'unused.min 0'
-        # echo 'unused.info Unused memory, in MB'
 
         exit 0
 fi
 
-# Note: while it's possible to show all three values "used", "wired", "unused", the sum total often differs by around 1% from an exact 100% value.
-# This makes the top of the chart uneven, and can be solved by omitting "unused" which will be implied.
 TOPINFO=$(top -l 1 | grep "PhysMem: ")
 MEM_USED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($2, 1, length($2)) }')
 MEM_WIRED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($4, 2, length($4)-1) }') 
-# MEM_UNUSED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($6, 1, length($6)) }') 
-echo "used.value" $(echo $(dehumanise_to_M "$MEM_USED") - $(dehumanise_to_M "$MEM_WIRED") | bc)
-echo "wired.value" $(dehumanise_to_M "$MEM_WIRED" | bc)
-# echo "unused.value" $(dehumanise_to_M "$MEM_UNUSED" | bc)
+echo "used.value" $(( $(dehumanise_to_M "$MEM_USED") - $(dehumanise_to_M "$MEM_WIRED") ))
+echo "wired.value" $(( $(dehumanise_to_M "$MEM_WIRED") ))

--- a/plugins/memory/memory_osx
+++ b/plugins/memory/memory_osx
@@ -30,33 +30,32 @@ if [ "$1" = "autoconf" ]; then
         echo yes
         exit 0
     else
-        echo no
+        echo "no (uname does not report 'Darwin')"
         exit 0
     fi
 fi
 
 TOTALMEM=$(sysctl hw.memsize | cut -d" " -f2)
-graphlimit=$(( TOTALMEM/1048576 ))
+graphlimit=$TOTALMEM
 
-dehumanise_to_M() {
-    echo "$1" | sed -e "s/K/\/1024/g;s/M//;s/G/*1024/;s/T/*1024*1024/"
+dehumanise() {
+    echo "$1" | sed -e "s/K/*1024/g;s/M/*1024*1024/;s/G/*1024*1024*1024/;s/T/*1024*1024*1024*1024/"
 }
 
 if [ "$1" = "config" ]; then
         echo 'graph_title Memory'
         echo "graph_order used wired unused"
         echo "graph_args --base 1024 -r --lower-limit 0 --upper-limit $graphlimit"
-        echo 'graph_scale no'
-        echo 'graph_vlabel MB'
+        echo 'graph_vlabel Bytes'
         echo 'graph_category system'
         echo 'used.label used (not incl. wired)'
         echo 'used.draw AREA'
         echo 'used.min 0'
-        echo "used.info Used memory, not including wired, in MB"
+        echo "used.info Used memory, not including wired"
         echo 'wired.label wired'
         echo 'wired.draw STACK'
         echo 'wired.min 0'
-        echo 'wired.info Wired memory, in MB'
+        echo 'wired.info Wired memory'
 
         exit 0
 fi
@@ -64,5 +63,5 @@ fi
 TOPINFO=$(top -l 1 | grep "PhysMem: ")
 MEM_USED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($2, 1, length($2)) }')
 MEM_WIRED=$(echo "$TOPINFO" | awk '/PhysMem: / { print substr($4, 2, length($4)-1) }') 
-echo "used.value" $(( $(dehumanise_to_M "$MEM_USED") - $(dehumanise_to_M "$MEM_WIRED") ))
-echo "wired.value" $(( $(dehumanise_to_M "$MEM_WIRED") ))
+echo "used.value" $(( $(dehumanise "$MEM_USED") - $(dehumanise "$MEM_WIRED") ))
+echo "wired.value" $(( $(dehumanise "$MEM_WIRED") ))


### PR DESCRIPTION
Hi,

Out of the box, the munin macports package for mac osx doesn't include graphs for CPU or MEMORY, which are possibly the most useful plugins. It would be great to provide something right away after a new installation.

You may have a better idea about file organization. An idea would be to include these in the contrib repository with the file names "cpu_osx" and "memory_osx", and in the macports distribution with the plain file names "cpu" and "memory".

![cpu](https://user-images.githubusercontent.com/1257803/107084432-aa15cc80-67bc-11eb-922e-5431b9edf1b3.png)
![memory](https://user-images.githubusercontent.com/1257803/107084393-9c604700-67bc-11eb-81a7-c982ec4949d1.png)