### PR TITLE
nginx_unit: use more human readable scale

### DIFF
--- a/plugins/nginx_unit/nginx_unit
+++ b/plugins/nginx_unit/nginx_unit
@@ -126,7 +126,7 @@ def config(apps):
     print('graph_title Unit application average age')
     print('graph_info NGINX Unit application average age per process.')
     print('graph_category appserver')
-    print('graph_vlabel seconds')
+    print('graph_vlabel days')
     print('graph_args --lower-limit 0')
     for app in sorted(apps):
         safe = safename(app)
@@ -172,7 +172,7 @@ def fetch(apps):
     print('multigraph nginx_unit_age')
     for app, values in apps.items():
         safe = safename(app)
-        print(f'{safe}.value {values["age"] / values["count"]}')
+        print(f'{safe}.value {values["age"] / values["count"] / 86400}')
 
     print('multigraph nginx_unit_memory')
     for app, values in apps.items():


### PR DESCRIPTION
Value "2.34M seconds" doesn't mean anything  but "27 days" does.  Use days for process age.