### PR TITLE
chrony_status: fix fetch output for serverstats graph

### DIFF
--- a/plugins/chrony/chrony_status
+++ b/plugins/chrony/chrony_status
@@ -46,6 +46,24 @@ import os
 import subprocess
 import sys
 
+GRAPHS = [
+    'stratum',
+    'systime',
+    'delay',
+    'frequency',
+    'serverstats',
+]
+
+SERVERSTATS = [
+    'received',
+    'dropped',
+    'command_received',
+    'command_dropped',
+    'client_log_records_dropped',
+    'nts_ke_connections_accepted',
+    'nts_ke_connections_dropped',
+    'authenticated_packets',
+]
 
 FIELDS = {
     'stratum': 'Stratum',
@@ -57,6 +75,9 @@ FIELDS = {
     'command_received': 'Command packets received',
     'command_dropped': 'Command packets dropped',
     'client_log_records_dropped': 'Client log records dropped',
+    'nts_ke_connections_accepted': 'NTS-KE connections accepted',
+    'nts_ke_connections_dropped': 'NTS-KE connections dropped',
+    'authenticated_packets': 'Authenticated NTP packets',
 }
 
 
@@ -76,9 +97,9 @@ def get_values():
     for label in FIELDS:
         for line in lines:
             if line.startswith(FIELDS[label]):
-                value = float(line.split(':', 1)[1].split()[0])
+                value = line.split(':', 1)[1].split()[0]
                 if ' slow' in line:
-                    value = -value
+                    value = -float(value)
                 ret[label] = value
     return ret
 
@@ -137,6 +158,15 @@ def config():
     print('client_log_records_dropped.label Client log records dropped')
     print('client_log_records_dropped.type DERIVE')
     print('client_log_records_dropped.min 0')
+    print('nts_ke_connections_accepted.label NTS-KE connections accepted')
+    print('nts_ke_connections_accepted.type DERIVE')
+    print('nts_ke_connections_accepted.min 0')
+    print('nts_ke_connections_dropped.label NTS-KE connections dropped')
+    print('nts_ke_connections_dropped.type DERIVE')
+    print('nts_ke_connections_dropped.min 0')
+    print('authenticated_packets.label Authenticated NTP packets')
+    print('authenticated_packets.type DERIVE')
+    print('authenticated_packets.min 0')
 
     if os.environ.get('MUNIN_CAP_DIRTYCONFIG') == '1':
         fetch()
@@ -145,12 +175,16 @@ def config():
 def fetch():
     """Print values."""
     values = get_values()
-    for key in FIELDS:
-        print('multigraph chrony_{}'.format(key))
-        if key == 'stratum' and values[key] == 0:
-            print('{}.value U'.format(key))
+    for graph in GRAPHS:
+        print('multigraph chrony_{}'.format(graph))
+        if graph == 'stratum' and values[graph] == 0:
+            print('{}.value U'.format(graph))
+        elif graph == 'serverstats':
+            for stat in SERVERSTATS:
+                if stat in values:
+                    print('{}.value {}'.format(stat, values[stat]))
         else:
-            print('{}.value {:.8f}'.format(key, values[key]))
+            print('{}.value {}'.format(graph, values[graph]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Was not expecting #1255 to be merged so quickly 🤪. Now the new serverstats graph has been fully tested and actually works 😉.

This change also doesn't needlessly convert all values to floating point numbers, instead provides the values to munin in the same format as they are originally output by chrony.

Also this adds some server stats found in chrony 4.0 (but still works with 3.4 and probably earlier).