### PR TITLE
Update md_iostat_ for '--write-mostly' drives

### DIFF
--- a/plugins/disk/md_iostat_
+++ b/plugins/disk/md_iostat_
@@ -130,7 +130,7 @@ while (<MD>) {
 
 # Remove unwanted things like raid device number, partition number
 # and sort nicely.
-@devs = sort by_dev map { s/\d*\[.*\]$//; $_; } @devs;
+@devs = sort by_dev map { s/\d*\[.*$//; $_; } @devs;
 
 # Insert the raid device into the mix.
 unshift(@devs,$md);


### PR DESCRIPTION
Doesn't work with '--write-mostly' drives like sde1 in : 

```
     md94 : active raid1 sde1[1](W)(S) sdd1[2]
```

I assume to remove everything behind the opening bracket