### PR TITLE
Proposed update: all mongodb scripts load MONGO_DB_URI env setting.

### DIFF
--- a/plugins/mongodb/mongo_collection_
+++ b/plugins/mongodb/mongo_collection_
@@ -170,6 +170,8 @@ if __name__ == "__main__":
         settings_password = environ['password']
     if 'ignoredb' in environ:
         settings_ignoredb = environ['ignoredb'].split(',')
+    if 'MONGO_DB_URI' in environ:
+        settings_mongodb_uri = environ['MONGO_DB_URI']
     m = re.search('^(.*)_([a-zA-Z0-9]*)$', path.basename(argv[0]))
     if len(argv) < 2:
         doData(m.group(1), m.group(2))

--- a/plugins/mongodb/mongo_lag
+++ b/plugins/mongodb/mongo_lag
@@ -20,7 +20,7 @@ Default for host is 127.0.0.1 and port 27017 and will work without being defined
     env.username user
     env.password P@55w0rd
 
-    or
+or
 
     [mongo_lag]
     env.MONGO_DB_URI mongodb://user:passwd@127.0.0.1:27017

--- a/plugins/mongodb/mongo_lag
+++ b/plugins/mongodb/mongo_lag
@@ -20,6 +20,11 @@ Default for host is 127.0.0.1 and port 27017 and will work without being defined
     env.username user
     env.password P@55w0rd
 
+    or
+
+    [mongo_lag]
+    env.MONGO_DB_URI mongodb://user:passwd@127.0.0.1:27017
+
 =head1 AUTHOR
 
 Stefan Andersen <stefan@stefanandersen.dk>
@@ -44,14 +49,17 @@ import sys
 import pymongo
 
 def _get_members():
-    host = os.environ.get('host', '127.0.0.1')
-    port = os.environ.get('port', 27017)
-    username = os.environ.get('username', '')
-    password = os.environ.get('password', '')
-    conn = pymongo.MongoClient(host, int(port))
-    if username:
-        connAuth = conn['admin']
-        connAuth.authenticate(username, password)
+    if 'MONGO_DB_URI' in os.environ:
+        conn = pymongo.MongoClient(os.environ['MONGO_DB_URI'])
+    else:
+        host = os.environ.get('host', '127.0.0.1')
+        port = os.environ.get('port', 27017)
+        username = os.environ.get('username', '')
+        password = os.environ.get('password', '')
+        conn = pymongo.MongoClient(host, int(port))
+        if username:
+            connAuth = conn['admin']
+            connAuth.authenticate(username, password)
 
     repl_status = conn.admin.command("replSetGetStatus")
 

--- a/plugins/mongodb/mongodb_conn
+++ b/plugins/mongodb/mongodb_conn
@@ -18,6 +18,11 @@ Default for host is 127.0.0.1 and port 27017 and will work without being defined
     env.username user
     env.password P@55w0rd
 
+    or
+
+    [mongodb_conn]
+    env.MONGO_DB_URI mongodb://user:passwd@127.0.0.1:27017
+
 =head1 AUTHOR
 
 Alban Espie-Guillon <alban.espie@alterway.fr>
@@ -42,14 +47,17 @@ import pymongo
 
 
 def _get_connections():
-    host = os.environ.get('host', '127.0.0.1')
-    port = os.environ.get('port', 27017)
-    username = os.environ.get('username', '')
-    password = os.environ.get('password', '')
-    conn = pymongo.MongoClient(host, int(port))
-    if username:
-        connAuth = conn['admin']
-        connAuth.authenticate(username, password)
+    if 'MONGO_DB_URI' in os.environ:
+        conn = pymongo.MongoClient(os.environ['MONGO_DB_URI'])
+    else:
+        host = os.environ.get('host', '127.0.0.1')
+        port = os.environ.get('port', 27017)
+        username = os.environ.get('username', '')
+        password = os.environ.get('password', '')
+        conn = pymongo.MongoClient(host, int(port))
+        if username:
+            connAuth = conn['admin']
+            connAuth.authenticate(username, password)
 
     """ cli : db.serverStatus().connections """
     conn_status = conn.admin.command("serverStatus")['connections']

--- a/plugins/mongodb/mongodb_conn
+++ b/plugins/mongodb/mongodb_conn
@@ -18,7 +18,7 @@ Default for host is 127.0.0.1 and port 27017 and will work without being defined
     env.username user
     env.password P@55w0rd
 
-    or
+or
 
     [mongodb_conn]
     env.MONGO_DB_URI mongodb://user:passwd@127.0.0.1:27017


### PR DESCRIPTION
Hi:

I'm just proposing this patch so we can have "one config line to set them all". If all scripts load the same env var, I'm using MONGO_DB_URI as there were some scripts that were already using that var name (ie: mongodb_docs).

Let me know please if you have any question.

Thanks all for your work on this project.

Cheers,


Jeremías