### PR TITLE
Fix for docker_containers

### DIFF
--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -388,7 +388,7 @@ def containers(client, mode):
         print("graph_category virtualization")
         print("containers_quantity.label Containers")
     else:
-        print('containers_quantity.value', len(client.containers))
+        print('containers_quantity.value', len(client.all_containers))
 
 
 def images(client, mode):


### PR DESCRIPTION
This PR just fixes the issue (https://github.com/munin-monitoring/contrib/issues/1228).

The commit (https://github.com/munin-monitoring/contrib/commit/a3ae1af155e2fa07b3c8b97fd7e538935b059705) removed the method `client.containers` and didn't changed/removed all dependencies of the script.