### PR TITLE
arris-sb6183: Fix int32 wrapping in WebUI

### DIFF
--- a/plugins/router/arris-sb6183
+++ b/plugins/router/arris-sb6183
@@ -77,20 +77,21 @@ GPLv2
 =cut
 """
 
-import re
-import os
-import sys
 import ctypes
+import os
+import re
+import sys
 from urllib import request
-
-def fixint(i):
-    return ctypes.c_uint32(int(i)).value
 
 HOSTNAME = os.getenv("hostname", None)
 STATUS_URL = "http://192.168.100.1/RgConnect.asp"
 INFO_URL = "http://192.168.100.1/RgSwInfo.asp"
 UPCOUNT = 4
 DOWNCOUNT = 16
+
+# Recast an int32 to uint32
+def fixint(i):
+    return ctypes.c_uint32(int(i)).value
 
 if len(sys.argv) == 2:
     if sys.argv[1] == "config":

--- a/plugins/router/arris-sb6183
+++ b/plugins/router/arris-sb6183
@@ -80,7 +80,11 @@ GPLv2
 import re
 import os
 import sys
+import ctypes
 from urllib import request
+
+def fixint(i):
+    return ctypes.c_uint32(int(i)).value
 
 HOSTNAME = os.getenv("hostname", None)
 STATUS_URL = "http://192.168.100.1/RgConnect.asp"
@@ -293,10 +297,10 @@ for row in trs:
     data = dict(
         zip(headings, ["".join(x.itertext()).strip() for x in row.findall("td")])
     )
-    uncorr += int(data["Uncorrectables"])
-    correct += int(data["Corrected"])
+    uncorr += fixint(data["Uncorrectables"])
+    correct += fixint(data["Corrected"])
 
-    channel = int(data["Channel"])
+    channel = fixint(data["Channel"])
 
     print("\nmultigraph arris_power.down_{0}".format(channel))
     value = data["Power"].split(" ")[0]
@@ -309,8 +313,8 @@ for row in trs:
     snr[channel - 1] = value
 
     print("multigraph arris_error.down_{0}".format(channel))
-    print("corr.value {0}".format(data["Corrected"]))
-    print("uncr.value {0}".format(data["Uncorrectables"]))
+    print("corr.value {0}".format(fixint(data["Corrected"])))
+    print("uncr.value {0}".format(fixint(data["Uncorrectables"])))
 
 # Fill missing
 for i in range(len(trs), DOWNCOUNT):
@@ -349,7 +353,7 @@ for row in trs:
     data = dict(
         zip(headings, ["".join(x.itertext()).strip() for x in row.findall("td")])
     )
-    channel = int(data["Channel"])
+    channel = fixint(data["Channel"])
     print("multigraph arris_power.up_{0}".format(channel))
     value = data["Power"].split(" ")[0]
     print("power.value {0}".format(value))


### PR DESCRIPTION
When error counts wrap they are displayed as int32 and negative.
Recast them to uint32 to fix math.

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>