### PR TITLE
change plugin category to "tor"

### DIFF
--- a/plugins/tor/tor-bandwidth-usage
+++ b/plugins/tor/tor-bandwidth-usage
@@ -109,7 +109,7 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
     say "graph_title Tor traffic";
     say "graph_args --base 1000";
     say "graph_vlabel bits in (-) / out (+) per \${graph_period}";
-    say "graph_category network";
+    say "graph_category tor";
     say "graph_info This graph shows the traffic through this Tor node.";
     say "down.label received";
     say "down.type DERIVE";

--- a/plugins/tor/tor-connections
+++ b/plugins/tor/tor-connections
@@ -17,7 +17,7 @@ if ($cmd == "config") {
 	print "graph_title Connections\n";
 	print "graph_args -l 0 --base 1000\n";
 	print "graph_vlabel connections\n";
-	print "graph_category network\n";
+	print "graph_category tor\n";
 	print "graph_info This graph shows the number of Tor OR connections.\n";
 	print "graph_period second\n";
 

--- a/plugins/tor/tor-traffic
+++ b/plugins/tor/tor-traffic
@@ -17,7 +17,7 @@ if ($cmd == "config") {
 	echo "graph_title Traffic\n";
 	echo "graph_args --base 1000 \n";
 	echo "graph_vlabel bits in (-) / out (+) per ${graph_period}\n";
-	echo "graph_category network\n";
+	echo "graph_category tor\n";
 
 	echo "down.label Download\n";
         echo "down.type GAUGE\n";

--- a/plugins/tor/tor_
+++ b/plugins/tor/tor_
@@ -203,7 +203,7 @@ class TorBandwidth(TorPlugin):
         graph = {'title': 'Tor observed bandwidth',
                  'args': '-l 0 --base 1000',
                  'vlabel': 'bytes/s',
-                 'category': 'network',
+                 'category': 'tor',
                  'info': 'estimated capacity based on usage in bytes/s'}
         labels = {'bandwidth': {'label': 'bandwidth', 'min': 0, 'type': 'GAUGE'}}
 
@@ -241,7 +241,7 @@ class TorConnections(TorPlugin):
         graph = {'title': 'Tor connections',
                  'args': '-l 0 --base 1000',
                  'vlabel': 'connections',
-                 'category': 'network',
+                 'category': 'tor',
                  'info': 'OR connections by state'}
         labels = {'new': {'label': 'new', 'min': 0, 'max': 25000, 'type': 'GAUGE'},
                   'launched': {'label': 'launched', 'min': 0, 'max': 25000, 'type': 'GAUGE'},
@@ -291,7 +291,7 @@ class TorCountries(TorPlugin):
         graph = {'title': 'Tor countries',
                  'args': '-l 0 --base 1000',
                  'vlabel': 'countries',
-                 'category': 'network',
+                 'category': 'tor',
                  'info': 'OR connections by state'}
         labels = {}
 
@@ -368,7 +368,7 @@ class TorDormant(TorPlugin):
         graph = {'title': 'Tor dormant',
                  'args': '-l 0 --base 1000',
                  'vlabel': 'dormant',
-                 'category': 'network',
+                 'category': 'tor',
                  'info': 'Is Tor not building circuits because it is idle?'}
         labels = {'dormant': {'label': 'dormant', 'min': 0, 'max': 1, 'type': 'GAUGE'}}
 
@@ -396,7 +396,7 @@ class TorFlags(TorPlugin):
         graph = {'title': 'Tor relay flags',
                  'args': '-l 0 --base 1000',
                  'vlabel': 'flags',
-                 'category': 'network',
+                 'category': 'tor',
                  'info': 'Flags active for relay'}
         labels = {flag: {'label': flag, 'min': 0, 'max': 1, 'type': 'GAUGE'} for flag in stem.Flag}
 
@@ -438,7 +438,7 @@ class TorRouters(TorPlugin):
         graph = {'title': 'Tor routers',
                  'args': '-l 0',
                  'vlabel': 'routers',
-                 'category': 'network',
+                 'category': 'tor',
                  'info': 'known Tor onion routers'}
         labels = {'routers': {'label': 'routers', 'min': 0, 'type': 'GAUGE'}}
         TorPlugin.conf_from_dict(graph, labels)
@@ -472,7 +472,7 @@ class TorTraffic(TorPlugin):
         graph = {'title': 'Tor traffic',
                  'args': '-l 0 --base 1024',
                  'vlabel': 'bytes/s',
-                 'category': 'network',
+                 'category': 'tor',
                  'info': 'bytes read/written'}
         labels = {'read': {'label': 'read', 'min': 0, 'type': 'DERIVE'},
                   'written': {'label': 'written', 'min': 0, 'type': 'DERIVE'}}

--- a/plugins/tor/tor_routers
+++ b/plugins/tor/tor_routers
@@ -99,7 +99,7 @@ if ($ARGV[0] and $ARGV[0] eq "config") {
 	print "graph_title Routers\n";
 	print "graph_args -l 0\n";
 	print "graph_vlabel routers\n";
-	print "graph_category network\n";
+	print "graph_category tor\n";
 	print "graph_info This graph shows the number of known Tor ORs.\n";
 
     print "ors.label routers\n";

--- a/plugins/tor/tor_traffic
+++ b/plugins/tor/tor_traffic
@@ -14,7 +14,7 @@ if [ "$1" = config ]; then
 	echo "graph_title Tor Traffic"
 	echo "graph_args --base 1000"
 	echo "graph_vlabel bytes in / out"
-	echo "graph_category network"
+	echo "graph_category tor"
 	echo "down.label Download"
         echo "down.type GAUGE"
         echo "up.label Upload"


### PR DESCRIPTION
Hi,

i standardized the plugin category to "tor" for all `tor_*` Plugins.

Is this allowed?

Wishes
mg