### PR TITLE
zfs list -t filesystem,volume to suppress snapshots

### DIFF
--- a/plugins/zfs/zfs_list
+++ b/plugins/zfs/zfs_list
@@ -31,7 +31,7 @@ if [ "$1" = "suggest" ]; then
 fi
 
 if [ "$1" = "config" ]; then
-	for i in `zfs list -Hp | awk '{print $1}'`; do
+	for i in `zfs list -Hp -t filesystem,volume | awk '{print $1}'`; do
 		values=( $(zfs get -p usedbydataset,usedbychildren,usedbysnapshots,usedbyrefreservation,available,quota $i | awk 'BEGIN {total=0;} { if( NR==1 ) next; } !/quota/ {total=total+$3;} {print $3} END{print total;}') )
 		fsname=$(clean_fieldname $(echo "$i" | sed 's/\//__/g'))
 
@@ -75,7 +75,7 @@ EOF
 	exit 0
 fi
 
-for i in `zfs list -Hp | awk '{print $1}'`; do
+for i in `zfs list -Hp -t filesystem,volume | awk '{print $1}'`; do
 	values=( $(zfs get -p usedbydataset,usedbychildren,usedbysnapshots,usedbyrefreservation,available,quota $i | awk 'BEGIN {total=0;} { if( NR==1 ) next; } !/quota/ {total=total+$3;} {print $3} END{print total;}') )
 	fsname=$(clean_fieldname $(echo "$i" | sed 's/\//__/g'))
 


### PR DESCRIPTION
zfs list might list thousands of transient snapshots if `zpool
listsnapshots=on` and something like zfs-auto-snapshot is used.  It's
also not useful to graph them since they're unchanging in time, and
the parent volume is graphed anyway.  Limit zfs list to
"filesystem,volume" instead of "all" including snapshots