### PR TITLE
certificate_file_expiry: label "50" instead of "5e+01"

### DIFF
--- a/plugins/ssl/certificate_file_expiry
+++ b/plugins/ssl/certificate_file_expiry
@@ -55,8 +55,8 @@ GPLv2
 
 if [ "$1" = "config" ] ; then
   echo "graph_title Certificate validity"
-  echo "graph_args --logarithmic --base 1000"
-  echo "graph_vlabel certificate validity in days"
+  echo "graph_args --base 1000"
+  echo "graph_vlabel days"
   echo "graph_category security"
 fi
 


### PR DESCRIPTION
Scale values were "4e+01, 5e+01, ...". Using linear scale and "48, 50, 52, ..." is much more readable.

Also use shorter vlabel, old one is too long.