### PR TITLE
[btrfs_device_usage] fix division by zero when btrfs pool is unhealthy

### DIFF
--- a/plugins/disk/btrfs_device_usage
+++ b/plugins/disk/btrfs_device_usage
@@ -155,9 +155,14 @@ def munin_values(fs):
 
     for this_device in devices:
         this_dev_info = fs.dev_info(this_device.devid)
-        usage = 100.0 * this_dev_info.bytes_used / this_dev_info.total_bytes
-        print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
-              ".value " + str(round(usage, 2)))
+        if this_dev_info.total_bytes > 0:
+            usage = 100.0 * this_dev_info.bytes_used / this_dev_info.total_bytes
+            print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
+                  ".value " + str(round(usage, 2)))
+        else:
+            print("btrfs_percent_" + fsid + "_" + str(this_device.devid) +
+                  ".value U")
+          
 
     print("")
 


### PR DESCRIPTION
During certain situations, a device in the btrfs pool can show a total
capacity of 0 bytes. This is aspecially true when replacing or removing a
failed disk.

This fix stops the plugin from crashing in that situation but just report
the devices percentage as unknown (U). That way other devices in the pool
stil can be monitored.