### PR TITLE
Allow php_apc_ plugin to use APCu functions

### DIFF
--- a/plugins/php/php_apc.php
+++ b/plugins/php/php_apc.php
@@ -1,24 +1,34 @@
 <?php
 $ret = array();
 
-if(function_exists("apc_cache_info") && function_exists("apc_sma_info"))
+// Detect APC functions to call.
+$apc_fn_name = "";
+if(function_exists("apcu_cache_info") && function_exists("apcu_sma_info"))
+{
+  $apc_fn_name = "apcu";
+} elseif (function_exists("apc_cache_info") && function_exists("apc_sma_info"))
+{
+  $apc_fn_name = "apc";
+}
+
+if(!empty($apc_fn_name))
 {
   switch ($_GET["act"])
   {
     case "memory":
-      $tmp = apc_sma_info();
+      $tmp = call_user_func($apc_fn_name . "_sma_info");
       $ret["mem_used"] = $tmp["seg_size"]-$tmp["avail_mem"];
       $ret["mem_avail"] = $tmp["avail_mem"];
       break;
     case "hits":
-      $tmp = apc_cache_info();
+      $tmp =  call_user_func($apc_fn_name . "_cache_info");
       $ret["num_hits"] = $tmp["num_hits"];
       $ret["num_misses"] = $tmp["num_misses"];
       break;
     case "percents":
-      $tmp = apc_sma_info();
+      $tmp =  call_user_func($apc_fn_name . "_sma_info");
       $ret["memory"] = 100-(($tmp["avail_mem"] / $tmp["seg_size"])*100);
-      $tmp = apc_cache_info();
+      $tmp = apcu_cache_info();
       $ret["hits"] = ($tmp["num_hits"] / ( $tmp["num_hits"]+$tmp["num_misses"]) ) * 100;
       $ret["misses"] = ($tmp["num_misses"] / ( $tmp["num_hits"]+$tmp["num_misses"]) ) * 100;
       break;


### PR DESCRIPTION
Fixes https://github.com/munin-monitoring/contrib/issues/1194

Detect available functions (apc_ or apcu_ ones) and call the right ones.