### PR TITLE
nvme: Prefix 'NVME' to spare graph title for consistency.

### DIFF
--- a/plugins/disk/nvme
+++ b/plugins/disk/nvme
@@ -286,7 +286,7 @@ EOF
     }
     print <<'EOF';
 multigraph nvme_spare
-graph_title Available spare blocks
+graph_title NVME Available spare blocks
 graph_order $sn_list
 graph_vlabel Percent
 graph_category disk


### PR DESCRIPTION
Hi.  All other graph titles in this module are prefixed with 'NVME' except this one, which was added later on.  My patch change the titles to make them consistent.  Thank you!