### PR TITLE
Fix for Python 3

### DIFF
--- a/plugins/lighttpd/lighttpd_
+++ b/plugins/lighttpd/lighttpd_
@@ -122,7 +122,7 @@ else:
             auth = urllib.request.HTTPBasicAuthHandler(mgr)
         opener = urllib.request.build_opener(auth)
         urllib.request.install_opener(opener)
-    info = urllib.request.urlopen(request).read()
+    info = urllib.request.urlopen(request).read().decode('utf-8')
     data = {}
     for line in info.split("\n"):
         try:


### PR DESCRIPTION
Default for Python 3 is to return byte-objects, not string. This will cause the plugin to fail with an error: "TypeError: a bytes-like object is required, not 'str'". Fixed by decoding for UTF8.