### PR TITLE
Update ssl-certificate-expiry to allow legacy renegotiation

### DIFF
--- a/plugins/ssl/ssl-certificate-expiry
+++ b/plugins/ssl/ssl-certificate-expiry
@@ -26,6 +26,7 @@ To set warning and critical levels do like this:
     env.proxy PROXYHOST:PORT          # optional, enables openssl operation over proxy
     env.checkname yes                 # optional, checks if used servername is covered by certificate
     env.skip_cert_hashes 2e5ac55d     # optional, skip check of certs with those hashes (2e5ac55d is DST Root CA X3, cross-signing Let's Encrypt certs, but expiring on 2021-09-30)
+    env.legacy_renegotiation yes      # optional, allow unsafe renegotiation when connecting to older systems.
 
 Alternatively, if you want to monitor hosts separately, you can create multiple symlinks named as follows.
 
@@ -136,6 +137,7 @@ print_expire_days() {
     [ -n "$starttls" ] && s_client_args="$s_client_args -starttls $starttls"
     [ -n "${proxy:-}" ] && s_client_args="$s_client_args -proxy $proxy"
     [ -n "${checkname:-}" ] && [ "$checkname" = "yes" ] && s_client_args="$s_client_args -verify_hostname $host"
+    [ -n "${legacy_renegotiation:-}" ] && [ "$legacy_renegotiation" = "yes" ] && s_client_args="$s_client_args -legacy_renegotiation"
 
     # We extract and check the server certificate,
     # but the end date also depends on intermediate certs. Therefore


### PR DESCRIPTION
This small change can be used to enable SSL legacy renegotiation.  It is sometimes required for older software or hardware - in my case a cluster of Aruba APs.