### PR TITLE
zfs_pool_dataset_count: Integers

### DIFF
--- a/plugins/zfs/zfs_pool_dataset_count
+++ b/plugins/zfs/zfs_pool_dataset_count
@@ -50,7 +50,8 @@ if [ "$1" = "config" ]; then
   echo 'graph_title zfs -  pool, dataset and snapshot count' # Titelzeile
   echo 'graph_vlabel count' # Text links, hochkant
   echo 'graph_category fs' # Kategorie
-  echo 'graph_args -l 0' # wertebegrenzer 0-100
+  echo "graph_printf %6.0lf"
+  echo "graph_args -l 0 --base 1000"
   exit 0
 fi
 


### PR DESCRIPTION
This PR set the graph options to output only integers because you cant have 1.3 datasets/pools. ;-)