### PR TITLE
Proposed update: mongodb scripts configurable graph category.

### DIFF
--- a/plugins/mongodb/mongo_collection_
+++ b/plugins/mongodb/mongo_collection_
@@ -35,6 +35,7 @@
 
 import pymongo
 from operator import itemgetter
+from os import getenv
 
 settings_host = '127.0.0.1'
 settings_port = 27017
@@ -44,6 +45,7 @@ settings_db = 'admin'
 settings_user = ''
 settings_password = ''
 settings_ignoredb = {}
+settings_graph_category = getenv('graph_category', 'db')
 
 typeIndex = {}
 typeIndex['collcount'] = {}
@@ -52,7 +54,7 @@ typeIndex['collcount']['title'] = 'per collection document count'
 typeIndex['collcount']['yaxis'] = 'documents'
 typeIndex['collcount']['base'] = '1000'
 typeIndex['collcount']['scale'] = '--logarithmic -l1'
-typeIndex['collcount']['category'] = 'db'
+typeIndex['collcount']['category'] = settings_graph_category
 
 typeIndex['collsize'] = {}
 typeIndex['collsize']['index'] = 'size'
@@ -60,7 +62,7 @@ typeIndex['collsize']['title'] = 'per collection data size'
 typeIndex['collsize']['yaxis'] = 'Byte'
 typeIndex['collsize']['base'] = '1024'
 typeIndex['collsize']['scale'] = '--logarithmic -l1 --units=si'
-typeIndex['collsize']['category'] = 'db'
+typeIndex['collsize']['category'] = settings_graph_category
 
 typeIndex['avgsize'] = {}
 typeIndex['avgsize']['index'] = 'avgObjSize'
@@ -68,7 +70,7 @@ typeIndex['avgsize']['title'] = 'average object size'
 typeIndex['avgsize']['yaxis'] = 'Byte'
 typeIndex['avgsize']['base'] = '1024'
 typeIndex['avgsize']['scale'] = '--logarithmic --units=si'
-typeIndex['avgsize']['category'] = 'db'
+typeIndex['avgsize']['category'] = settings_graph_category
 
 typeIndex['storage'] = {}
 typeIndex['storage']['index'] = 'storageSize'
@@ -76,7 +78,7 @@ typeIndex['storage']['title'] = 'per collection storage size'
 typeIndex['storage']['yaxis'] = 'Byte'
 typeIndex['storage']['base'] = '1024'
 typeIndex['storage']['scale'] = '--logarithmic -l1 --units=si'
-typeIndex['storage']['category'] = 'db'
+typeIndex['storage']['category'] = settings_graph_category
 
 typeIndex['indexsize'] = {}
 typeIndex['indexsize']['index'] = 'totalIndexSize'
@@ -84,7 +86,7 @@ typeIndex['indexsize']['title'] = 'per collection index size'
 typeIndex['indexsize']['yaxis'] = 'Byte'
 typeIndex['indexsize']['base'] = '1024'
 typeIndex['indexsize']['scale'] = '--logarithmic -l 1 --units=si'
-typeIndex['indexsize']['category'] = 'db'
+typeIndex['indexsize']['category'] = settings_graph_category
 
 
 def getCollstats(graphtype):
@@ -139,7 +141,7 @@ def doConfig(base, graphtype):
             print("graph_title MongoDB " + typeIndex[graphtype]['title'] + " for database " + d)
             print("graph_args --base " + typeIndex[graphtype]['base'] + " " + typeIndex[graphtype]['scale'])
             print("graph_vlabel " + typeIndex[graphtype]['yaxis'])
-            print("graph_category db")
+            print("graph_category %s" % settings_graph_category)
         print("%s_%s.label %s" % (graphtype, k, k))
         print("%s_%s.min 0" % (graphtype, k))
         print("%s_%s.draw LINE1" % (graphtype, k))

--- a/plugins/mongodb/mongo_lag
+++ b/plugins/mongodb/mongo_lag
@@ -76,8 +76,8 @@ def config():
     print("""graph_title MongoDB replication lag
 graph_args --base 1000
 graph_vlabel Replication lag (seconds)
-graph_category db
-""")
+graph_category %s
+""" % os.getenv('graph_category', 'db'))
 
     for member in _get_members():
         print("{0}.label {0}".format(member))

--- a/plugins/mongodb/mongo_mem
+++ b/plugins/mongodb/mongo_mem
@@ -70,7 +70,7 @@ def doConfig():
 graph_title MongoDB memory usage
 graph_args --base 1024 -l 0 --vertical-label Bytes
 graph_category %s
-""" % os.getenv('graph_category', 'mongodb'))
+""" % os.getenv('graph_category', 'db'))
 
     for k in getServerStatus()["mem"]:
         if ok( k ):

--- a/plugins/mongodb/mongo_mem
+++ b/plugins/mongodb/mongo_mem
@@ -69,8 +69,8 @@ def doConfig():
     print("""
 graph_title MongoDB memory usage
 graph_args --base 1024 -l 0 --vertical-label Bytes
-graph_category mongodb
-""")
+graph_category %s
+""" % os.getenv('graph_category', 'mongodb'))
 
     for k in getServerStatus()["mem"]:
         if ok( k ):

--- a/plugins/mongodb/mongo_ops
+++ b/plugins/mongodb/mongo_ops
@@ -68,9 +68,9 @@ def doConfig():
 graph_title MongoDB ops
 graph_args --base 1000 -l 0
 graph_vlabel ops / ${graph_period}
-graph_category db
+graph_category %s
 graph_total total
-""")
+""" % os.getenv('graph_category', 'db'))
 
     for k in getServerStatus()["opcounters"]:
         print(k + ".label " + k)

--- a/plugins/mongodb/mongodb_conn
+++ b/plugins/mongodb/mongodb_conn
@@ -66,7 +66,7 @@ def config():
     print("""
 graph_title MongoDB Connections Count
 graph_vlabel Connections count
-graph_category db
+graph_category %s
 graph_args --base 1000 -l 0
 current.label current
 current.draw AREASTACK
@@ -74,7 +74,7 @@ available.label available
 available.draw AREASTACK
 active.label active
 active.draw AREASTACK
-""")
+""" % os.getenv('graph_category', 'db'))
 
 
 if __name__ == "__main__":

--- a/plugins/mongodb/mongodb_docs
+++ b/plugins/mongodb/mongodb_docs
@@ -69,8 +69,8 @@ def doConfig():
 graph_title MongoDB documents
 graph_args --base 1000 -l 0
 graph_vlabel documents
-graph_category db
-""")
+graph_category %s
+""" % os.getenv('graph_category', 'db'))
 
     for k in getServerStatus()["metrics"]["document"]:
         print(k + ".label " + k)


### PR DESCRIPTION
Hi:

I'm proposing this patch so we can configure the graphs category for mongodb scripts, as some of them were setting it as 'db', but others were using 'mongodb'.

Making it configurable I think it's the best backward-compatibility way to set them under the same category (or not) if needed.

Let me know please if you have any question.

Thanks all for your work on this project.

Cheers,


Jeremías