### PR TITLE
Fix mikrotik_system -  temp + voltage

### DIFF
--- a/plugins/router/mikrotik_system
+++ b/plugins/router/mikrotik_system
@@ -267,7 +267,7 @@ function get_temperature_value {
         }'
     fi
     if [ "$ros_version" == "7" ]; then
-      echo "$line" | awk '/cpu-temperature/{
+      echo "$line" | awk '/temperature/{
         print "temperature.value " $3
         }'
     fi

--- a/plugins/router/mikrotik_system
+++ b/plugins/router/mikrotik_system
@@ -127,7 +127,7 @@ function get_voltage_label {
     # if found
     # print line
     # external/bash-variables with "'"<var>"'"
-    echo "$line" | awk '/voltage:/{
+    echo "$line" | awk '/voltage/{
       print "multigraph voltage_graph_""'"$name"'";
       print "graph_title voltage " "'"$name"'";
       print "graph_vlabel volt";
@@ -139,21 +139,29 @@ function get_voltage_label {
   done <<< "$data" # der variable data
 }
 function get_voltage_value {
+  get_ros_version
   while read -r line; do
     # like the label functions
     # print title if dirtyconfig is not set
     # because the call does not come in "config"
     if [ "$MUNIN_CAP_DIRTYCONFIG" = "0" ] || [ -z "$MUNIN_CAP_DIRTYCONFIG" ]; then
-      echo "$line" | awk '/voltage:/{
+      echo "$line" | awk '/voltage/{
         print "multigraph voltage_graph_""'"$name"'";
         }'
     fi
-    # remove with gsub the char % in argument $2
-    # print $2
-    echo "$line" | awk '/voltage:/{
-      gsub(/V/,"",$2);
-      print "voltage.value " $2
-      }'
+    if [ "$ros_version" == "6" ]; then
+      # remove with gsub the char % in argument $2
+      # print $2
+      echo "$line" | awk '/voltage/{
+        gsub(/V/,"",$2);
+        print "voltage.value " $2
+        }'
+    fi
+    if [ "$ros_version" == "7" ]; then
+      echo "$line" | awk '/voltage/{
+        print "voltage.value " $3
+        }'
+    fi
   done <<< "$data"
 }
 


### PR DESCRIPTION
Hi,

with the latest versions of RouterOS some Names have changed.

That PR fixes the Errors for "temperature" and "voltage".

It is tested on RB5009, hex, CRS309, CRS305 with RouterOS 7.2.1. It is NOT tested with older Versions of RouterOS because i dont have any devices left with it.