### PR TITLE
Prevent escaping of internal names with leading numbers to fix graph …

### DIFF
--- a/plugins/disk/nvme
+++ b/plugins/disk/nvme
@@ -152,7 +152,7 @@ sub nvme_list {
         if (m:^Node\s+SN\s+Model\s+Namespace Usage:) {
             ++$recognised_output;
         } elsif (m:^(/\S+)\s+(\S+)\s+(\S.*\S)\s{3,}(\d+)\s+(\S+\s+.B)\s+/\s+(\S+\s+.B):) {
-            $devices{$2} = {
+            $devices{'SN_'.$2} = {
                 device    => $1,
                 sn        => $2,
                 model     => $3,


### PR DESCRIPTION
…processing

With serials like

Node             SN                   Model                                    Namespace Usage                      Format           FW Rev  
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     285S100HTYST         KXG50ZNV512G TOSHIBA                     1         512,11  GB / 512,11  GB    512   B +  0 B   AAGA4106
/dev/nvme1n1     S4GENX0N713949       SAMSUNG MZVLB512HBJQ-00000               1         474,89  GB / 512,11  GB    512   B +  0 B   EXF7201Q

the internal names (by serial number) were rewritten to

Field 	Internal name 	Type 	Warn 	Crit 	Info
/dev/nvme0n1 	_85S100HTYST_w 	derive 	  	  	 
/dev/nvme1n1 	S4GENX0N713949_w 	derive

--> the trailing underscore in case of nvme0n1 created problems in graph processing:

[RRD ERROR] Unable to graph /var/cache/munin/www/lxdserver/....agitos.de/nvme_bytes-month.png : undefined vname c285S100HTYST_r

Therefore I added a prefix 'SN_' for internal names.