### PR TITLE
[ssl/ssl-certificate-expiry] Add configurable timeout

### DIFF
--- a/plugins/ssl/ssl-certificate-expiry
+++ b/plugins/ssl/ssl-certificate-expiry
@@ -72,7 +72,7 @@ uncached updates after the cache file is older than an hour.
 
 =cut
 
-# shellcheck disable=SC1091
+# shellcheck disable=SC1090,SC1091
 . "${MUNIN_LIBDIR}/plugins/plugin.sh"
 
 if [ "${MUNIN_DEBUG:-0}" = 1 ]; then

--- a/plugins/ssl/ssl-certificate-expiry
+++ b/plugins/ssl/ssl-certificate-expiry
@@ -26,6 +26,7 @@ To set warning and critical levels do like this:
     env.proxy PROXYHOST:PORT          # optional, enables openssl operation over proxy
     env.checkname yes                 # optional, checks if used servername is covered by certificate
     env.skip_cert_hashes 2e5ac55d     # optional, skip check of certs with those hashes (2e5ac55d is DST Root CA X3, cross-signing Let's Encrypt certs, but expiring on 2021-09-30)
+    env.timeout 60s                   # optional, sets a timeout for openssl operations. This is useful when the remote server might not be available.
 
 Alternatively, if you want to monitor hosts separately, you can create multiple symlinks named as follows.
 
@@ -137,6 +138,12 @@ print_expire_days() {
     [ -n "${proxy:-}" ] && s_client_args="$s_client_args -proxy $proxy"
     [ -n "${checkname:-}" ] && [ "$checkname" = "yes" ] && s_client_args="$s_client_args -verify_hostname $host"
 
+    # If timeout is configured, setup the command to call.
+    # Use `--preserve-status` to still get the returncode of openssl, not the
+    # one of timeout.
+    local timeout_call=''
+    [ -n "${timeout:-}" ] && timeout_call="timeout --preserve-status ${timeout}"
+
     # We extract and check the server certificate,
     # but the end date also depends on intermediate certs. Therefore
     # we want to check intermediate certs as well.
@@ -155,7 +162,7 @@ print_expire_days() {
     # shellcheck disable=SC2086
     openssl_call="s_client -servername $host -connect ${host}:${port} -showcerts $s_client_args"
     # shellcheck disable=SC2086
-    openssl_response=$(echo "" | openssl ${openssl_call} 2>/dev/null)
+    openssl_response=$(echo "" | ${timeout_call} openssl ${openssl_call} 2>/dev/null)
     if echo "$openssl_response" | grep -qi "Hostname mismatch"; then
 	echo "<>"
     else


### PR DESCRIPTION
This should help with unreachable hosts, as the plugin can take more than 10 minutes to complete otherwise. These changes should be fully backwards compatible, since the default is no timeout set, so it acts the same way as before if not explicitly configured otherwise.

Also I took the freedom to disable shellcheck SC1090. When linting this script, this will always fire. This is because shellcheck only does static code analysis and thus can not determine dynamic filepath for includes.

Changes:
- Introduce "timeout" configuration
- Only run timeout when configured
- Document usage of new configuration
- Disable shellcheck SC1090