### PR TITLE
du-2: fix resource consumption when first running the plugin

### DIFF
--- a/plugins/disk/du-2
+++ b/plugins/disk/du-2
@@ -8,6 +8,7 @@
 =head1 AUTHOR AND COPYRIGHT
 
   Copyright 2011-2014 Luc Didry <luc AT didry.org>
+  Copyright 2022 Andreas Perhab, WT-IO-IT GmbH <a.perhab@wtioit.at>
 
 =head1 HOWTO CONFIGURE AND USE :
 
@@ -160,15 +161,21 @@ sub cache_is_too_old {
 
 sub du_not_running {
     if (-e $LOCKFILE) {
-        my ($time) = `cat $TIMEFILE`;
-        chomp $time;
-        if ( (time - $time) > ($ENV{interval}*60*60) ) {
-            # The cache is really old (60xinterval) => Maybe the lockfile wasn't properly deleted.
-            # Let's delete it.
-            system("rm $LOCKFILE;");
-            return 1;
+        if (-e $TIMEFILE) {
+            my ($time) = `cat $TIMEFILE`;
+            chomp $time;
+            if ( (time - $time) > ($ENV{interval}*60*60) ) {
+                # The cache is really old (60xinterval) => Maybe the lockfile wasn't properly deleted.
+                # Let's delete it.
+                unlink($LOCKFILE);
+                return 1;
+            } else {
+                return 0;
+            }
         } else {
-	        return 0;
+            # when $TIMEFILE is not yet created (first run is not yet finished), $LOCKFILE is honoured
+            # to prevent spawning multiple resource intensive processes
+            return 0;
         }
     } else {
         return 1;


### PR DESCRIPTION
when installing / first running the plugin, it can take longer than
one munin-update call to create the $TIMEFILE. so until it is created
we assume the $LOCKFILE is not too old yet and let the first run finish
before we spawn additional processes.

On one of our systems we run munin-node in a docker-container and it started to consume more and more memory / cpu and disk io until the system started the oom killer. This seems to happen when du-2 takes a long time to complete and you start with a fresh installation where the file containing the last cache update timestamp is not yet created.

Info @wt-io-it