### PR TITLE
proxmox_vm_count: Integers

### DIFF
--- a/plugins/proxmox/proxmox_vm_count
+++ b/plugins/proxmox/proxmox_vm_count
@@ -78,7 +78,8 @@ if [ "$1" = "config" ]; then
     echo 'graph_title ProxMox - Number of VMs and LXCs'
     echo 'graph_vlabel Count'
     echo 'graph_category virtualization'
-    echo 'graph_args -l 0'
+    echo "graph_printf %6.0lf"
+    echo "graph_args -l 0 --base 1000"
     exit 0
 fi
 echo total.value "$total"


### PR DESCRIPTION
This PR set the graph options to output only integers because you cant have 1.3 VMs running. ;-)