### PR TITLE
[plugins/disk/] Allow for configuration of warning levels on btrfs_device_* plugins

### DIFF
--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -106,7 +106,7 @@ def munin_config(fs):
         print("corruption_errs.label Corruption Errors")
         print("corruption_errs.warning " + os.getenv('corruption_errs_warning',
               default = str(warning)))
-        if os.getenv('corruption_errs_critical', default = critical) != False:
+        if os.getenv('corruption_errs_critical', default = critical):
             print("corruption_errs.critical " +
                   os.getenv('corruption_errs_critical',
                   default = str(critical)))
@@ -114,14 +114,14 @@ def munin_config(fs):
         print("flush_errs.label Flush Errors")
         print("flush_errs.warning " + os.getenv('flush_errs_warning',
               default = str(warning)))
-        if os.getenv('flush_errs_critical', default = critical) != False:
+        if os.getenv('flush_errs_critical', default = critical):
             print("flush_errs.critical " + os.getenv('flush_errs_critical',
                   default = str(critical)))
 
         print("generation_errs.label Generation Errors")
         print("generation_errs.warning " + os.getenv('generation_errs_warning',
               default = str(warning)))
-        if os.getenv('generation_errs_critical', default = critical) != False:
+        if os.getenv('generation_errs_critical', default = critical):
             print("generation_errs.critical " +
                   os.getenv('generation_errs_critical',
                   default = str(critical)))
@@ -129,14 +129,14 @@ def munin_config(fs):
         print("read_errs.label Read Errors")
         print("read_errs.warning " + os.getenv('read_errs_warning',
               default = str(warning)))
-        if os.getenv('read_errs_critical', default = critical) != False:
+        if os.getenv('read_errs_critical', default = critical):
             print("read_errs.critical " + os.getenv('read_errs_critical',
                   default = str(critical)))
 
         print("write_errs.label Write Errors")
         print("write_errs.warning " + os.getenv('write_errs_warning',
               default = str(warning)))
-        if os.getenv('write_errs_critical', default = critical) != False:
+        if os.getenv('write_errs_critical', default = critical):
             print("write_errs.critical " + os.getenv('write_errs_critical',
                   default = str(critical)))
 
@@ -145,7 +145,7 @@ def munin_config(fs):
         print("flags.label Nr. of Flags")
         print("flags.warning " + os.getenv('flags_warning',
               default = str(warning)))
-        if os.getenv('flags_critical', default = critical) != False:
+        if os.getenv('flags_critical', default = critical):
             print("flags.critical " + os.getenv('flags_critical',
                   default = str(critical)))
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -16,6 +16,18 @@ Must be run as root.
 [btrfs_device_stats]
 user root
 
+You can optionaly configure the warning and critical limits. By default warning
+is set to 1 and critical is not set at all. You can set the limits either for
+the entire plugin or per individual metric. The individual values take
+precedence over the general ones. See the following example:
+
+[btrfs_device_stats]
+user root
+env.warning 2
+env.critical 4
+env.flags_warning 23
+env.read_errs_critical 42
+
 =head2 DEFAULT CONFIGURATION
 
 =head1 BUGS

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -90,8 +90,8 @@ def munin_config(fs):
     print("")
 
     devices = fs.devices()
-    warning = os.getenv('warning', default = 1)
-    critical = os.getenv('critical', default = False)
+    warning = os.getenv('warning', default=1)
+    critical = os.getenv('critical', default=False)
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
@@ -105,49 +105,49 @@ def munin_config(fs):
 
         print("corruption_errs.label Corruption Errors")
         print("corruption_errs.warning " + os.getenv('corruption_errs_warning',
-              default = str(warning)))
-        if os.getenv('corruption_errs_critical', default = critical):
+              default=str(warning)))
+        if os.getenv('corruption_errs_critical', default=critical):
             print("corruption_errs.critical " +
                   os.getenv('corruption_errs_critical',
-                  default = str(critical)))
+                  default=str(critical)))
 
         print("flush_errs.label Flush Errors")
         print("flush_errs.warning " + os.getenv('flush_errs_warning',
               default = str(warning)))
