### PR TITLE
[gitlab_statistics] Fix urllib request decoding

### DIFF
--- a/plugins/git/gitlab_statistics
+++ b/plugins/git/gitlab_statistics
@@ -37,7 +37,7 @@ Copyright (C) 2019 pcy <pcy.ulyssis.org>
 
 import os
 import json
-import urllib
+import urllib.request
 import sys
 
 
@@ -57,7 +57,7 @@ logarithmic = weakbool(os.getenv('logarithmic', 'N'))
 def reqjson():
     try:
         raw_data = urllib.request.urlopen(url)
-        return json.loads(raw_data)
+        return json.loads(raw_data.read().decode())
     except IOError:
         print("Cannot reach the GitLab API endpoint.", file=sys.stderr)
         exit(1)


### PR DESCRIPTION
Fix the error `AttributeError: module 'urllib' has no attribute 'request'` and then the error `TypeError: the JSON object must be str, bytes or bytearray, not HTTPResponse` by reading and decoding the urllib request.