### PR TITLE
nutups2: fix for status line without value

### DIFF
--- a/plugins/power/nutups2_
+++ b/plugins/power/nutups2_
@@ -151,7 +151,7 @@ sub read_ups_values {
 	for my $line (@lines) {
 		chomp $line;
 
-		my ($key, $value) = $line =~ m/^([^:]+):\s+(\S.*)$/;
+		my ($key, $value) = $line =~ m/^([^:]+):\s+(.*)$/;
 		$values->{$key} = $value;
 	}
 	return $values;


### PR DESCRIPTION
"upsc name" can output line "input.transfer.reason: " (key without value).
Allow it.