### PR TITLE
[weather_press/temp/hum_]: Bugfixes in noaa based plugins and add humidity

### DIFF
--- a/plugins/weather/weather_hum_
+++ b/plugins/weather/weather_hum_
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+munin US NOAA weather plugin (http://tgftp.nws.noaa.gov)
+
+Draws relative humidity in %.
+Copy/link file as 'weather_humidity_CODE', like: weather_humidity_LOWW for Austria, Vienna.
+
+Get the code by going to http://tgftp.nws.noaa.gov, selecting your
+location, and copying the code from the address bar of your browser; should
+be something like CODE.html.
+
+Linux users might need to adjust the shebang.
+"""
+
+import sys
+from urllib.request import urlopen
+import re
+
+url = 'https://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT'
+
+re_hum = re.compile(r'Relative Humidity:\s*(\d+)%')
+
+
+code = sys.argv[0][(sys.argv[0].rfind('_') + 1):]
+if not code:
+    sys.exit(1)
+elif len(sys.argv) == 2 and sys.argv[1] == "autoconf":
+    print("yes")
+elif len(sys.argv) == 2 and sys.argv[1] == "config":
+    print('graph_title Relative humidity at code %s' % code)
+    print('graph_vlabel humidity in %')
+    print('graph_category sensors')
+
+    print('humidity.label Humidity')
+    print('graph_args --base 1000 -l 0')
+else:
+    u = urlopen(url % code)
+    txt = str(u.read())
+    u.close()
+
+    hum = re_hum.findall(txt)[0]
+    print('humidity.value %s' % hum)

--- a/plugins/weather/weather_press_
+++ b/plugins/weather/weather_press_
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-munin US NOAA weather plugin (http://tgftp.nws.noaa.gov)
+munin US NOAA weather plugin (https://tgftp.nws.noaa.gov)
 
 Draws pressure in hPa.
 Copy/link file as 'weather_pressure_CODE', like: weather_pressure_LOWW for Austria, Vienna.
 
-Get the code by going to http://tgftp.nws.noaa.gov, selecting your
+Get the code by going to https://tgftp.nws.noaa.gov, selecting your
 location, and copying the code from the address bar of your browser; should
 be something like CODE.html.
 
@@ -16,7 +16,7 @@ import sys
 from urllib.request import urlopen
 import re
 
-url = 'http://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT'
+url = 'https://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT'
 
 re_hpa = re.compile(r'Pressure.*\((\d+) hPa\)')
 

--- a/plugins/weather/weather_press_
+++ b/plugins/weather/weather_press_
@@ -37,7 +37,7 @@ elif len(sys.argv) == 2 and sys.argv[1] == "config":
     print('graph_scale no')
 else:
     u = urlopen(url % code)
-    txt = u.read()
+    txt = str(u.read())
     u.close()
 
     hpa = re_hpa.findall(txt)[0]

--- a/plugins/weather/weather_temp_
+++ b/plugins/weather/weather_temp_
@@ -37,7 +37,7 @@ elif len(sys.argv) == 2 and sys.argv[1] == "config":
     print('graph_args --base 1000 -l 0')
 else:
     u = urlopen(url % code)
-    txt = u.read()
+    txt = str(u.read())
     u.close()
 
     C = re_C.findall(txt)[0]

--- a/plugins/weather/weather_temp_
+++ b/plugins/weather/weather_temp_
@@ -18,8 +18,8 @@ import re
 
 url = 'https://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT'
 
-re_C = re.compile(r'Temperature:.*\((-?\d+\.?\d?) C\)')
-re_DewC = re.compile(r'Dew.*\((-?\d+\.?\d?) C\)')
+re_C = re.compile(r'Temperature:\s*[0-9]*\s*[F]*\s*\((-?\d+\.?\d?) C\)')
+re_DewC = re.compile(r'Dew.*:\s*[0-9]*\s*[F]*\s*\((-?\d+\.?\d?) C\)')
 
 code = sys.argv[0][(sys.argv[0].rfind('_') + 1):]
 

--- a/plugins/weather/weather_temp_
+++ b/plugins/weather/weather_temp_
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-munin US NOAA weather plugin (http://tgftp.nws.noaa.gov)
+munin US NOAA weather plugin (https://tgftp.nws.noaa.gov)
 
 Draws temperature/dew point in C.
 Copy/link file as 'weather_temp_CODE', like: weather_temp_LOWW for Austria, Vienna.
 
-Get the code by going to http://tgftp.nws.noaa.gov, selecting your
+Get the code by going to https://tgftp.nws.noaa.gov, selecting your
 location, and copying the code from the address bar of your browser; should
 be something like CODE.html.
 
@@ -16,7 +16,7 @@ import sys
 from urllib.request import urlopen
 import re
 
-url = 'http://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT'
+url = 'https://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT'
 
 re_C = re.compile(r'Temperature:.*\((-?\d+\.?\d?) C\)')
 re_DewC = re.compile(r'Dew.*\((-?\d+\.?\d?) C\)')


### PR DESCRIPTION
This fixes a few bugs in the noaa.gov based weather plugins and adds a new one for humidity.

There was an issue with the read function of urllib returning an object, which got handled as a string afterwards. This caused issues:

```
Traceback (most recent call last):
  File "/tmp/weather/./weather_press_LOWW", line 43, in <module>
    hpa = re_hpa.findall(txt)[0]
TypeError: cannot use a string pattern on a bytes-like object
```

While implicit string casting might work, it's better to do so explicitly. This avoids said bug.

There was another bug in the temperature plugin, that didn't occur every time. It caused the temperature be set to the same value as the dew point. Turned out that, for some reasons, linebreaks were handled differently from time to time. Improving the RegEx to be more specific helped with that.

While at it, I changed the URL to include TLS connections. It's 2023 and `https` should really be the norm, rather than be the exception.

There's also a new plugin `weather_hum_` that monitors the humidity. It is basically a copy&paste from the other two plugins and works quite the same way. While working on the other plugins, I just saw the opportunity for scoring an additional metric without much work.

Changes:
- Fix bug by casting url-read object to string in `weather_press_` and `weather_temp_` plugins
- Use `https` connections instead of insecure `http`
- Fix big in `weather_temp_` causing temperature to be the same as dew point
- Add new plugin `weather_hum_` to monitor humidity