### PR TITLE
jitsi-videobridge: videostreams aren't anymore

### DIFF
--- a/plugins/jitsi/jitsi_videobridge
+++ b/plugins/jitsi/jitsi_videobridge
@@ -17,10 +17,14 @@ Jitsi-Videobridge instances
 Requires enabled colibri statistics on jitsi-videobridge and an 
 installed jq, a command-line json processor.
 
-You may specify the URL where to get the statistics
+You may specify the URL where to get the statistics.
+
+ sites       - URL of colibri stats
+ max_time    - Timeout curl - defaults to 3 seconds
 
  [jitsi_videobridge]
  env.url http://127.0.0.1:8080/colibri/stats
+ env.max_time 3
 
 ... and you may disable the audiochannel when you don't use an
 audio gateway.
@@ -49,7 +53,7 @@ case $1 in
     autoconf)
         if [ -x /usr/bin/curl ]; then
             if [ -x /usr/bin/jq ]; then
-	        curl -s -f -m 2 -I "$COLIBRI_URL" | grep -iq "Content-Type: application/json" && echo "yes" && exit 0 || echo "no (invalid or empty response from colibri API ($COLIBRI_URL))" && exit 0
+	        curl -s -f -m "${max_time:-3}" -I "$COLIBRI_URL" | grep -iq "Content-Type: application/json" && echo "yes" && exit 0 || echo "no (invalid or empty response from colibri API ($COLIBRI_URL))" && exit 0
             else
                 echo "no (jq not found)" && exit 0
             fi
@@ -80,14 +84,6 @@ case $1 in
         echo "jitsi_participants.info current number of participants"
         echo "jitsi_participants.min 0"
         echo "jitsi_participants.draw LINE2"
-        echo "multigraph jitsi_videobridge_streams"
-        echo "graph_title Current jitsi-videobridge videostreams"
-        echo "graph_info Current jitsi-videobridge videostreams"
-        echo "graph_vlabel current videostreams"
-        echo "graph_args --base 1000 -l 0"
-        echo "jitsi_videostreams.label videostreams"
-        echo "jitsi_videostreams.info current number of videostreams"
-        echo "jitsi_videostreams.min 0"
         echo "multigraph jitsi_videobridge_conferences"
         echo "graph_title Total of jitsi-videobridge conferences"
         echo "graph_info Total of jitsi-videobridge conferences"
@@ -122,10 +118,6 @@ for KEY in videochannels audiochannels conferences participants; do
     VALUE=$(echo "$JSONSTATS" | jq -r ".$KEY // \"U\"")
     echo "jitsi_${KEY}.value $VALUE"
 done
-
-echo "multigraph jitsi_videobridge_streams"
-VALUE=$(echo "$JSONSTATS" | jq -r ".videostreams // \"U\"")
-echo "jitsi_videostreams.value $VALUE"
 
 echo "multigraph jitsi_videobridge_conferences"
 for KEY in total_conferences_created total_failed_conferences total_partially_failed_conferences total_conferences_completed; do


### PR DESCRIPTION
Remove videostreams graph (colibri stats doesn't give informations about videostreams).
Specify curl timeout.