### PR TITLE
LXC v3.1 compatibility

### DIFF
--- a/plugins/lxc/lxc_guests
+++ b/plugins/lxc/lxc_guests
@@ -135,7 +135,8 @@ lxc_count_processes () {
       "/sys/fs/cgroup/lxc/$guest_name/tasks" \
       "/sys/fs/cgroup/cpuacct/lxc/$guest_name/tasks" \
       "/sys/fs/cgroup/systemd/lxc/$guest_name/tasks" \
-      "/sys/fs/cgroup/cpuacct/sysdefault/lxc/$guest_name/tasks"
+      "/sys/fs/cgroup/cpuacct/sysdefault/lxc/$guest_name/tasks" \
+      "/sys/fs/cgroup/cpu/lxc.payload.$guest_name/tasks"
    do
       if [ -e "$SYSFS" ]; then
          wc -l <"$SYSFS"


### PR DESCRIPTION
The cgroup data was (yet again) moved to a new location in recent LXC
releases, starting with v3.1.0 from what I could gather.

https://github.com/lxc/lxc/issues/2782 states:
> [The cgroup lxc.payload] exists to adhere to cgroup2 delegation requirements.