### PR TITLE
nvme: enable specifying warnings and criticals for serial numbers

### DIFF
--- a/plugins/disk/nvme
+++ b/plugins/disk/nvme
@@ -24,6 +24,12 @@ name, e.g., 'nvme0n1', to make environment variable:
     env.nvme_usage_nvme0n1_warning 5:
     env.nvme_usage_warning 8:
 
+If your device names change on reboot you can also use the labels
+(based on serial numbers) to set the warning and critical labels
+
+    env.nvme_usage_SN_1234567_warning 8:101
+    env.nvme_usage_SN_1234567_critical 5:101
+
 =head1 INTERPRETATION
 
 This is a multigraph plugin which makes three graphs.
@@ -191,8 +197,10 @@ sub smart_log {
 sub my_print_thresholds {
     my ($label, $graph, $device, $warn_default, $crit_default) = @_;
     my $dev = basename($device);
-    my ($warn, $crit) = get_thresholds($graph, "${graph}_${dev}_warning", "${graph}_${dev}_critical",
+    my ($warn_label, $crit_label) = get_thresholds($graph, "${graph}_${label}_warning", "${graph}_${label}_critical",
                                        $warn_default, $crit_default);
+    my ($warn, $crit) = get_thresholds($graph, "${graph}_${dev}_warning", "${graph}_${dev}_critical",
+                                       $warn_label, $crit_label);
     print "${label}.warning $warn\n" if defined $warn;
     print "${label}.critical $crit\n" if defined $crit;
 }


### PR DESCRIPTION
On one of our servers equiped with an ASRock Rack X470D4U Mainboard running Ubuntu 18.04 LTS when we reboot the server we may end up with a new order of /dev/nvme* devices. So in the past we would need to reconfigure the warnings per device name at every reboot.

With this patch it is now possible to specify warnings and criticals with the NVME device serial number (label of the graph) as well.
The previously existing configuration options still take precedence over the new one.
