### PR TITLE
puppet_runtime: fix perlpod

### DIFF
--- a/plugins/puppet/puppet_runtime
+++ b/plugins/puppet/puppet_runtime
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
+
 =begin
+
 =head1 puppet_runtime
 
 A munin plugin that reports the duration of puppet runs.


### PR DESCRIPTION
`perlpod` needs these blank lines in order to detect and format the documentation.