### PR TITLE
Correct multigraph typo for uptime graph (arris-sb6183)

### DIFF
--- a/plugins/router/arris-sb6183
+++ b/plugins/router/arris-sb6183
@@ -253,7 +253,7 @@ def process_url(url):
     return dom.xpath('//table[contains(@class, "simpleTable")]')
 
 
-print("multi_graph arris_uptime")
+print("multigraph arris_uptime")
 arr = process_url(INFO_URL)
 if arr:
     trs = arr[1].findall("tr")


### PR DESCRIPTION
Corrected ```multi_graph``` to ```multigraph```.