### PR TITLE
Use exact values in zfs/zpool_capacity#allocated

### DIFF
--- a/plugins/zfs/zpool_capacity
+++ b/plugins/zfs/zpool_capacity
@@ -189,20 +189,11 @@ get_stats() {
         "$zpool_cmd" list -H -o name,fragmentation | sed 's/%$//'
         ;;
     allocated)
-        ( "$zpool_cmd" list -H -o name,allocated \
+        ( "$zpool_cmd" list -H -p -o name,allocated \
           | awk '{ print $1"_allocated", $2 }'
-          "$zpool_cmd" list -H -o name,size \
+          "$zpool_cmd" list -H -p -o name,size \
           | awk '{ print $1"_size", $2 }'
-        ) \
-        | perl -ane '
-            @unit{ qw/ K M G T P E / } = ( 1 .. 6 );
-            $name = $F[0];
-            $byteu = $F[1];
-            ( $n, $u ) = $byteu =~ /^([\d.]+)([KMGTPE]?)$/;
-            $byte  = int( $n * 1024 ** ( $u ? $unit{ $u } : 0 ) );
-            print "$name $byte\n";
-        '
-        # Note: ZFS supports up to 16EB.
+        )
         ;;
     dedup)
         "$zpool_cmd" list -H -o name,dedup \


### PR DESCRIPTION
As per the zpool(8) man page:

> zpool list [-HgLpPv] [-o property[,property]...] [-T u|d] [pool]... [interval [count]]
>         Lists the given pools along with a health status and space usage.  If no pools are specified, all pools in the system are listed.  When given an interval, the information is printed every
>         interval seconds until ^C is pressed.  If count is specified, the command exits after count reports are printed.
> [...]
>         -p      Display numbers in parsable (exact) values.