### PR TITLE
[wunderground_] Fix windChil and heatIndex in root graph

### DIFF
--- a/plugins/weather/wunderground_
+++ b/plugins/weather/wunderground_
@@ -137,7 +137,7 @@ graph_title Weather in \(.neighborhood)
 graph_info Weather ${STATION_INFO}
 graph_category weather
 graph_vlabel Temperature / UV Index / Precipitation
-graph_order temp=temperature.temp windChill=temp.windChill heatIndex=temp.heatIndex uv=uv_index.uv precipRate=precipitation.precipRate
+graph_order temp=temperature.temp windChill=temperature.windChill heatIndex=temperature.heatIndex uv=uv_index.uv precipRate=precipitation.precipRate
 temp.label Temperature [${TEMP_UNIT}]
 windChill.label Wind chill [${TEMP_UNIT}]
 heatIndex.label Heat index [${TEMP_UNIT}]


### PR DESCRIPTION
The data was incorrectly loaned from a `temp` subgraph, which should
have been `temperature`.

This led to errors during munin-graph, as follow

    [ERROR] Failed to find windChill source at temp.windChill, skipping field
    [ERROR] Failed to find heatIndex source at temp.heatIndex, skipping field
    [PERL WARNING] Use of uninitialized value in concatenation (.) or string at /usr/share/perl5/Munin/Master/Utils.pm line 1149, <GEN1> line 1728.
    [ERROR] filename is empty for $VAR1 = {
      '#%#name' => 'windChill',
      'graph_data_size' => 'normal',
      'label' => 'Wind chill [Â°C]',
      'update_rate' => '300'
    };
    , temp.windChill
    [PERL WARNING] Use of uninitialized value in concatenation (.) or string at /usr/share/perl5/Munin/Master/Utils.pm line 1149, <GEN1> line 1728.
    [ERROR] filename is empty for $VAR1 = {
      '#%#name' => 'heatIndex',
      'graph_data_size' => 'normal',
      'label' => 'Heat index [Â°C]',
      'update_rate' => '300'
    };
    , temp.heatIndex

Signed-off-by: Olivier Mehani <shtrom@ssji.net>