### PR TITLE
nvidia_gpu: fix units of Rx/Tx throughput (multiple gpus)

### DIFF
--- a/plugins/gpu/nvidia_gpu_
+++ b/plugins/gpu/nvidia_gpu_
@@ -268,12 +268,28 @@ case $name in
 		valueGpus=$(echo "$smiOutput" | grep "Gpu" | cut -d ':' -f 2 | cut -d ' ' -f 2)
 		;;
 	rx)
-		valueGpus=$(echo "$smiOutput" | grep "Rx Throughput" | cut -d ':' -f 2 | cut -d ' ' -f 2)
-		valueGpus=$((valueGpus*1024))
+		rxGpus=$(echo "$smiOutput" | grep "Rx Throughput" | cut -d ':' -f 2 | cut -d ' ' -f 2)
+		valueGpus=''
+		nGpusCounter=0
+		while [ $nGpusCounter -lt "$nGpus" ]
+		do
+			kiloBitsPerSecond=$(echo "$rxGpus" | sed -n $((nGpusCounter+1))p)
+			bitsPerSecond=$((kiloBitsPerSecond*1024))
+			valueGpus="${valueGpus}${bitsPerSecond}"$'\n'
+			: $((nGpusCounter=nGpusCounter+1))
+		done
 		;;
 	tx)
-		valueGpus=$(echo "$smiOutput" | grep "Tx Throughput" | cut -d ':' -f 2 | cut -d ' ' -f 2)
-		valueGpus=$((valueGpus*1024))
+		txGpus=$(echo "$smiOutput" | grep "Tx Throughput" | cut -d ':' -f 2 | cut -d ' ' -f 2)
+		valueGpus=''
+		nGpusCounter=0
+		while [ $nGpusCounter -lt "$nGpus" ]
+		do
+			kiloBitsPerSecond=$(echo "$txGpus" | sed -n $((nGpusCounter+1))p)
+			bitsPerSecond=$((kiloBitsPerSecond*1024))
+			valueGpus="${valueGpus}${bitsPerSecond}"$'\n'
+			: $((nGpusCounter=nGpusCounter+1))
+		done
 		;;
 	*)
 		echo "Can't run without a proper symlink. Exiting."


### PR DESCRIPTION
Today, I noticed that my recent PR for Rx/Tx throughput outputs #1226 does not give correct readings on systems with multiple gpus.

The problem is that the multiplication `$((valueGpus*1024))` does not work for unseparated input values (as returned by the echo-grep-cut combo). The result is unscaled data being processed by munin - therefore showing kilobits per second as bits per second.

Here is a fix for that! The code replicates the loop already found under `mem)` (lines 250-259).

Sorry for having overlooked this issue.