-        if os.getenv('flush_errs_critical', default = critical):
+        if os.getenv('flush_errs_critical', default=critical):
             print("flush_errs.critical " + os.getenv('flush_errs_critical',
-                  default = str(critical)))
+                  default=str(critical)))
 
         print("generation_errs.label Generation Errors")
         print("generation_errs.warning " + os.getenv('generation_errs_warning',
-              default = str(warning)))
-        if os.getenv('generation_errs_critical', default = critical):
+              default=str(warning)))
+        if os.getenv('generation_errs_critical', default=critical):
             print("generation_errs.critical " +
                   os.getenv('generation_errs_critical',
-                  default = str(critical)))
+                  default=str(critical)))
 
         print("read_errs.label Read Errors")
         print("read_errs.warning " + os.getenv('read_errs_warning',
-              default = str(warning)))
-        if os.getenv('read_errs_critical', default = critical):
+              default=str(warning)))
+        if os.getenv('read_errs_critical', default=critical):
             print("read_errs.critical " + os.getenv('read_errs_critical',
-                  default = str(critical)))
+                  default=str(critical)))
 
         print("write_errs.label Write Errors")
         print("write_errs.warning " + os.getenv('write_errs_warning',
-              default = str(warning)))
-        if os.getenv('write_errs_critical', default = critical):
+              default=str(warning)))
+        if os.getenv('write_errs_critical', default=critical):
             print("write_errs.critical " + os.getenv('write_errs_critical',
-                  default = str(critical)))
+                  default=str(critical)))
 
         print("nr_items.label Nr. of Items")
 
         print("flags.label Nr. of Flags")
         print("flags.warning " + os.getenv('flags_warning',
-              default = str(warning)))
-        if os.getenv('flags_critical', default = critical):
+              default=str(warning)))
+        if os.getenv('flags_critical', default=critical):
             print("flags.critical " + os.getenv('flags_critical',
-                  default = str(critical)))
+                  default=str(critical)))
 
         print("")
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -13,8 +13,8 @@ btrfs_device_stats - Script to monitor btrfs device statistics
 Simply create a symlink in your plugins directory like with any other plugin.
 Must be run as root.
 
- [btrfs_device_stats]
- user root
+[btrfs_device_stats]
+user root
 
 =head2 DEFAULT CONFIGURATION
 
@@ -22,7 +22,7 @@ Must be run as root.
 
 =head1 AUTHOR
 
-2019, HaseHarald
+2019-2021, HaseHarald
 
 =head1 MAGIC MARKERS
 
@@ -88,18 +88,18 @@ def munin_config(fs):
         print("graph_info This graph shows stats of devices used by btrfs")
 
         print("corruption_errs.label Corruption Errors")
-        print("corruption_errs.warming 1")
+        print("corruption_errs.warning 1")
         print("flush_errs.label Flush Errors")
-        print("flush_errs.warming 1")
+        print("flush_errs.warning 1")
         print("generation_errs.label Generation Errors")
-        print("generation_errs.warming 1")
+        print("generation_errs.warning 1")
         print("read_errs.label Read Errors")
-        print("read_errs.warming 1")
+        print("read_errs.warning 1")
         print("write_errs.label Write Errors")
-        print("write_errs.warming 1")
+        print("write_errs.warning 1")
         print("nr_items.label Nr. of Items")
         print("flags.label Nr. of Flags")
-        print("flags.warming 1")
+        print("flags.warning 1")
 
         print("")
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -79,6 +79,7 @@ def munin_config(fs):
 
     devices = fs.devices()
     warning = os.getenv('warning', default = 1)
+    critical = os.getenv('critical', default = False)
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
@@ -91,17 +92,35 @@ def munin_config(fs):
 
         print("corruption_errs.label Corruption Errors")
         print("corruption_errs.warning " + os.getenv('corruption_errs_warning', default = str(warning)))
+        if os.getenv('corruption_errs_critical', default = critical) != False:
+            print("corruption_errs.critical " + os.getenv('corruption_errs_critical', default = str(critical)))
+
         print("flush_errs.label Flush Errors")
         print("flush_errs.warning " + os.getenv('flush_errs_warning', default = str(warning)))
+        if os.getenv('flush_errs_critical', default = critical) != False:
+            print("flush_errs.critical " + os.getenv('flush_errs_critical', default = str(critical)))
+
         print("generation_errs.label Generation Errors")
         print("generation_errs.warning " + os.getenv('generation_errs_warning', default = str(warning)))
+        if os.getenv('generation_errs_critical', default = critical) != False:
+            print("generation_errs.critical " + os.getenv('generation_errs_critical', default = str(critical)))
+
         print("read_errs.label Read Errors")
         print("read_errs.warning " + os.getenv('read_errs_warning', default = str(warning)))
