### PR TITLE
[arris-sb8200] Fix channel selection and warnings

### DIFF
--- a/plugins/router/arris-sb8200
+++ b/plugins/router/arris-sb8200
@@ -98,13 +98,10 @@ import os
 import sys
 import base64
 
-# SB8200 has bad SSL cert, ignore warnings
-import urllib3
-
-urllib3.disable_warnings()
-
 # Extra Packages
+# SB8200 has bad SSL cert, ignore warnings
 import requests
+requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 from lxml import html
 
 
@@ -177,8 +174,9 @@ class Modem:
 
 # Sets maximum number of channels
 UPCOUNT = 8
-DOWNCOUNT = 33
-# DOWNCOUNT should be 32, but I have observed 33
+DOWNCOUNT = 32
+# DOWNCOUNT should be 32, I have observed "extra" channels with
+# modulation type of "Other" which only ever have errors
 
 if os.getenv("password", None) is None:
     print("Set password.", file=sys.stderr)
@@ -388,6 +386,8 @@ for row in trs:
     data = dict(
         zip(headings, ["".join(x.itertext()).strip() for x in row.findall("td")])
     )
+    if data["Modulation"] == "Other":
+        continue
     uncorr += int(data["Uncorrectables"])
     correct += int(data["Corrected"])
 


### PR DESCRIPTION
This actually silences InsecureRequestWarning.
The Arris SB8200 has 32 downstream channels, but in my experience report more than that, but the "extra" channels report modulation as "Other" instead of QAM256.  This filters those channels, since they seem to drive the error count up, but don't provide data.
