### PR TITLE
kvm_*: improve field names

### DIFF
--- a/plugins/libvirt/kvm_cpu
+++ b/plugins/libvirt/kvm_cpu
@@ -83,7 +83,7 @@ def clean_vm_name(vm_name):
             return parts[parts.index('-name') + 1]
         except ValueError:
             pass
-    return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
+    return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)
 
 
 def detect_kvm():

--- a/plugins/libvirt/kvm_io
+++ b/plugins/libvirt/kvm_io
@@ -82,7 +82,7 @@ def clean_vm_name(vm_name):
             vm_name = parts[parts.index('-name') + 1]
         except ValueError:
             pass
-    return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
+    return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)
 
 
 def fetch(vms):

--- a/plugins/libvirt/kvm_mem
+++ b/plugins/libvirt/kvm_mem
@@ -51,8 +51,8 @@ def clean_vm_name(vm_name):
             return parts[parts.index('-name')+1]
         except ValueError:
             pass
+    return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)
 
-    return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
 
 def fetch(vms):
     ''' Fetch values for a list of pids

--- a/plugins/libvirt/kvm_net
+++ b/plugins/libvirt/kvm_net
@@ -106,7 +106,7 @@ def clean_vm_name(vm_name):
             return parts[parts.index('-name')+1]
         except ValueError:
             pass
-    return re.sub(r"[^a-zA-Z0-9_]", "_", vm_name)
+    return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)
 
 
 def fetch(vms):


### PR DESCRIPTION
fixed graph failure for VM names starting with digits

used "Validate filednames" Python stanza from docs to improve
clean_vm_name functions, helping graph creations for VM with names
starting with digits, like "150-121-Apache".

remember: each data source in a plugin must be identified by a field
name (in this case VM names). The characters must be [a-zA-Z0-9_],
while the first character must be [a-zA-Z_].