### PR TITLE
[minecraft-users-ram] Fix several bugs in plugin minecraft-users-ram_

### DIFF
--- a/plugins/minecraft/minecraft-users-ram_
+++ b/plugins/minecraft/minecraft-users-ram_
@@ -43,16 +43,16 @@ then
     echo 'graph_vlabel Players / RAM / CPU'
     echo 'users.label Players'
     echo 'ramusage.label RAM usage in GiB'
-    echo 'cpuusage.label CPU usage'
+    echo 'cpuusage.label CPU usage in %'
     exit 0
 fi
 
-PLAYERCOUNT=$(LC_LANG=C netstat -tn | grep ":$MC_PORT " | grep ESTABLISHED | wc -l)
-MC_PID=$(netstat -tlpn | grep ":$MC_PORT " | sed -n -e '1p' | awk '{ print $7 }' | cut -d '/' -f1)
+PLAYERCOUNT=$(LANG=en LC_LANG=C netstat -tn | grep "\:$MC_PORT " | grep -c "ESTABLISHED")
+MC_PID=$(netstat -tlpn | grep ":$MC_PORT " | sed -n -e '1p' | awk '{ print $7 }' | cut -d '/' -f1 | grep -v '-')
 if [ -n "${MC_PID}" ]
 then #is running
     MEMGiB=$(ps -p "$MC_PID" -o rss | sed -n '2p' | awk '{ print $1 / 1024 / 1024 }')
-    CPU=$(top -bp "$MC_PID" -n 1 | sed -n '$p' | awk '{ print $10 / 100; }')
+    CPU=$(ps -p "$MC_PID" -o pcpu | sed -n '2p' | awk '{ print $1 }')
 else
     MEMGiB="U"
     CPU="U"


### PR DESCRIPTION
Fixes:
- Make playercount work on non english systems
- Avoid getting an invalid PID if not run with sufficient permissions
- Fix getting CPU usage

Enhance:
- Clearify that CPU usage is in percent