+        if os.getenv('read_errs_critical', default = critical) != False:
+            print("read_errs.critical " + os.getenv('read_errs_critical', default = str(critical)))
+
         print("write_errs.label Write Errors")
         print("write_errs.warning " + os.getenv('write_errs_warning', default = str(warning)))
+        if os.getenv('write_errs_critical', default = critical) != False:
+            print("write_errs.critical " + os.getenv('write_errs_critical', default = str(critical)))
+
         print("nr_items.label Nr. of Items")
+
         print("flags.label Nr. of Flags")
         print("flags.warning " + os.getenv('flags_warning', default = str(warning)))
+        if os.getenv('flags_critical', default = critical) != False:
+            print("flags.critical " + os.getenv('flags_critical', default = str(critical)))
 
         print("")
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -113,7 +113,7 @@ def munin_config(fs):
 
         print("flush_errs.label Flush Errors")
         print("flush_errs.warning " + os.getenv('flush_errs_warning',
-              default = str(warning)))
+              default=str(warning)))
         if os.getenv('flush_errs_critical', default=critical):
             print("flush_errs.critical " + os.getenv('flush_errs_critical',
                   default=str(critical)))

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -54,6 +54,7 @@ LGPLv3
 
 
 import btrfs
+import os
 import sys
 
 
@@ -77,6 +78,7 @@ def munin_config(fs):
     print("")
 
     devices = fs.devices()
+    warning = os.getenv('warning', default = 1)
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
@@ -88,18 +90,18 @@ def munin_config(fs):
         print("graph_info This graph shows stats of devices used by btrfs")
 
         print("corruption_errs.label Corruption Errors")
-        print("corruption_errs.warning 1")
+        print("corruption_errs.warning " + os.getenv('corruption_errs_warning', default = str(warning)))
         print("flush_errs.label Flush Errors")
-        print("flush_errs.warning 1")
+        print("flush_errs.warning " + os.getenv('flush_errs_warning', default = str(warning)))
         print("generation_errs.label Generation Errors")
-        print("generation_errs.warning 1")
+        print("generation_errs.warning " + os.getenv('generation_errs_warning', default = str(warning)))
         print("read_errs.label Read Errors")
-        print("read_errs.warning 1")
+        print("read_errs.warning " + os.getenv('read_errs_warning', default = str(warning)))
         print("write_errs.label Write Errors")
-        print("write_errs.warning 1")
+        print("write_errs.warning " + os.getenv('write_errs_warning', default = str(warning)))
         print("nr_items.label Nr. of Items")
         print("flags.label Nr. of Flags")
-        print("flags.warning 1")
+        print("flags.warning " + os.getenv('flags_warning', default = str(warning)))
 
         print("")
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -18,8 +18,9 @@ user root
 
 You can optionaly configure the warning and critical limits. By default warning
 is set to 1 and critical is not set at all. You can set the limits either for
-the entire plugin or per individual metric. The individual values take
-precedence over the general ones. See the following example:
+the entire plugin or per individual metric and down to a specific device. The
+more specific values take precedence over the general ones.
+See the following example:
 
 [btrfs_device_stats]
 user root
@@ -27,6 +28,7 @@ env.warning 2
 env.critical 4
 env.flags_warning 23
 env.read_errs_critical 42
+env.generation_errs_a04f3d6b_438c_4b61_979b_e5fda7fb858c_1_warning 187
 
 =head2 DEFAULT CONFIGURATION
 
@@ -90,11 +92,14 @@ def munin_config(fs):
     print("")
 
     devices = fs.devices()
-    warning = os.getenv('warning', default=1)
-    critical = os.getenv('critical', default=False)
     for this_device in devices:
+        # Set defaults
+        warning = os.getenv('warning', default="1")
+        critical = os.getenv('critical', default=False)
+        # Get device informations
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
+
         print("multigraph btrfs_device_stats_" + fsid + "." +
               str(this_device.devid))
         print("graph_args --base 1000 -l 0")
@@ -103,51 +108,97 @@ def munin_config(fs):
         print("graph_category disk")
         print("graph_info This graph shows stats of devices used by btrfs")
 
