### PR TITLE
Update varnish5_ improving request_rate, transfer_rates

### DIFF
--- a/plugins/varnish/varnish5_
+++ b/plugins/varnish/varnish5_
@@ -170,37 +170,26 @@ my %data;
 my %ASPECTS = (
 	'request_rate' => {
 		'title' => 'Request rates',
-		'order' => 'cache_hit cache_hitpass cache_miss cache_hitmiss'
-			 . 'backend_conn backend_unhealthy '
-			 . 'client_req client_conn' ,
+		'order' => 'sess_conn client_req s_pass cache_miss cache_hitmiss cache_hitpass cache_hit s_pipe'
+			 . ' backend_conn backend_unhealthy',
 		'values' => {
 			'sess_conn' => {
 				'type' => 'DERIVE',
+				'draw' => 'AREA',
 				'min' => '0',
-				'colour' => '444444',
+				'colour' => 'FF5D00',
 				'graph' => 'ON'
 			},
 			'client_req' => {
 				'type' => 'DERIVE',
-				'colour' => '111111',
-				'min' => '0'
+				'colour' => '777777',
+				'min' => '0',
 			},
-			'cache_hit' => {
+			's_pass' => {
 				'type' => 'DERIVE',
 				'draw' => 'AREA',
-				'colour' => '00FF00',
-				'min' => '0'
-			},
-			'cache_hitpass' => {
-				'info' => 'Hitpass are cached passes: An '
-					. 'entry in the cache instructing '
-					. 'Varnish to pass. Typically '
-					. 'achieved after a pass in '
-					. 'vcl_fetch.',
-				'type' => 'DERIVE',
-				'draw' => 'STACK',
-				'colour' => 'FFFF00',
-				'min' => '0'
+				'min' => '0',
+				'colour' => 'BA4300'
 			},
 			'cache_miss' => {
 				'type' => 'DERIVE',
@@ -219,25 +208,38 @@ my %ASPECTS = (
 				'colour' => 'FFFF00',
 				'min' => '0'
 			},
+			'cache_hitpass' => {
+				'info' => 'Hitpass are cached passes: An '
+					. 'entry in the cache instructing '
+					. 'Varnish to pass. Typically '
+					. 'achieved after a pass in '
+					. 'vcl_fetch.',
+				'type' => 'DERIVE',
+				'draw' => 'STACK',
+				'colour' => 'FFFF00',
+				'min' => '0'
+			},
+			'cache_hit' => {
+				'type' => 'DERIVE',
+				'draw' => 'STACK',
+				'colour' => '00FF00',
+				'min' => '0'
+			},
+			's_pipe' => {
+				'type' => 'DERIVE',
+				'draw' => 'STACK',
+				'min' => '0',
+				'colour' => '0A7B0B'
+			},
 			'backend_conn' => {
 				'type' => 'DERIVE',
-				'colour' => '995599',
+				'colour' => 'EEEEEE',
 				'min' => '0'
 			},
 			'backend_unhealthy' => {
 				'type' => 'DERIVE',
 				'min' => '0',
 				'colour' => 'FF55FF'
-			},
-			's_pipe' => {
-				'type' => 'DERIVE',
-				'min' => '0',
-				'colour' => '1d2bdf'
-			},
-			's_pass' => {
-				'type' => 'DERIVE',
-				'min' => '0',
-				'colour' => '785d0d'
 			}
 		}
 	},
@@ -346,14 +348,14 @@ my %ASPECTS = (
 	},
 	'transfer_rates' => {
 		'title' => 'Transfer rates',
-		'order' => 's_resp_bodybytes s_resp_hdrbytes',
+		'order' => 's_resp_hdrbytes s_resp_bodybytes',
 		'args' => '-l 0',
 		'vlabel' => 'bit/s',
 		'values' => {
 			's_resp_hdrbytes' => {
 				'type' => 'DERIVE',
 				'label' => 'Header traffic',
-				'draw' => 'STACK',
+				'draw' => 'AREA',
 				'min' => '0',
 				'info' => 'HTTP Header traffic. TCP/IP '
 					. 'overhead is not included.',
@@ -361,7 +363,7 @@ my %ASPECTS = (
 			},
 			's_resp_bodybytes' => {
 				'type' => 'DERIVE',
-				'draw' => 'AREA',
+				'draw' => 'STACK',
 				'label' => 'Body traffic',
 				'min' => '0',
 				'cdef' => 's_resp_bodybytes,8,*'
@@ -773,7 +775,6 @@ my %ASPECTS = (
 			},
 			'sess_pipe_overflow' => {
 				'type' => 'DERIVE'
-
 			}
 		}
 	},
@@ -1219,4 +1220,3 @@ foreach my $value (keys %{$ASPECTS{$self}{'values'}}) {
 		print "$data{$value}{'value'}\n";
 	}
 }
-


### PR DESCRIPTION
- request_rate
  - major reordering. making possible to read pass rates evolutions and rejected requests visible
  - small fix: sess_conn not client_conn in the order

- transfer_rates
  - using AREA/STACK