### PR TITLE
nvidia_gpu_: fix current temperature on nvidia 460

### DIFF
--- a/plugins/gpu/nvidia_gpu_
+++ b/plugins/gpu/nvidia_gpu_
@@ -214,7 +214,7 @@ fi
 # Get requested value
 case $name in
 	temp)
-		valueGpus=$(echo "$smiOutput" | grep -A 1 "Temperature" | grep -i "Gpu" | cut -d : -f 2 | cut -d ' ' -f 2)
+		valueGpus=$(echo "$smiOutput" | grep "GPU Current Temp" | cut -d : -f 2 | cut -d ' ' -f 2)
 		;;
 	mem)
 		totalMemGpus=$(echo "$smiOutput" | grep -v BAR1 | grep -A 3 "Memory Usage" | grep "Total" | cut -d : -f 2 | cut -d ' ' -f 2)


### PR DESCRIPTION
After upgrading to nvidia drivers version 460, the output of `nvidia-smi -q` has changed, breaking the parsing script `nvidia_gpu_` at line `217`. This is due to an extra "Temperature" line being printed by `nvidia-smi -q`. This patch fixes this by grepping for the full string `GPU Current Temp`, which should be more robust and also backward compatible.


Compare this: (v450)
```
nvidia-smi -q | grep -i temp
```
```
    Temperature
        GPU Current Temp                  : 28 C
        GPU Shutdown Temp                 : 94 C
        GPU Slowdown Temp                 : 91 C
        GPU Max Operating Temp            : N/A
        Memory Current Temp               : N/A
        Memory Max Operating Temp         : N/A
    Temperature
        GPU Current Temp                  : 28 C
        GPU Shutdown Temp                 : 94 C
        GPU Slowdown Temp                 : 91 C
        GPU Max Operating Temp            : N/A
        Memory Current Temp               : N/A
        Memory Max Operating Temp         : N/A
```

to this (v460)
```
    Temperature
        GPU Current Temp                  : 28 C
        GPU Shutdown Temp                 : 94 C
        GPU Slowdown Temp                 : 91 C
        GPU Max Operating Temp            : 89 C
        GPU Target Temperature            : 84 C
        Memory Current Temp               : N/A
        Memory Max Operating Temp         : N/A
    Temperature
        GPU Current Temp                  : 28 C
        GPU Shutdown Temp                 : 94 C
        GPU Slowdown Temp                 : 91 C
        GPU Max Operating Temp            : 89 C
        GPU Target Temperature            : 84 C
        Memory Current Temp               : N/A
        Memory Max Operating Temp         : N/A

```
Before the patch, line `217` returns:
```bash
nvidia-smi -q | grep -A 1 "Temperature" | grep -i "Gpu" | cut -d : -f 2 | cut -d ' ' -f 2
```
```
28
84
28
84
```
which is wrong, because munin would plot 28°C for the first device and 84°C for the second device.
After the patch:
```bash
nvidia-smi -q | grep "GPU Current Temp" | cut -d : -f 2 | cut -d ' ' -f 2
```
```
28
28
```

Tested with
NVIDIA-SMI 460.32.03
Driver Version: 460.32.03
CUDA Version: 11.2