+        # Labels and warning/critical values for Corruption Errors
+        this_corr_errs_warn = os.getenv('corruption_errs_warning',
+                                        default=warning)
+        this_corr_errs_warn = os.getenv('corruption_errs_' + fsid + "_" +
+                                        str(this_device.devid) + '_warning',
+                                        default=this_corr_errs_warn)
+        this_corr_errs_crit = os.getenv('corruption_errs_critical',
+                                        default=critical)
+        this_corr_errs_crit = os.getenv('corruption_errs_' + fsid + "_" +
+                                        str(this_device.devid) + '_critical',
+                                        default=this_corr_errs_crit)
         print("corruption_errs.label Corruption Errors")
-        print("corruption_errs.warning " + os.getenv('corruption_errs_warning',
-              default=str(warning)))
-        if os.getenv('corruption_errs_critical', default=critical):
-            print("corruption_errs.critical " +
-                  os.getenv('corruption_errs_critical',
-                            default=str(critical)))
+        print("corruption_errs.warning " + this_corr_errs_warn)
+        if this_corr_errs_crit:
+            print("corruption_errs.critical " + this_corr_errs_crit)
 
+        # Labels and warning/critical values for Flush Errors
+        this_flush_errs_warn = os.getenv('flush_errs_warning', default=warning)
+        this_flush_errs_warn = os.getenv('flush_errs_' + fsid + "_" +
+                                         str(this_device.devid) + '_warning',
+                                         default=this_flush_errs_warn)
+        this_flush_errs_crit = os.getenv('flush_errs_critical',
+                                         default=critical)
+        this_flush_errs_crit = os.getenv('flush_errs_' + fsid + "_" +
+                                         str(this_device.devid) + '_critical',
+                                         default=this_flush_errs_crit)
         print("flush_errs.label Flush Errors")
-        print("flush_errs.warning " + os.getenv('flush_errs_warning',
-              default=str(warning)))
-        if os.getenv('flush_errs_critical', default=critical):
-            print("flush_errs.critical " + os.getenv('flush_errs_critical',
-                  default=str(critical)))
+        print("flush_errs.warning " + this_flush_errs_warn)
+        if this_flush_errs_crit:
+            print("flush_errs.critical " + this_flush_errs_crit)
 
+        # Labels and warning/critical values for Generation Errors
+        this_gen_errs_warn = os.getenv('generation_errs_warning',
+                                       default=warning)
+        this_gen_errs_warn = os.getenv('generation_errs_' + fsid + "_" +
+                                       str(this_device.devid) + '_warning',
+                                       default=this_gen_errs_warn)
+        this_gen_errs_crit = os.getenv('generation_errs_critical',
+                                       default=critical)
+        this_gen_errs_crit = os.getenv('generation_errs_' + fsid + "_" +
+                                       str(this_device.devid) + '_critical',
+                                       default=this_gen_errs_crit)
         print("generation_errs.label Generation Errors")
-        print("generation_errs.warning " + os.getenv('generation_errs_warning',
-              default=str(warning)))
-        if os.getenv('generation_errs_critical', default=critical):
-            print("generation_errs.critical " +
-                  os.getenv('generation_errs_critical',
-                            default=str(critical)))
+        print("generation_errs.warning " + this_gen_errs_warn)
+        if this_gen_errs_crit:
+            print("generation_errs.critical " + this_gen_errs_crit)
 
+        # Labels and warning/critical values for Read Errors
+        this_read_errs_warn = os.getenv('read_errs_warning', default=warning)
+        this_read_errs_warn = os.getenv('read_' + fsid + "_" +
+                                        str(this_device.devid) + '_warning',
+                                        default=this_read_errs_warn)
+        this_read_errs_crit = os.getenv('read_errs_critical', default=critical)
+        this_read_errs_crit = os.getenv('read_errs_' + fsid + "_" +
+                                        str(this_device.devid) + '_critical',
+                                        default=this_read_errs_crit)
         print("read_errs.label Read Errors")
-        print("read_errs.warning " + os.getenv('read_errs_warning',
-              default=str(warning)))
-        if os.getenv('read_errs_critical', default=critical):
-            print("read_errs.critical " + os.getenv('read_errs_critical',
-                  default=str(critical)))
+        print("read_errs.warning " + this_read_errs_warn)
+        if this_read_errs_crit:
+            print("read_errs.critical " + this_read_errs_crit)
 
