### PR TITLE
bind9_*_stats: fix using env variable stat_file

### DIFF
--- a/plugins/bind/bind9_resolver_stats
+++ b/plugins/bind/bind9_resolver_stats
@@ -40,19 +40,19 @@ section="Resolver Statistics"
 # - use sed to get lines after (and excluding) the section start tag
 # - use sed to get lines up to (and excluding) the next section start tag
 # - use grep to remove any lines starting with a [
-cmd='cat "/var/cache/bind/named.stats" | sed "0,/^\+\+ '${section}' \+\+/d" | sed -e "/^\+\+/,\$d" | grep -v "^\["'
+cmd='cat "'"$stat_file"'" | sed "0,/^\+\+ '"${section}"' \+\+/d" | sed -e "/^\+\+/,\$d" | grep -v "^\["'
 
 # Config mode.
 if [ "$1" = "config" ]; then
 	echo 'graph_args --lower-limit 0'
 	echo 'graph_category dns'
-	echo 'graph_info '${section}' for the Bind9 Name Server'
+	echo 'graph_info '"${section}"' for the Bind9 Name Server'
 	echo 'graph_scale no'
-	echo 'graph_title Bind9 '${section}
+	echo 'graph_title Bind9 '"${section}"
 	echo 'graph_vlabel requests/${graph_period}'
 
 	# Output the stat configs.
