### PR TITLE
Update kvm_cpu

### DIFF
--- a/plugins/libvirt/kvm_cpu
+++ b/plugins/libvirt/kvm_cpu
@@ -47,7 +47,7 @@ def config(vm_names):
     @param vm_names : a list of "cleaned" vms' name
     '''
     percent = 100 * len(
-        filter(lambda x: x[0:3] == 'cpu' and x[3] != ' ', open('/proc/stat', 'r').readlines()))
+        list(filter(lambda x: x[0:3] == 'cpu' and x[3] != ' ', open('/proc/stat', 'r').readlines())))
 
     base_config = """graph_title KVM Virtual Machine CPU usage
 graph_vlabel %%
@@ -97,7 +97,7 @@ def find_vm_names(pids):
     '''
     result = {}
     for pid in pids:
-        cmdline = open("/proc/%s/cmdline" % pid, "r")
+        cmdline = open("/proc/%s/cmdline" % pid.decode(), "r")
         result[pid] = clean_vm_name(
             re.sub(r"^.*guest=([a-zA-Z0-9.-_-]*).*$", r"\1", cmdline.readline()))
     return result
@@ -116,7 +116,7 @@ def fetch(vms):
     @param dictionary {kvm_pid: cleaned vm name}
     '''
     for pid, name in vms.items():
-        user, system = open("/proc/%s/stat" % pid, 'r').readline().split(' ')[13:15]
+        user, system = open("/proc/%s/stat" % pid.decode(), 'r').readline().split(' ')[13:15]
         print('%s_cpu.value %d' % (name, int(user) + int(system)))
 
 

--- a/plugins/libvirt/kvm_cpu
+++ b/plugins/libvirt/kvm_cpu
@@ -47,7 +47,9 @@ def config(vm_names):
     @param vm_names : a list of "cleaned" vms' name
     '''
     percent = 100 * len(
-        list(filter(lambda x: x[0:3] == 'cpu' and x[3] != ' ', open('/proc/stat', 'r').readlines())))
+        list(
+            filter(
+                lambda x: x[0:3] == 'cpu' and x[3] != ' ', open('/proc/stat', 'r').readlines())))
 
     base_config = """graph_title KVM Virtual Machine CPU usage
 graph_vlabel %%
@@ -97,7 +99,7 @@ def find_vm_names(pids):
     '''
     result = {}
     for pid in pids:
-        cmdline = open("/proc/%s/cmdline" % pid.decode(), "r")
+        cmdline = open("/proc/%s/cmdline" % pid, "r")
         result[pid] = clean_vm_name(
             re.sub(r"^.*guest=([a-zA-Z0-9.-_-]*).*$", r"\1", cmdline.readline()))
     return result
@@ -108,7 +110,7 @@ def list_pids():
     @return a list of pids from running kvm
     '''
     pid = Popen("pidof qemu-kvm qemu-system-x86_64 kvm", shell=True, stdout=PIPE)
-    return pid.communicate()[0].split()
+    return pid.communicate()[0].decode().split()
 
 
 def fetch(vms):
@@ -116,7 +118,7 @@ def fetch(vms):
     @param dictionary {kvm_pid: cleaned vm name}
     '''
     for pid, name in vms.items():
-        user, system = open("/proc/%s/stat" % pid.decode(), 'r').readline().split(' ')[13:15]
+        user, system = open("/proc/%s/stat" % pid, 'r').readline().split(' ')[13:15]
         print('%s_cpu.value %d' % (name, int(user) + int(system)))
 
 


### PR DESCRIPTION
in python3 filter returns an object, not an list. I think a list is required here? at least the plugin works as soon as list(...) is added.
need to change from pid to pid.decode, as pid is binary and not a string.