+        # Labels and warning/critical values for Write Errors
+        this_write_errs_warn = os.getenv('write_errs_warning', default=warning)
+        this_write_errs_warn = os.getenv('write_errs_' + fsid + "_" +
+                                         str(this_device.devid) + '_warning',
+                                         default=this_write_errs_warn)
+        this_write_errs_crit = os.getenv('write_errs_critical',
+                                         default=critical)
+        this_write_errs_crit = os.getenv('write_errs_' + fsid + "_" +
+                                         str(this_device.devid) + '_critical',
+                                         default=this_write_errs_crit)
         print("write_errs.label Write Errors")
-        print("write_errs.warning " + os.getenv('write_errs_warning',
-              default=str(warning)))
-        if os.getenv('write_errs_critical', default=critical):
-            print("write_errs.critical " + os.getenv('write_errs_critical',
-                  default=str(critical)))
+        print("write_errs.warning " + this_write_errs_warn)
+        if this_write_errs_crit:
+            print("write_errs.critical " + this_write_errs_crit)
 
         print("nr_items.label Nr. of Items")
 
+        # Labels and warning/critical values for Flags
+        this_flags_warn = os.getenv('flags_warning', default=warning)
+        this_flags_warn = os.getenv('flags_' + fsid + "_" +
+                                    str(this_device.devid) + '_warning',
+                                    default=this_flags_warn)
+        this_flags_crit = os.getenv('flags_critical', default=critical)
+        this_flags_crit = os.getenv('flags_' + fsid + "_" +
+                                    str(this_device.devid) + '_critical',
+                                    default=this_flags_crit)
         print("flags.label Nr. of Flags")
-        print("flags.warning " + os.getenv('flags_warning',
-              default=str(warning)))
-        if os.getenv('flags_critical', default=critical):
-            print("flags.critical " + os.getenv('flags_critical',
-                  default=str(critical)))
+        print("flags.warning " + this_flags_warn)
+        if this_flags_crit:
+            print("flags.critical " + this_flags_crit)
 
         print("")
 

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -95,7 +95,8 @@ def munin_config(fs):
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
         this_dev_name = this_dev_info.path.replace('/dev/', '')
-        print("multigraph btrfs_device_stats_" + fsid + "." + str(this_device.devid))
+        print("multigraph btrfs_device_stats_" + fsid + "." +
+              str(this_device.devid))
         print("graph_args --base 1000 -l 0")
         print("graph_vlabel btrfs attribute value")
         print("graph_title btrfs device stats for " + this_dev_name)
@@ -103,36 +104,50 @@ def munin_config(fs):
         print("graph_info This graph shows stats of devices used by btrfs")
 
         print("corruption_errs.label Corruption Errors")
-        print("corruption_errs.warning " + os.getenv('corruption_errs_warning', default = str(warning)))
+        print("corruption_errs.warning " + os.getenv('corruption_errs_warning',
+              default = str(warning)))
         if os.getenv('corruption_errs_critical', default = critical) != False:
-            print("corruption_errs.critical " + os.getenv('corruption_errs_critical', default = str(critical)))
+            print("corruption_errs.critical " +
+                  os.getenv('corruption_errs_critical',
+                  default = str(critical)))
 
         print("flush_errs.label Flush Errors")
-        print("flush_errs.warning " + os.getenv('flush_errs_warning', default = str(warning)))
+        print("flush_errs.warning " + os.getenv('flush_errs_warning',
+              default = str(warning)))
         if os.getenv('flush_errs_critical', default = critical) != False:
-            print("flush_errs.critical " + os.getenv('flush_errs_critical', default = str(critical)))
+            print("flush_errs.critical " + os.getenv('flush_errs_critical',
+                  default = str(critical)))
 
         print("generation_errs.label Generation Errors")
-        print("generation_errs.warning " + os.getenv('generation_errs_warning', default = str(warning)))
+        print("generation_errs.warning " + os.getenv('generation_errs_warning',
+              default = str(warning)))
         if os.getenv('generation_errs_critical', default = critical) != False:
-            print("generation_errs.critical " + os.getenv('generation_errs_critical', default = str(critical)))
+            print("generation_errs.critical " +
+                  os.getenv('generation_errs_critical',
+                  default = str(critical)))
 
         print("read_errs.label Read Errors")
-        print("read_errs.warning " + os.getenv('read_errs_warning', default = str(warning)))
+        print("read_errs.warning " + os.getenv('read_errs_warning',
+              default = str(warning)))
         if os.getenv('read_errs_critical', default = critical) != False:
