### PR TITLE
munin_events: fix plugin having too much output

### DIFF
--- a/plugins/munin/munin_events
+++ b/plugins/munin/munin_events
@@ -87,7 +87,7 @@ values() {
     do_value 'munin_error' 'ERROR'
     do_value 'munin_fatal' 'FATAL'
     # Set offset
-    "$logtail_bin" "$muninupdate" > /dev/null 1>&2
+    "$logtail_bin" "$muninupdate" >/dev/null 2>&1
     chmod 640 "${muninupdate}.offset"
 }
 


### PR DESCRIPTION
in 56cd2c926ca99e396a0b6c2ebee76394bb4de195 `&> /dev/null` was converted
to posix in an invalid way, should have been `>/dev/null 2>&1`

this prevents the plugin dumping the logs to stderr at the end after printing the values

Info @wt-io-it

