### PR TITLE
[rabbitmq_messages*] Fix rabbitmqctl output filter

### DIFF
--- a/plugins/rabbitmq/rabbitmq_messages
+++ b/plugins/rabbitmq/rabbitmq_messages
@@ -31,7 +31,7 @@ fi
 HOME=/tmp/
 VHOST=${vhost:-"/"}
 QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
-		grep -v '^Listing' | \
+		grep -vE '^Timeout:|^Listing|^name' | \
 		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
 
 if [ "$1" = "config" ]; then
@@ -71,5 +71,5 @@ fi
 # "value" subfield for every data field.
 
 HOME=$HOME rabbitmqctl list_queues -p $VHOST | \
-	grep -v "^Listing" | grep -v "done.$" | \
+	grep -vE "^Timeout:|^Listing|^name" | grep -v "done.$" | \
 	perl -nle'($q, $s) = split; $q =~ s/[.=-]/_/g; print("$q.value $s")'

--- a/plugins/rabbitmq/rabbitmq_messages_unacknowledged
+++ b/plugins/rabbitmq/rabbitmq_messages_unacknowledged
@@ -31,7 +31,7 @@ fi
 HOME=/tmp/
 VHOST=${vhost:-"/"}
 QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
-		grep -v '^Listing' | \
+		grep -vE '^Timeout:|^Listing|^name' | \
 		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
 
 if [ "$1" = "config" ]; then
@@ -71,5 +71,5 @@ fi
 # "value" subfield for every data field.
 
 HOME=$HOME rabbitmqctl list_queues -p $VHOST name messages_unacknowledged | \
-	grep -v "^Listing" | grep -v "done.$" | \
+	grep -vE "^Timeout:|^Listing|^name" | grep -v "done.$" | \
     perl -nle'($q, $s) = split; $q =~ s/[.=-]/_/g; print("$q.value $s")'

--- a/plugins/rabbitmq/rabbitmq_messages_uncommitted
+++ b/plugins/rabbitmq/rabbitmq_messages_uncommitted
@@ -31,7 +31,7 @@ fi
 HOME=/tmp/
 VHOST=${vhost:-"/"}
 QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
-		grep -v '^Listing' | \
+		grep -vE '^Timeout:|^Listing|^name' | \
 		grep -v 'done\.$' | sed -e 's/[.=-]/_/g' )
 
 if [ "$1" = "config" ]; then
@@ -71,5 +71,5 @@ fi
 # "value" subfield for every data field.
 
 HOME=$HOME rabbitmqctl list_channels -p $VHOST name messages_uncommitted | \
-	grep -v "^Listing" | grep -v "done.$" | \
+	grep -vE "^Timeout:|^Listing|^name" | grep -v "done.$" | \
     perl -nle'($q, $s) = split; $q =~ s/[.=-]/_/g; print("$q.value $s")'


### PR DESCRIPTION
## Goal

- Fix rabbitmqctl output filter to avoid bad values

## Informations

Like #1323 

By default `rabbitmqctl list_queues -p / name messages` give this kind of output:
```
Timeout: 60.0 seconds ...
Listing queues for vhost / ...
name	messages
celery	0
```

Then in this plugin it result to:
```
Timeout:.value 60.0
name.value messages
celery.value 0
```

This merge request fix the grep command to get this plugin result:
```
celery.value 0
```