### PR TITLE
rtom_vol: remove unused config parameters

### DIFF
--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -66,9 +66,6 @@ if ( $ARGV[0] and $ARGV[0] eq "config" ) {
 	print "default.label total\n";
 	print "default.draw LINE2\n";
 	print "default.info all torrents\n";
-	print "hashing.graph no\n";
-	print "seeding.graph no\n";
-	print "active.graph no\n";
 	exit 0;
 }
 


### PR DESCRIPTION
Since there are no associated values for 'hashing', 'seeding', and
'active', a warning is seen in munin-update.log every time this plugin
is fetched.