### PR TITLE
Update apt_ubuntu to display integers instead of floats

### DIFF
--- a/plugins/ubuntu/apt_ubuntu
+++ b/plugins/ubuntu/apt_ubuntu
@@ -77,6 +77,7 @@ def config():
     print('graph_category security')
     print('graph_title %s' % (title))
     print('graph_vlabel %s' % (vlabel))
+    print('graph_printf %.0lf')
     for i, archive in enumerate(archives + [other]):
         if len(colour) > i:
             print('%s.colour %s' % (archive, colour[i]))


### PR DESCRIPTION
Half a package can't be updated, so make the graph display integers instead of floats that always end in `.00`