### PR TITLE
Add 'containers' to the supported series

### DIFF
--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -481,6 +481,7 @@ def memory(client, mode):
 
 def main():
     series = [
+        'containers',
         'cpu',
         'images',
         'memory',


### PR DESCRIPTION
Apparently, the code support that serie, as the docs say.

This addresses https://github.com/munin-monitoring/contrib/issues/1180