### PR TITLE
systemd_mem: improvements

### DIFF
--- a/plugins/systemd/systemd_mem
+++ b/plugins/systemd/systemd_mem
@@ -58,12 +58,19 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 . "$MUNIN_LIBDIR/plugins/plugin.sh"
 
+# at least on debian stretch services report this as unlimited / unknown value (2^64)
+# see https://lists.freedesktop.org/archives/systemd-devel/2018-July/041092.html
+SYSTEMD_UNLIMITED="18446744073709551615"
+
+all_services=${all_services:-}
+services=${services:-"munin-node"}
+
 for_services() {
     if [ "$all_services" != "" ]; then
         systemctl --type=service --state=running --no-pager --no-legend --output=short-precise \
           | awk '{sub(".service$", "", $1); print $1}'
     else
-        echo ${services:-"munin-node"}
+        echo "$services"
     fi
 }
 
@@ -75,18 +82,18 @@ output_config() {
     echo "graph_category memory"
     for service in $(for_services); do
         clean_name="$(clean_fieldname "$service")"
-        description=$(systemctl show "$service" --property=Description | cut -d '=' -f 2)
+        description=$(systemctl show "$service" --property=Description | cut -d '=' -f 2-)
         warning=$(systemctl show "$service" --property=MemoryHigh | cut -d '=' -f 2)
         critical=$(systemctl show "$service" --property=MemoryMax | cut -d '=' -f 2)
-        if [ "$critical" = "infinity" ] ; then
+        if [ "$critical" = "infinity" ] || [ "$critical" = "$SYSTEMD_UNLIMITED" ] ; then
             critical=$(systemctl show "$service" --property=MemoryLimit | cut -d '=' -f 2)
         fi
         printf "%s.label %s\n" "$clean_name" "$description"
         printf "%s.info memory usage\n" "$clean_name"
-        if [ "$warning" != "infinity" ] ; then
+        if [ "$warning" != "infinity" ] && [ "$warning" != "$SYSTEMD_UNLIMITED" ] ; then
           printf "%s.warning %s\n" "$clean_name" "$warning"
         fi
-        if [ "$critical" != "infinity" ] ; then
+        if [ "$critical" != "infinity" ] && [ "$critical" != "$SYSTEMD_UNLIMITED" ] ; then
           printf "%s.critical %s\n" "$clean_name" "$critical"
         fi
     done
@@ -96,10 +103,10 @@ output_values() {
     for service in $(for_services); do
         clean_name="$(clean_fieldname "$service")"
         usage=$(systemctl show "$service" --property=MemoryCurrent | cut -d '=' -f 2)
-        if [ "$usage" = "[not set]" ]; then
-            usage=0
+        if [ "$usage" = "[not set]" ] || [ "$usage" = "$SYSTEMD_UNLIMITED" ]; then
+            usage="U"
         fi
-        printf  "%s.value %d\n" "$clean_name" "$usage"
+        printf  "%s.value %s\n" "$clean_name" "$usage"
     done
 }
 


### PR DESCRIPTION
The following changes are made with this:
* the plugin now reports unknown values as `U` instead of `0`
* when configuring the new option `env.all_services true` it automatically monitors all running services
* on some of our systems unknown / not set values where reported as `18446744073709551615` (UINT64_MAX). this is now handled as unknown / unset by the plugin as well

Info @wt-io-it