### PR TITLE
[exodus_] Add plugin to monitore number of applications, reports and trackers

### DIFF
--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -38,6 +38,10 @@ You need to create a file named exodus placed in the directory
 
 Codimp <contact@lithio.fr>
 
+=head1 LICENSE
+
+GPLv3
+
 =head1 MAGIC MARKERS
 
  #%# family=manual

--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -71,7 +71,7 @@ def main():
         mode = sys.argv[1]
     except IndexError:
         mode = ""
-    wildcard = sys.argv[0].split("exodus_")[1].split("_")[0]
+    wildcard = sys.argv[0].split("exodus_")[1]
 
     if mode == "suggest":
         print("applications")

--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -58,12 +58,12 @@ import sys
 import requests
 
 
-def print_count(type):
-    endpoint = os.getenv('exodus_url') + '/api/' + type + '/count'
+def print_count(element):
+    endpoint = os.getenv('exodus_url') + '/api/' + element + '/count'
     headers = {"Authorization": "Token " + os.getenv('exodus_token')}
     count = requests.post(endpoint, headers=headers)
     if count.status_code == 200:
-        print(type + '.value', count.json()['count'])
+        print(element + '.value', count.json()['count'])
 
 
 def main():

--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -52,11 +52,11 @@ import requests
 
 
 def print_count(element):
-    endpoint = os.getenv('exodus_url') + '/api/' + element + '/count'
-    headers = {"Authorization": "Token " + os.getenv('exodus_token')}
+    endpoint = os.getenv("exodus_url") + "/api/" + element + "/count"
+    headers = {"Authorization": "Token " + os.getenv("exodus_token")}
     count = requests.post(endpoint, headers=headers)
     if count.status_code == 200:
-        print(element + '.value', count.json()['count'])
+        print(element + ".value", count.json()["count"])
 
 
 def main():
@@ -79,7 +79,7 @@ def main():
             print("graph_category exodus")
             print("applications.label Applications")
         else:
-            print_count('applications')
+            print_count("applications")
     elif wildcard == "reports":
         if mode == "config":
             print("graph_title Exodus reports")
@@ -87,7 +87,7 @@ def main():
             print("graph_category exodus")
             print("reports.label Reports")
         else:
-            print_count('reports')
+            print_count("reports")
     elif wildcard == "trackers":
         if mode == "config":
             print("graph_title Exodus trackers")
@@ -95,8 +95,8 @@ def main():
             print("graph_category exodus")
             print("trackers.label Trackers")
         else:
-            print_count('trackers')
+            print_count("trackers")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -5,8 +5,7 @@
 exodus_ - Exodus wildcard-plugin to monitor an L<Exodus|https://github.com/Exodus-Privacy/exodus/>
 instance.
 
-This wildcard plugin provides at the moment only the suffixes C<applications>, C<reports>
-and C<trackers>.
+This wildcard plugin provides the suffixes C<applications>, C<reports> and C<trackers>.
 
 =head1 INSTALLATION
 
@@ -20,13 +19,7 @@ and C<trackers>.
 
 =back
 
-After the installation you need to restart your munin-node:
-
-=over 2
-
-    systemctl restart munin-node
-
-=back
+After the installation you need to restart your munin-node service.
 
 =head1 CONFIGURATION
 

--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -48,15 +48,18 @@ Codimp <contact@lithio.fr>
 
 import os
 import sys
-import requests
+import json
+import urllib.request
 
 
 def print_count(element):
     endpoint = os.getenv("exodus_url") + "/api/" + element + "/count"
     headers = {"Authorization": "Token " + os.getenv("exodus_token")}
-    count = requests.post(endpoint, headers=headers)
-    if count.status_code == 200:
-        print(element + ".value", count.json()["count"])
+    request = urllib.request.Request(endpoint, method="POST", headers=headers)
+    with urllib.request.urlopen(request) as connection:
+        if connection.getcode() == 200:
+            count = json.loads(connection.read())["count"]
+            print(element + ".value", count)
 
 
 def main():

--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -77,6 +77,7 @@ def main():
         print("applications")
         print("reports")
         print("trackers")
+        exit(0)
 
     if wildcard == "applications":
         if mode == "config":

--- a/plugins/exodus/exodus_
+++ b/plugins/exodus/exodus_
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+=head1 NAME
+
+exodus_ - Exodus wildcard-plugin to monitor an L<Exodus|https://github.com/Exodus-Privacy/exodus/>
+instance.
+
+This wildcard plugin provides at the moment only the suffixes C<applications>, C<reports>
+and C<trackers>.
+
+=head1 INSTALLATION
+
+- Copy this plugin in your munin plugins directory
+
+=over 2
+
+    ln -s /usr/share/munin/plugins/exodus_ /etc/munin/plugins/exodus_applications
+    ln -s /usr/share/munin/plugins/exodus_ /etc/munin/plugins/exodus_reports
+    ln -s /usr/share/munin/plugins/exodus_ /etc/munin/plugins/exodus_trackers
+
+=back
+
+After the installation you need to restart your munin-node:
+
+=over 2
+
+    systemctl restart munin-node
+
+=back
+
+=head1 CONFIGURATION
+
+You need to create a file named exodus placed in the directory
+/etc/munin/plugin-conf.d/ with the following config:
+
+=over 2
+
+    [exodus_*]
+    env.exodus_url https://reports.exodus-privacy.eu.org
+    env.exodus_token your-api-token
+
+=back
+
+=head1 AUTHORS
+
+Codimp <contact@lithio.fr>
+
+=head1 MAGIC MARKERS
+
+ #%# family=manual
+ #%# capabilities=suggest
+
+=cut
+"""
+
+import os
+import sys
+import requests
+
+
+def print_count(type):
+    endpoint = os.getenv('exodus_url') + '/api/' + type + '/count'
+    headers = {"Authorization": "Token " + os.getenv('exodus_token')}
+    count = requests.post(endpoint, headers=headers)
+    if count.status_code == 200:
+        print(type + '.value', count.json()['count'])
+
+
+def main():
+    try:
+        mode = sys.argv[1]
+    except IndexError:
+        mode = ""
+    wildcard = sys.argv[0].split("exodus_")[1].split("_")[0]
+
+    if mode == "suggest":
+        print("applications")
+        print("reports")
+        print("trackers")
+
+    if wildcard == "applications":
+        if mode == "config":
+            print("graph_title Exodus applications")
+            print("graph_vlabel applications")
+            print("graph_category exodus")
+            print("applications.label Applications")
+        else:
+            print_count('applications')
+    elif wildcard == "reports":
+        if mode == "config":
+            print("graph_title Exodus reports")
+            print("graph_vlabel reports")
+            print("graph_category exodus")
+            print("reports.label Reports")
+        else:
+            print_count('reports')
+    elif wildcard == "trackers":
+        if mode == "config":
+            print("graph_title Exodus trackers")
+            print("graph_vlabel trackers")
+            print("graph_category exodus")
+            print("trackers.label Trackers")
+        else:
+            print_count('trackers')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Goal

This plugin monitore number of applications, reports and trackers of an [Exodus](https://github.com/Exodus-Privacy/exodus/) instance.

## Informations

This plugin is based on [the Exodus API documentation](https://github.com/Exodus-Privacy/exodus/blob/v1/doc/api.md) and can be used with any Exodus instance starting from [version 1.25.0](https://github.com/Exodus-Privacy/exodus/releases/tag/v1.25.0).