-	eval ${cmd} | while read num name
+	eval "${cmd}" | while read -r num name
 	do
 		# Shorten some names.
 		label=${name//queries with /}
@@ -65,9 +65,9 @@ if [ "$1" = "config" ]; then
 		# Now change names to all have no spaces.
 		key=${label//[ -]/_}
 
-		echo ${key}.label ${label}
-		echo ${key}.info ${name}
-		echo ${key}.type COUNTER
+		echo "${key}.label ${label}"
+		echo "${key}.info ${name}"
+		echo "${key}.type COUNTER"
 	done
 
 	# If dirty config capability is enabled then fall through
@@ -76,7 +76,7 @@ if [ "$1" = "config" ]; then
 fi
 
 # Output the stats.
-eval ${cmd} | while read num name
+eval "${cmd}" | while read -r num name
 do
 	# Shorten some names.
 	label=${name//queries with /}
@@ -89,5 +89,5 @@ do
 	# Now change names to all have no spaces.
 	key=${label//[ -]/_}
 
-	echo ${key}.value ${num}
+	echo "${key}.value ${num}"
 done

--- a/plugins/bind/bind9_server_stats
+++ b/plugins/bind/bind9_server_stats
@@ -40,19 +40,19 @@ section="Name Server Statistics"
 # - use sed to get lines after (and excluding) the section start tag
 # - use sed to get lines up to (and excluding) the next section start tag
 # - use grep to remove any lines starting with a [
-cmd='cat "/var/cache/bind/named.stats" | sed "0,/^\+\+ '${section}' \+\+/d" | sed -e "/^\+\+/,\$d" | grep -v "^\["'
+cmd='cat "'"$stat_file"'" | sed "0,/^\+\+ '"${section}"' \+\+/d" | sed -e "/^\+\+/,\$d" | grep -v "^\["'
 
 # Config mode.
 if [ "$1" = "config" ]; then
 	echo 'graph_args --lower-limit 0'
 	echo 'graph_category dns'
-	echo 'graph_info '${section}' for the Bind9 Name Server'
+	echo 'graph_info '"${section}"' for the Bind9 Name Server'
 	echo 'graph_scale no'
-	echo 'graph_title Bind9 '${section}
+	echo 'graph_title Bind9 '"${section}"
 	echo 'graph_vlabel requests/${graph_period}'
 
 	# Output the stat configs.
-	eval ${cmd} | while read num name
+	eval "${cmd}" | while read -r num name
 	do
 		# Shorten some names.
 		label=${name//queries resulted in /}
@@ -64,9 +64,9 @@ if [ "$1" = "config" ]; then
 		# Now change names to all have no spaces.
 		key=${label// /_}
 
-		echo ${key}.label ${label}
-		echo ${key}.info ${name}
-		echo ${key}.type COUNTER
+		echo "${key}.label ${label}"
+		echo "${key}.info ${name}"
+		echo "${key}.type COUNTER"
 	done
 
 	# If dirty config capability is enabled then fall through
@@ -75,7 +75,7 @@ if [ "$1" = "config" ]; then
 fi
 
 # Output the stats.
-eval ${cmd} | while read num name
+eval "${cmd}" | while read -r num name
 do
 	# Shorten some names.
 	label=${name//queries resulted in /}
@@ -87,5 +87,5 @@ do
 	# Now change names to all have no spaces.
 	key=${label// /_}
 
-	echo ${key}.value ${num}
+	echo "${key}.value ${num}"
 done

--- a/plugins/bind/bind9_socket_stats
+++ b/plugins/bind/bind9_socket_stats
@@ -40,15 +40,15 @@ section="Socket I/O Statistics"
 # - use sed to get lines after (and excluding) the section start tag
 # - use sed to get lines up to (and excluding) the next section start tag
 # - use grep to remove any lines starting with a [
-cmd='cat "/var/cache/bind/named.stats" | sed "0,/^\+\+ '${section//\//\\/}' \+\+/d" | sed -e "/^\+\+/,\$d" | grep -v "^\["'
+cmd='cat "'"$stat_file"'" | sed "0,/^\+\+ '"${section//\//\\/}"' \+\+/d" | sed -e "/^\+\+/,\$d" | grep -v "^\["'
 
 # Config mode.
 if [ "$1" = "config" ]; then
 	echo 'graph_args --lower-limit 0'
 	echo 'graph_category dns'
-	echo 'graph_info '${section}' for the Bind9 Name Server'
+	echo 'graph_info '"${section}"' for the Bind9 Name Server'
 	echo 'graph_scale no'
-	echo 'graph_title Bind9 '${section}
+	echo 'graph_title Bind9 '"${section}"
 	echo 'graph_vlabel requests/${graph_period}'
 
 	# Output the stat configs.
@@ -62,9 +62,9 @@ if [ "$1" = "config" ]; then
 		# Now change names to all have no spaces.
 		key=${key//[\/ - ]/_}
 
-		echo ${key}.label ${label}
-		echo ${key}.info ${name}
-		echo ${key}.type COUNTER
+		echo "${key}.label ${label}"
+		echo "${key}.info ${name}"
+		echo "${key}.type COUNTER"
 	done
 
 	# If dirty config capability is enabled then fall through
@@ -73,7 +73,7 @@ if [ "$1" = "config" ]; then
 fi
 
 # Output the stats.
-eval ${cmd} | while read num name
+eval "${cmd}" | while read -r num name
 do
 	# All lowercase.
 	key=$(echo "$name" | tr 'A-Z' 'a-z')
@@ -81,5 +81,5 @@ do
 	# Now change names to all have no spaces.
 	key=${key//[\/ - ]/_}
 
-	echo ${key}.value ${num}
+	echo "${key}.value ${num}"
 done


### PR DESCRIPTION
previously only stat_file would only be used for data cleanup not for
fetching the data. also fixed some shellcheck warnings.

This fixes the following problem:
If you configured `stat_file` to be `/var/run/named/named.stats` like this:
```
[bind9_*]
   env.stat_file /var/run/named/named.stats
```
and enabled writing statistics with `statistics-file "/var/run/named/named.stats";` in bind9
you got the error `cat: /var/cache/bind/named.stats: No such file or directory` when running the plugin.

With this fix stat_file is also considered for `cat` not only for `rm`.

I fixed some shellcheck stuff in the affected files as well, but didn't want to change too much for a simple bugfix (e.g. there is still unecessary cat uses, chaining of seds and some other stuff in there).

Info @wt-io-it