### PR TITLE
knot: cache results, needed for first run after server reboot

### DIFF
--- a/plugins/knot/knot
+++ b/plugins/knot/knot
@@ -122,7 +122,7 @@ def get_stats():
 
     # After server reboot output can be almost empty. Use cached results
     # instead, needed for plugin config when using munin-async.
-    cachename = os.getenv('MUNIN_PLUGSTATE') + '/knot.state'
+    cachename = os.path.join(os.getenv('MUNIN_PLUGSTATE'), 'knot.state')
     if len(output) > 2048:
         with open(cachename, 'wt') as cache:
             cache.write(output)

--- a/plugins/knot/knot
+++ b/plugins/knot/knot
@@ -38,6 +38,7 @@ GPLv2
 import os
 import subprocess
 import sys
+import time
 from collections import defaultdict
 
 
@@ -112,13 +113,25 @@ def get_stats():
     """Get statistics."""
     # Get status output
     try:
-        pipe = subprocess.Popen(
-            ['/usr/sbin/knotc', '--force', 'stats'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT)
-        output = pipe.communicate()[0].decode('utf-8', 'ignore')
-    except OSError:
+        output = subprocess.run(['knotc', '--force', 'stats'],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, check=False,
+                                encoding='utf-8', errors='ignore').stdout
+    except FileNotFoundError:
         return {}
+
+    # After server reboot output can be almost empty. Use cached results
+    # instead, needed for plugin config when using munin-async.
+    cachename = os.getenv('MUNIN_PLUGSTATE') + '/knot.state'
+    if len(output) > 2048:
+        with open(cachename, 'wt') as cache:
+            cache.write(output)
+    elif (
+            os.path.exists(cachename) and
+            os.stat(cachename).st_mtime > time.time() - 900
+    ):
+        with open(cachename, 'rt') as cache:
+            output = cache.read()
 
     # Parse output. Keep graph labels in knotc-order.
     values = defaultdict(dict)


### PR DESCRIPTION
Sometimes after reboot munin-async + munin-node runs before knot is
ready. This will result missing knot stats, as there is no static
config in plugin. Cache results and use them instead if knot's output
is empty.