### PR TITLE
Added check to ensure network stats for container exist before reading them

### DIFF
--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -318,9 +318,10 @@ def print_containers_network(client):
     for container, stats in parallel_container_stats(client):
         tx_bytes = 0
         rx_bytes = 0
-        for data in stats['networks'].values():
-            tx_bytes += data['tx_bytes']
-            rx_bytes += data['rx_bytes']
+        if "networks" in stats:
+            for data in stats['networks'].values():
+                tx_bytes += data['tx_bytes']
+                rx_bytes += data['rx_bytes']
         print(container.name + '_up.value', tx_bytes)
         print(container.name + '_down.value', rx_bytes)
         print(container.name + '_up.extinfo', container_attributes(container))


### PR DESCRIPTION
In some cases, the docker plugin will not report a "networks" statistics dictionary when no networks are attached to a container (e.g. when attaching to host network).

This pull request adds a check to ensure the network stats exist before reading from them. Without this check, the `docker_network` plugin can exit with an error under these circumstances and won't produce any valid data.