### PR TITLE
docker_: sanitize value container names

### DIFF
--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -298,8 +298,9 @@ def print_containers_cpu(client):
                         - float(stats["precpu_stats"]["system_cpu_usage"]))
         if system_delta > 0.0:
             cpu_percent = cpu_delta / system_delta * 100.0 * os.cpu_count()
-        print(container.name + '.value', cpu_percent)
-        print(container.name + '.extinfo', container_attributes(container))
+        clean_container_name = clean_fieldname(container.name)
+        print(clean_container_name + '.value', cpu_percent)
+        print(clean_container_name + '.extinfo', container_attributes(container))
 
 
 def print_containers_memory(client):
@@ -310,8 +311,9 @@ def print_containers_memory(client):
         else:
             memory_usage = stats['memory_stats']['usage']
             extinfo = 'Total memory usage'
-        print(container.name + '.value', memory_usage)
-        print(container.name + '.extinfo', container_attributes(container, extinfo))
+        clean_container_name = clean_fieldname(container.name)
+        print(clean_container_name + '.value', memory_usage)
+        print(clean_container_name + '.extinfo', container_attributes(container, extinfo))
 
 
 def print_containers_network(client):
@@ -321,9 +323,10 @@ def print_containers_network(client):
         for data in stats['networks'].values():
             tx_bytes += data['tx_bytes']
             rx_bytes += data['rx_bytes']
-        print(container.name + '_up.value', tx_bytes)
-        print(container.name + '_down.value', rx_bytes)
-        print(container.name + '_up.extinfo', container_attributes(container))
+        clean_container_name = clean_fieldname(container.name)
+        print(clean_container_name + '_up.value', tx_bytes)
+        print(clean_container_name + '_down.value', rx_bytes)
+        print(clean_container_name + '_up.extinfo', container_attributes(container))
 
 
 def volume_summary(volume):


### PR DESCRIPTION
docker_ plugin sanitized container names when printing config but
not values which led to a disparity resulting in no data on graphs
for all containers whose names are subject to sanitization. (#1212)