### PR TITLE
bind95_: report 0 values for not found lines

### DIFF
--- a/plugins/bind/bind95_
+++ b/plugins/bind/bind95_
@@ -2,27 +2,58 @@
 #
 # Copyright Jean-Samuel Reynaud <js.reynaud@free.fr>
 # Licensed under GPL v2
-#
-# We use this script to produce graph with munin for dns requests
-# This script must have his name start with bind95_
-# bind95_ : Global bind statistic
-# bind95_test.com : Bind statistic for test.com zone (no view)
-# bind95_test.com@internal : Bind statistic for test.com zone (view internal)
-# This version work with bind 9.5
-#
-# Thanks for Benjamin Pineau for perl cleaning and corrections
-#
-# You should have to add the following lines to you plugin configuration
-# (/etc/munin/plugin-conf.d/munin-node):
-#[bind95_*]
-#user root
-#stat_file /var/cache/bind/named.stats
-#rndc /usr/sbin/rndc
-#
-#
-# Magic markers
-#%# family=auto
-#%# capabilities=autoconf
+
+=head1 NAME
+
+bind95_ - Graph dns requests by type
+
+=head1 DESCRIPTION
+
+We use this script to produce graph with munin for dns requests.
+
+This version work with bind 9.5
+
+Thanks to Benjamin Pineau for perl cleaning and corrections
+
+=head1 CONFIGURATION
+
+This script must have his name start with bind95_
+
+=over 2
+
+  bind95_ : Global bind statistic
+  bind95_test.com : Bind statistic for test.com zone (no view)
+  bind95_test.com@internal : Bind statistic for test.com zone (view internal)
+
+=back
+
+You should have to add the following lines to you plugin configuration
+(/etc/munin/plugin-conf.d/munin-node):
+
+=over 2
+
+  [bind95_*]
+  user root
+  stat_file /var/cache/bind/named.stats
+  rndc /usr/sbin/rndc
+
+=back
+
+=head1 MAGIC MARKERS
+
+  #%# family=auto
+  #%# capabilities=autoconf
+
+=head1 AUTHORS
+
+Jean-Samuel Reynaud <js.reynaud@free.fr>
+Andreas Perhab <a.perhab@wtioit.at>
+
+=head1 LICENSE
+
+GPLv2
+
+=cut
 
 use strict;
 use warnings;
@@ -78,6 +109,7 @@ my @counters = (
 
 # Parse the statistic file
 sub parseFile {
+    my @printed_counters = ();
     my $dom = shift @_;
     open(IN,"<$stat_file") or die "Can't open $stat_file : $!";
     my $current_zone = "";
@@ -95,11 +127,19 @@ sub parseFile {
                 my ($val,$desc) = split(' ',$l,2);
                 if (grep { $desc eq $_ } @counters) {
                     printf "%s.value %u\n",md5_hex($desc),$val;
+                    push @printed_counters, $desc;
                 }
             }
         }
     }
     close(IN);
+    foreach(@counters) {
+        my $desc = $_;
+        my @already_printed = grep { $desc eq $_ } @printed_counters;
+        if (!@already_printed) {
+            printf "%s.value 0\n", md5_hex($desc);
+        }
+    }
 }
 
 


### PR DESCRIPTION
This prevents `bind95_` from displaying `-nan` for counters not yet present in stats file (not requests yet) and instead displays them as 0. It makes sure that there is a value for all counters defined in `bind95_ config`.

Info @wt-io-it
