### PR TITLE
fixed file mode of mikrotik_system + added that it was tested on RB493G

### DIFF
--- a/plugins/router/mikrotik_system
+++ b/plugins/router/mikrotik_system
@@ -6,7 +6,7 @@
 mikrotik_system - This plugin fetches multiple Values from a mikrotik device.
 
 =head1 CONFIGURATION
-tested with a RB750GR3, RB5009 and CRS309.
+tested with a RB493G, RB750GR3, RB5009 and CRS309.
 Dependencies:
 - sshpass
 


### PR DESCRIPTION
The file wasn't executable for which munin-run complained:
```
$ munin-run mikrotik_system
# Unknown service 'mikrotik_system'
```