### PR TITLE
Fix for clamav plugin

### DIFF
--- a/plugins/clamav/clamav
+++ b/plugins/clamav/clamav
@@ -29,3 +29,4 @@ EOT
 fi
 
 echo -n "virus.value " && fgrep -c FOUND $log
+exit 0


### PR DESCRIPTION
Add `exit 0` at the end, otherwise the plugin fails