### PR TITLE
Update the Deluge plugin to handle Deluge 2.x

### DIFF
--- a/plugins/torrent/deluge_
+++ b/plugins/torrent/deluge_
@@ -1,14 +1,14 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 
 """=cut
 =head1 NAME
 
-deluge_ - Munin wildcard plugin to monitor Deluge torrent client
+deluge_ - Munin wildcard plugin to monitor the Deluge torrent client
 
 =head1 REQUIREMENTS
 
- - Python2.5+ (Deluge itself won't work with python3)
- - Deluge
+ - Python3+
+ - Deluge2+
 
 This plugin also uses
  - deluge.ui.client
@@ -19,13 +19,13 @@ These modules are required by Deluge itself.
 =head1 INSTALLATION
 
 This plugin has 3 modes :
- - connections : monitors the number of connections
+ - peers : monitors the number of peers
  - bandwidth : monitors the bandwidth (up, up overhead, down, down overhead)
  - states : monitors the torrents' states
 
 To use one of these modes, link the this plugin as 'deluge_<mode>'
 For example :
-ln -s /path/to/deluge_ /etc/munin/plugins/deluge_connections
+ln -s /path/to/deluge_ /etc/munin/plugins/deluge_peers
 
 =head1 CONFIGURATION
 
@@ -58,10 +58,10 @@ set the env.XDG_CONFIG_HOME if needed.
 
 =head1 INTERPRETATION
 
-=head2 connections
+=head2 peers
 
-In the "connections" mode, this plugin shows a graph with the number of
-connections
+In the "peers" mode, this plugin shows a graph with the number of
+total peers, half open peers, and peers interested in upload and download slots
 
 =head2 bandwidth
 
@@ -83,11 +83,12 @@ Downloading, Seeding, Paused, Error, Queued, Checking, Other
 
 =head1 VERSION
 
-1.0.0
+2.0.0
 
 =head1 AUTHOR
 
 Neraud (https://github.com/Neraud)
+kmkr (https://github.com/kmkr)
 
 =head1 LICENSE
 
@@ -105,17 +106,17 @@ import sys
 
 
 try:
-    from deluge.log import setupLogger
+    from deluge.log import setup_logger
     from deluge.ui.client import client
     from twisted.internet import reactor, defer
-    setupLogger()
+    setup_logger()
 except (ImportError, NameError):
     successful_import = False
 else:
     successful_import = True
 
 
-plugin_version = "1.0.0"
+plugin_version = "2.0.0"
 
 log = logging.getLogger("delugeStats")
 log.setLevel(logging.WARNING)
@@ -139,7 +140,7 @@ names_for_munin = {
     'state.Error': 'error',
     'state.Queued': 'queued',
     'state.Checking': 'checking',
-    'state.Other': 'other'
+    'state.Other': 'other',
 }
 
 torrent_states = ["Downloading",
@@ -150,7 +151,17 @@ torrent_states = ["Downloading",
                   "Checking",
                   "Other"]
 
-modes = ["bandwidth", "connections", "states"]
+modes = ["bandwidth", "peers", "states"]
+
+connection_keys = [
+    { 'id': 'peer.num_peers_connected', 'label': 'Total' },
+    { 'id': 'peer.num_peers_half_open', 'label': 'Half open' },
+    { 'id': 'peer.num_peers_up_interested', 'label': 'Interested (upload)' },
+    { 'id': 'peer.num_peers_down_interested', 'label': 'Interested (download)' }
+]
+
+def for_munin(value):
+    return value.replace('.', '').replace('_', '')
 
 
 class StatClient:
@@ -182,15 +193,19 @@ class StatClient:
             errbackArgs=("Connection failed: check settings and try again."))
         reactor.run()
 
+
     def on_connect_success(self, result):
         log.debug("Connection was successful")
         self.connected = True
 
-        if self.mode == "connections":
-            log.debug("Calling get_num_connections")
-            client.core.get_num_connections().addCallbacks(
-                self.on_num_connections,
-                self.end_session, errbackArgs=("get_num_connections failed"))
+        if self.mode == "peers":
+            log.debug("Calling get_session_status")
+            keys = []
+            for connection_key in connection_keys:
+                keys.append(connection_key['id'])
+            client.core.get_session_status(keys=keys).addCallbacks(
+                self.on_peer_session_status,
+                self.end_session, errbackArgs=("get_session_status failed"))
         elif self.mode == "bandwidth":
             log.debug("Calling get_session_status")
             interesting_status = [
@@ -206,11 +221,17 @@ class StatClient:
                 self.on_session_state,
                 self.end_session,
                 errbackArgs=("get_session_state failed"))
+        else:
+            log.error("Unknown mode '%s'", mode)
+            sys.exit(1)
 
-    def on_num_connections(self, num_connections):
-        log.debug("Got num_connections from the daemon : %s", num_connections)
-        print("{0}.value {1}".format(
-            names_for_munin["numConnections"], num_connections))
+    def on_peer_session_status(self, result):
+        log.debug("Got result from the daemon : %s", result)
+        for connection_key in connection_keys:
+            print(
+                f"{for_munin(connection_key['id'])}.value "
+                f"{result[connection_key['id']]}"
+            )
         self.end_session("Done")
 
     def on_bandwidth(self, values):
@@ -277,7 +298,7 @@ class StatClient:
 
 def get_mode():
     script_name = os.path.basename(sys.argv[0])
-    mode = script_name[string.rindex(script_name, '_') + 1:]
+    mode = script_name[script_name.rindex('_') + 1:]
 
     log.debug("Mode : %s", mode)
 
@@ -290,18 +311,17 @@ def get_mode():
 
 
 def print_config(mode):
-    if mode == "connections":
-        print("graph_title Number of connections")
+    if mode == "peers":
+        print("graph_title Number of peers")
         print("graph_args --base 1000 -l 0")
-        print("graph_vlabel connections")
+        print("graph_vlabel peers")
         print("graph_scale yes")
         print("graph_category filetransfer")
         print(
-            "graph_info This graph shows the number of connections used by Deluge Torrent")
-        print(names_for_munin["numConnections"] + ".label connections")
-        print(names_for_munin["numConnections"] + ".min 0")
-        print(names_for_munin["numConnections"]
-              + ".info The number of connections used by Deluge Torrent")
+            "graph_info This graph shows the number of peers for the Deluge Torrent client")
+        for connection_key in connection_keys:
+            print(f"{for_munin(connection_key['id'])}.label {connection_key['label']}")
+            print(f"{for_munin(connection_key['id'])}.min 0")
     elif mode == "bandwidth":
         print("graph_title Bandwidth usage")
         print("graph_order payloadDownloadRate overheadDownloadRate payloadUploadRate "


### PR DESCRIPTION
Version 1.0.0 of this plugin requires version 1 of Deluge. Deluge 2 was released in June 2019.

This commits bumps the plugin to version 2.0.0.

This plugin has three modes. The modes "bandwidth" and "states" are working equally to the previous version.  The third mode, "connections", is changed.

The connections mode previously printed one value: the total number of connections.  That RPC call is removed in Deluge 2, and I'm instead using `get_session_status`, which delegates the call to libtorrent's [session statistics function](https://libtorrent.org/manual-ref.html#session-statistics). libtorrent is better documented, so it's easier to work with compared to Deluge.

"Number of peers" replaces the previous "number of connections", and I've added half open peers, and peers interested in download and upload slots to the same graph.

## Screenshot

Here's how the plugin is rendered.

![filetransfer (Munin)](https://user-images.githubusercontent.com/242216/127051658-2df88aa0-5325-4e29-9815-32c06bb234b2.png)
