### PR TITLE
[icecast2_stats_] Fix sources parsing if there is only one source

### DIFF
--- a/plugins/icecast/icecast2_stats_
+++ b/plugins/icecast/icecast2_stats_
@@ -108,9 +108,17 @@ def _get_json_statistics():
 
 def get_sources():
     sources = []
-    for source in _get_json_statistics()["icestats"]["source"]:
+    if type(_get_json_statistics()["icestats"]["source"]) == dict:
+        source = _get_json_statistics()["icestats"]["source"]
         path_name = source["listenurl"].split("/")[-1]
         sources.append({"name": path_name,
+                        "fieldname": clean_fieldname(path_name),
+                        "listeners": source["listeners"],
+                        "duration_days": get_iso8601_age_days(source["stream_start_iso8601"])})
+    else:
+        for source in _get_json_statistics()["icestats"]["source"]:
+            path_name = source["listenurl"].split("/")[-1]
+            sources.append({"name": path_name,
                             "fieldname": clean_fieldname(path_name),
                             "listeners": source["listeners"],
                             "duration_days": get_iso8601_age_days(source["stream_start_iso8601"])})


### PR DESCRIPTION
## Goal

- Fix sources parsing if only one source is available (without array)
- Keep parsing loop the same if there is more than one source (with array)

## Informations

By default with Icecast2, when more than one source is available `["icestats"]["source"]` is an array of dict (each dict is a source) but when only one source is available `["icestats"]["source"]` is just a dict with the single source values.

This change check if `["icestats"]["source"]` is a dict or not to make an appropriate parsing choice.