### PR TITLE
Deye/Solarman: remove AppId variable

### DIFF
--- a/plugins/solar/solarman_api_inverter
+++ b/plugins/solar/solarman_api_inverter
@@ -68,7 +68,7 @@ function get_data {
         ## create request body for panel data
         SLRM_DATA_REQUEST_BODY=$(jq --null-input --arg deviceSn "${SLRM_DEVICE_SN}" '{"deviceSn": $deviceSn}')
         ## get panel data
-        SLRM_DATA=$(curl --silent --request POST --url "https://api.solarmanpv.com/device/v1.0/currentData?appId=${SLRM_APPID}&language=en&=" --header "Authorization: bearer ${SLRM_BEARER_TOKEN}" --header 'Content-Type: application/json' --data "${SLRM_DATA_REQUEST_BODY}")
+        SLRM_DATA=$(curl --silent --request POST --url "https://api.solarmanpv.com/device/v1.0/currentData?language=en&=" --header "Authorization: bearer ${SLRM_BEARER_TOKEN}" --header 'Content-Type: application/json' --data "${SLRM_DATA_REQUEST_BODY}")
         # wenn "device not found" nicht gefunden wird, dann breche aus beiden Schleifen heraus
 	 if [[ $(echo "$SLRM_DATA" | grep -v -i "device not found") ]] ; then
             retry="0"


### PR DESCRIPTION
Remove unneccesary AppId, it is only used while obtaining the token.

`Only the request token url needs to pass the APPID, other interfaces do not need to pass the APPID in the request url.`