-            print("read_errs.critical " + os.getenv('read_errs_critical', default = str(critical)))
+            print("read_errs.critical " + os.getenv('read_errs_critical',
+                  default = str(critical)))
 
         print("write_errs.label Write Errors")
-        print("write_errs.warning " + os.getenv('write_errs_warning', default = str(warning)))
+        print("write_errs.warning " + os.getenv('write_errs_warning',
+              default = str(warning)))
         if os.getenv('write_errs_critical', default = critical) != False:
-            print("write_errs.critical " + os.getenv('write_errs_critical', default = str(critical)))
+            print("write_errs.critical " + os.getenv('write_errs_critical',
+                  default = str(critical)))
 
         print("nr_items.label Nr. of Items")
 
         print("flags.label Nr. of Flags")
-        print("flags.warning " + os.getenv('flags_warning', default = str(warning)))
+        print("flags.warning " + os.getenv('flags_warning',
+              default = str(warning)))
         if os.getenv('flags_critical', default = critical) != False:
-            print("flags.critical " + os.getenv('flags_critical', default = str(critical)))
+            print("flags.critical " + os.getenv('flags_critical',
+                  default = str(critical)))
 
         print("")
 
@@ -168,7 +183,8 @@ def munin_values(fs):
         nr_items_total = nr_items_total + nr_items
         flags_total = flags_total + flags
 
-        print("multigraph btrfs_device_stats_" + fsid + "." + str(this_device.devid))
+        print("multigraph btrfs_device_stats_" + fsid + "." +
+              str(this_device.devid))
 
         print("corruption_errs.value " + str(corruption_errs))
         print("flush_errs.value " + str(flush_errs))

--- a/plugins/disk/btrfs_device_stats
+++ b/plugins/disk/btrfs_device_stats
@@ -109,7 +109,7 @@ def munin_config(fs):
         if os.getenv('corruption_errs_critical', default=critical):
             print("corruption_errs.critical " +
                   os.getenv('corruption_errs_critical',
-                  default=str(critical)))
+                            default=str(critical)))
 
         print("flush_errs.label Flush Errors")
         print("flush_errs.warning " + os.getenv('flush_errs_warning',
@@ -124,7 +124,7 @@ def munin_config(fs):
         if os.getenv('generation_errs_critical', default=critical):
             print("generation_errs.critical " +
                   os.getenv('generation_errs_critical',
-                  default=str(critical)))
+                            default=str(critical)))
 
         print("read_errs.label Read Errors")
         print("read_errs.warning " + os.getenv('read_errs_warning',

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -75,19 +75,19 @@ import sys
 def munin_config(fs):
     fsid = str(fs.fsid).replace('-', '_')
 
-    byte_warning = os.getenv('byte_warning', default = False)
-    byte_critical = os.getenv('byte_critical', default = False)
+    byte_warning = os.getenv('byte_warning', default=False)
+    byte_critical = os.getenv('byte_critical', default=False)
     byte_warning = os.getenv('byte_' + fsid + '_warning',
-                             default = byte_warning)
+                             default=byte_warning)
     byte_critical = os.getenv('byte_' + fsid + '_critical',
-                              default = byte_critical)
+                              default=byte_critical)
 
-    percent_warning = os.getenv('percent_warning', default = 95)
-    percent_critical = os.getenv('percent_critical', default = 98)
+    percent_warning = os.getenv('percent_warning', default=95)
+    percent_critical = os.getenv('percent_critical', default=98)
     percent_warning = os.getenv('percent_' + fsid + '_warning',
-                                default = percent_warning)
+                                default=percent_warning)
     percent_critical = os.getenv('percent_' + fsid + '_critical',
-                                 default = percent_critical)
+                                 default=percent_critical)
 
     print("multigraph btrfs_device_usage_byte_" + fsid)
     print("graph_title btrfs usage by device in bytes on " + fs.path)

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -103,10 +103,10 @@ def munin_config(fs):
         this_dev_name = this_dev_info.path.replace('/dev/', '')
         print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
               ".label " + this_dev_name)
-        if byte_warning != False:
+        if byte_warning:
             print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
                   ".warning " + str(byte_warning))
-        if byte_critical != False:
+        if byte_critical:
             print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
                   ".critical " + str(byte_critical))
 

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -16,13 +16,27 @@ Must be run as root.
 [btrfs_device_usage]
 user root
 
