### PR TITLE
kvm_*: improve field names for Proxmox, Centos

### DIFF
--- a/plugins/libvirt/kvm_cpu
+++ b/plugins/libvirt/kvm_cpu
@@ -80,7 +80,7 @@ def clean_vm_name(vm_name):
     parts = vm_name.split('\x00')
     if parts[0].endswith('kvm'):
         try:
-            return parts[parts.index('-name') + 1]
+            return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", parts[parts.index('-name') + 1])
         except ValueError:
             pass
     return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)

--- a/plugins/libvirt/kvm_io
+++ b/plugins/libvirt/kvm_io
@@ -79,7 +79,7 @@ def clean_vm_name(vm_name):
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:
-            vm_name = parts[parts.index('-name') + 1]
+            vm_name = re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", parts[parts.index('-name') + 1])
         except ValueError:
             pass
     return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)

--- a/plugins/libvirt/kvm_mem
+++ b/plugins/libvirt/kvm_mem
@@ -48,7 +48,7 @@ def clean_vm_name(vm_name):
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:
-            return parts[parts.index('-name')+1]
+            return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", parts[parts.index('-name')+1])
         except ValueError:
             pass
     return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)

--- a/plugins/libvirt/kvm_net
+++ b/plugins/libvirt/kvm_net
@@ -103,7 +103,7 @@ def clean_vm_name(vm_name):
     parts = vm_name.split('\x00')
     if (parts[0].endswith('kvm')):
         try:
-            return parts[parts.index('-name')+1]
+            return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", parts[parts.index('-name')+1])
         except ValueError:
             pass
     return re.sub(r"(^[^A-Za-z_]|[^A-Za-z0-9_])", "_", vm_name)


### PR DESCRIPTION
fixed graphing failures for VM deployed on legacy Centos 6.9 virtualization
platforms (script uses the Proxmox entries), in the case of VM domain names
beggining with digits (first field name character must be [a-ZA-Z_])

used "Validate field names" Python stanza from documentation ("How to write
plugins", "Notes on field names") to improve the clean_vm_name function, thus
munin kvm graph creation succeeded for VM with names starting with digits,
like "150-121-Apache", deployed on Centos 6.9 virtualization platforms.