### PR TITLE
Fix imapproxy_multi

### DIFF
--- a/plugins/imapproxy/imapproxy_multi
+++ b/plugins/imapproxy/imapproxy_multi
@@ -79,9 +79,10 @@ def print_fetch():
     connections_created = 0
     connections_reused = 0
     connections = Popen(
-        "pimpstat -c | egrep '(Total (Reused|Created)|Cache (Hits|Misses))'",
+      "/usr/sbin/pimpstat -f /etc/imapproxy.conf -c | /usr/bin/egrep '(Total (Reused|Created)|Cache (Hits|Misses))'",
         shell=True,
-        stdout=PIPE
+        stdout=PIPE,
+        universal_newlines=True
     )
     for line in connections.stdout:
         if re.search(r'Hits', line):


### PR DESCRIPTION
- Added imapproxy.conf as parameter as pimpstat won't work without
- Added unversal_newlines as Popen parameter because otherwise it's binary output