### PR TITLE
[ssl-certificate-expiry] add env.skip_cert_hashes to skip certificates

### DIFF
--- a/plugins/ssl/ssl-certificate-expiry
+++ b/plugins/ssl/ssl-certificate-expiry
@@ -1,6 +1,6 @@
 #!/bin/sh -u
 # -*- sh -*-
-# shellcheck disable=SC2039
+# shellcheck disable=SC2039,SC3043
 
 : << =cut
 
@@ -70,7 +70,7 @@ uncached updates after the cache file is older than an hour.
 
 =cut
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1091
 . "${MUNIN_LIBDIR}/plugins/plugin.sh"
 
 if [ "${MUNIN_DEBUG:-0}" = 1 ]; then

--- a/plugins/ssl/ssl-certificate-expiry
+++ b/plugins/ssl/ssl-certificate-expiry
@@ -102,7 +102,7 @@ parse_valid_days_from_certificate() {
 
         # Skip certificate if its hash is in env.skip_cert_hashes
         hash="$(echo "${cert_data}" | head -n 1)"
-        echo "${skip_cert_hashes:-}" | grep -q "${hash}" && return
+        echo "${skip_cert_hashes:-}" | grep -iqwF "${hash}" && return
 
         valid_until_string=$(echo "$cert_data" \
             | grep "^notAfter=" | cut -f 2 -d "=")

--- a/plugins/ssl/ssl-certificate-expiry
+++ b/plugins/ssl/ssl-certificate-expiry
@@ -1,6 +1,6 @@
 #!/bin/sh -u
 # -*- sh -*-
-# shellcheck disable=SC2039,SC3043
+# shellcheck shell=dash
 
 : << =cut
 

--- a/plugins/ssl/ssl-certificate-expiry
+++ b/plugins/ssl/ssl-certificate-expiry
@@ -25,6 +25,7 @@ To set warning and critical levels do like this:
     env.warning 30:
     env.proxy PROXYHOST:PORT          # optional, enables openssl operation over proxy
     env.checkname yes                 # optional, checks if used servername is covered by certificate
+    env.skip_cert_hashes 2e5ac55d     # optional, skip check of certs with those hashes (2e5ac55d is DST Root CA X3, cross-signing Let's Encrypt certs, but expiring on 2021-09-30)
 
 Alternatively, if you want to monitor hosts separately, you can create multiple symlinks named as follows.
 
@@ -58,13 +59,13 @@ uncached updates after the cache file is older than an hour.
 =head1 AUTHORS
 
  * Pactrick Domack (ssl_)
- * Olivier Mehani (ssl-certificate-expiry)
+ * Olivier Mehani (ssl-certificate-expiry, skip_cert_hashes)
  * Martin Schobert (check for intermediate certs)
  * Arndt Kritzner (hostname verification and proxy usage)
- 
+
  * Copyright (C) 2013 Patrick Domack <patrickdk@patrickdk.com>
- * Copyright (C) 2017, 2019 Olivier Mehani <shtrom+munin@ssji.net>
- * Copyright (C) 2020 Martin Schobert <martin@schobert.cc> 
+ * Copyright (C) 2017, 2019, 2021 Olivier Mehani <shtrom+munin@ssji.net>
+ * Copyright (C) 2020 Martin Schobert <martin@schobert.cc>
 
 =head1 LICENSE
 
@@ -97,7 +98,13 @@ parse_valid_days_from_certificate() {
     input_data=$(cat)
 
     if echo "$input_data" | grep -q -- "-----BEGIN CERTIFICATE-----"; then
-        valid_until_string=$(echo "$input_data" | openssl x509 -noout -enddate \
+        cert_data=$(echo "$input_data" | openssl x509 -noout -subject_hash -enddate)
+
+        # Skip certificate if its hash is in env.skip_cert_hashes
+        hash="$(echo "${cert_data}" | head -n 1)"
+        echo "${skip_cert_hashes:-}" | grep -q "${hash}" && return
+
+        valid_until_string=$(echo "$cert_data" \
             | grep "^notAfter=" | cut -f 2 -d "=")
         if [ -n "$valid_until_string" ]; then
             # FreeBSD requires special arguments for "date"


### PR DESCRIPTION
This fix allows to skip validity checks on any intermediate certificate
which subject hash appears in the list.

Let's Encrypt certificates are cross-signed by both DST Root CA X3 and
ISRG Root X1. DST Root CA X3 has expired on 2021-09-30 [0], which causes
the plugin to incorrectly report some full-chain LE certificates as
expired.

[0] https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