+You can optionaly configure the warning and critical limits for byte and
+percentage graphs. By default percent_warning is set to 95 and percent_critical
+is 98. For the byte-graphs there are no default limits set. You can set the
+limits either for the entire graph (byte_ percent_) or per individual filesystem
+using it's UUID (replace minus with underscore). The individual values take
+precedence over the general ones. See the following example:
+
+btrfs_device_usage]
+user root
+env.byte_warning 400300200100
+env.percent_critical 97
+env.percent_10164f3f_6670_4982_a941_bffb50d27f29_warning 23
+env.byte_10164f3f_6670_4982_a941_bffb50d27f29_critical 5000000000
+
 =head2 DEFAULT CONFIGURATION
 
 =head1 BUGS
 
 =head1 AUTHOR
 
-2019, HaseHarald
+2019-2021, HaseHarald
 
 =head1 MAGIC MARKERS
 

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -13,8 +13,8 @@ btrfs_device_usage - Script to monitor usage of btrfs devices
 Simply create a symlink in your plugins directory like with any other plugin.
 Must be run as root.
 
- [btrfs_device_usage]
- user root
+[btrfs_device_usage]
+user root
 
 =head2 DEFAULT CONFIGURATION
 
@@ -54,11 +54,22 @@ LGPLv3
 
 
 import btrfs
+import os
 import sys
 
 
 def munin_config(fs):
     fsid = str(fs.fsid).replace('-', '_')
+
+    byte_warning = os.getenv('byte_warning', default = False)
+    byte_critical = os.getenv('byte_critical', default = False)
+    byte_warning = os.getenv('byte_' + fsid + '_warning', default = byte_warning)
+    byte_critical = os.getenv('byte_' + fsid + '_critical', default = byte_critical)
+
+    percent_warning = os.getenv('percent_warning', default = 95)
+    percent_critical = os.getenv('percent_critical', default = 98)
+    percent_warning = os.getenv('percent_' + fsid + '_warning', default = percent_warning)
+    percent_critical = os.getenv('percent_' + fsid + '_critical', default = percent_critical)
 
     print("multigraph btrfs_device_usage_byte_" + fsid)
     print("graph_title btrfs usage by device in bytes on " + fs.path)
@@ -74,6 +85,12 @@ def munin_config(fs):
         this_dev_name = this_dev_info.path.replace('/dev/', '')
         print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
               ".label " + this_dev_name)
+        if byte_warning != False:
+            print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
+                  ".warning " + str(byte_warning))
+        if byte_critical != False:
+            print("btrfs_bytes_" + fsid + "_" + str(this_device.devid) +
+                  ".critical " + str(byte_critical))
 
     print("")
 
@@ -92,8 +109,10 @@ def munin_config(fs):
         this_dev_name = this_dev_info.path.replace('/dev/', '')
         print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
               ".label " + this_dev_name)
-        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".warning 95")
-        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) + ".critical 98")
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
+              ".warning " + str(percent_warning))
+        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
+              ".critical " + str(percent_critical))
 
     print("")
 

--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -77,13 +77,17 @@ def munin_config(fs):
 
     byte_warning = os.getenv('byte_warning', default = False)
     byte_critical = os.getenv('byte_critical', default = False)
-    byte_warning = os.getenv('byte_' + fsid + '_warning', default = byte_warning)
-    byte_critical = os.getenv('byte_' + fsid + '_critical', default = byte_critical)
+    byte_warning = os.getenv('byte_' + fsid + '_warning',
+                             default = byte_warning)
+    byte_critical = os.getenv('byte_' + fsid + '_critical',
+                              default = byte_critical)
 
     percent_warning = os.getenv('percent_warning', default = 95)
     percent_critical = os.getenv('percent_critical', default = 98)
-    percent_warning = os.getenv('percent_' + fsid + '_warning', default = percent_warning)
-    percent_critical = os.getenv('percent_' + fsid + '_critical', default = percent_critical)
+    percent_warning = os.getenv('percent_' + fsid + '_warning',
+                                default = percent_warning)
+    percent_critical = os.getenv('percent_' + fsid + '_critical',
+                                 default = percent_critical)
 
     print("multigraph btrfs_device_usage_byte_" + fsid)
     print("graph_title btrfs usage by device in bytes on " + fs.path)


### PR DESCRIPTION
This allows for an individual configuration of warning (and critical) levels of the btrfs_device_stats and btrfs_device_usage plugins. The changes are designed to be backwards compatible. So you don't have to adapt your configuration if you don't want to. But at least you can now.