### PR TITLE
[plugins/disk/] Fix warning on btrfs_device_stats.

### DIFF
--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -13,8 +13,8 @@ btrfs_device_stats - Script to monitor btrfs device statistics
 Simply create a symlink in your plugins directory like with any other plugin.
 Must be run as root.
 
- [btrfs_device_stats]
- user root
+[btrfs_device_stats]
+user root
 
 =head2 DEFAULT CONFIGURATION
 
@@ -22,7 +22,7 @@ Must be run as root.
 
 =head1 AUTHOR
 
-2019, HaseHarald
+2019-2021, HaseHarald
 
 =head1 MAGIC MARKERS
 
@@ -88,18 +88,18 @@ def munin_config(fs):
         print("graph_info This graph shows stats of devices used by btrfs")
 
         print("corruption_errs.label Corruption Errors")
-        print("corruption_errs.warming 1")
+        print("corruption_errs.warning 1")
         print("flush_errs.label Flush Errors")
-        print("flush_errs.warming 1")
+        print("flush_errs.warning 1")
         print("generation_errs.label Generation Errors")
-        print("generation_errs.warming 1")
+        print("generation_errs.warning 1")
         print("read_errs.label Read Errors")
-        print("read_errs.warming 1")
+        print("read_errs.warning 1")
         print("write_errs.label Write Errors")
-        print("write_errs.warming 1")
+        print("write_errs.warning 1")
         print("nr_items.label Nr. of Items")
         print("flags.label Nr. of Flags")
-        print("flags.warming 1")
+        print("flags.warning 1")
 
         print("")
 


### PR DESCRIPTION
It's always those typos!
I don't know why I didn't notice this in all those years. I had "warming" instead of "warning" all over the code. Stupid mistake!