### PR TITLE
nutups2_: "@" is invalid character in plugin name so use "." instead

### DIFF
--- a/plugins/power/nutups2_
+++ b/plugins/power/nutups2_
@@ -45,7 +45,7 @@ Although the 'suggest' command will only offer UPSes for which the local host
 is the master, you can also monitor remote UPSes if you include the host name
 in the symlink, like:
 
-	nutups2_<upsname>@<hostname or address>_frequency
+	nutups2_<upsname>.<hostname or address>_frequency
 
 etc.
 
@@ -315,6 +315,7 @@ croak("Unknown command line arguments") if $ARGV[0] and $ARGV[0] ne 'config';
 # The UPS name may contain underscores
 my $fn_re = join('|', keys %config);
 my ($ups, $func) = $0 =~ m/nutups2_(.*)_($fn_re)$/;
+$ups =~ s/\./@/;  # ups.host.name => ups@host.name
 
 if ($ARGV[0] and $ARGV[0] eq 'config') {
 	$config{$func}->{'config'}($func, $ups);


### PR DESCRIPTION
This is needed when you monitor local and remote UPSes from single
host. You must be able to specify "ups@host" in plugin name so do
it as "ups.host".