### PR TITLE
[rabbitmq_consumers] Fix rabbitmqctl output filter

### DIFF
--- a/plugins/rabbitmq/rabbitmq_consumers
+++ b/plugins/rabbitmq/rabbitmq_consumers
@@ -31,7 +31,7 @@ fi
 HOME=/tmp/
 VHOST=${vhost:-"/"}
 QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
-		grep -v '^Listing' | \
+		grep -vE '^Timeout:|^Listing queues|^name$' | \
 		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
 
 if [ "$1" = "config" ]; then
@@ -71,5 +71,5 @@ fi
 # "value" subfield for every data field.
 
 HOME=$HOME rabbitmqctl list_queues -p $VHOST name consumers| \
-	grep -v "^Listing" | grep -v "done.$" | \
+	grep -vE "^Timeout:|^Listing queues|^name" | grep -v "done.$" | \
     perl -nle'($q, $s) = split; $q =~ s/[.=-]/_/g; print("$q.value $s")'


### PR DESCRIPTION
## Goal

- Fix rabbitmqctl output filter to avoid bad values

## Informations

By default `rabbitmqctl list_queues -p / name consumers` give this kind of output:
```
Timeout: 60.0 seconds ...
Listing queues for vhost / ...
name	consumers
celery	1
```

Then in this plugin it result to:
```
Timeout:.value 60.0
name.value consumers
celery.value 1
```
The `consumers` value generates the following error message:
```
[ERROR] In RRD: Error updating /var/lib/munin/production/server1-rabbitmq_consumers-name-g.rrd: /var/lib/munin/production/server1-rabbitmq_consumers-name-g.rrd: Function update_pdp_prep, case DST_GAUGE - Cannot convert 'consumers' to float
```

This merge request fix the grep command to get this plugin result:
```
celery.value 1
```