### PR TITLE
chrony: don't resolve IP addresses to hostnames

### DIFF
--- a/plugins/chrony/chrony
+++ b/plugins/chrony/chrony
@@ -111,7 +111,7 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-chrony_status="$("$CHRONYC" tracking)"
+chrony_status="$("$CHRONYC" -n tracking)"
 echo "$fields" | while read fieldname factor regex label; do
 	status_line="$(echo "$chrony_status" | grep -i -- "$regex " | cut -d ":" -f 2-)"
 	if [ -z "$status_line" ]; then


### PR DESCRIPTION
If we don't want to show any host names in graphs/legend, it makes sense to not resolve them.

I occasionally notice the issue with name resolution of IPv6 addresses on certain networks, which makes `chronyc tracking` take 20+ seconds. Adding -n makes it almost instantaneous.