### PR TITLE
[router/freebox] Allow to override the default base URL

### DIFF
--- a/plugins/router/freebox
+++ b/plugins/router/freebox
@@ -12,6 +12,15 @@ freebox - Plugin to monitor stats of a Freebox (Free.fr's custom series of route
   #%# family=auto
   #%# capabilities=autoconf
 
+=head1 CONFIGURATION
+
+At some point, the default C<mafreebox.free.fr> address stopped pointing to the
+local Freebox. It is now necessary to specify the IP address or hostname of the
+router. This is done as follows.
+
+	[freebox]
+	env.freebox_url http://192.2.0.1
+
 =head1 CAVEAT
 
 Only tested on a Freebox v5 with an ADSL uplink.
@@ -20,7 +29,7 @@ Only tested on a Freebox v5 with an ADSL uplink.
 
 Olivier Mehani
 
-Copyright (C) 2019 Olivier Mehani <shtrom+munin@ssji.net>
+Copyright (C) 2019,2022 Olivier Mehani <shtrom+munin@ssji.net>
 
 =head1 LICENSE
 
@@ -35,7 +44,10 @@ if [ "${MUNIN_DEBUG:-0}" = 1 ]; then
     set -x
 fi
 
-fbx_info_url="http://mafreebox.free.fr/pub/fbx_info.txt"
+FBX_URL=${freebox_url:-"http://mafreebox.free.fr"}
+
+fbx_info_url="${FBX_URL}/pub/fbx_info.txt"
+
 #
 # Example output (including stray whitespaces):
 #


### PR DESCRIPTION
It seems the default base URL stopped working, so a locally-resolvable
address or name needs to be provided instead.

Signed-off-by: Olivier Mehani <shtrom@ssji.net>