### PR TITLE
Cater for newer OS dependencies - python and ceph updates

### DIFF
--- a/plugins/ceph/ceph-osd-info
+++ b/plugins/ceph/ceph-osd-info
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 : << =cut
@@ -96,9 +96,10 @@ def read_osd(filename):
 		try:
 			s=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM)
 			s.connect(filename)
-			s.send("{\"prefix\": \"perf dump\"}\0")
+			s.send(b'{"prefix": "perf dump"}\0')
 			result=s.recv(102400)
 			result=result[4:]
+			result=result.decode('utf-8')
 			return json.loads(result)
 		except:
 			pass
@@ -134,7 +135,7 @@ osds.sort()
 for key in osds:
 	data[key]=collapse_one(data[key])
 
-graphlist=[item[1].keys() for item in data.items()]+settings_graph.keys()
+graphlist=[item[1].keys() for item in data.items()]+list(settings_graph.keys())
 graphlist=list(set(itertools.chain(*graphlist)))
 
 if (sys.argv.__len__()>1) and (sys.argv[1]=="config"):
@@ -149,26 +150,26 @@ if (sys.argv.__len__()>1) and (sys.argv[1]=="config"):
 		gr_pretty=graph.replace("_"," ").title()
 		gr=graph.replace("-","_").replace(":","_")
 		graphdefaults={"graph_title":gr_pretty,"graph_vlabel":gr_pretty,"graph_category":"fs"}
-		graphsettings=dict(graphdefaults.items()+graphsettings.items())
-		print "multigraph %s" % (gr_simple)
-		print "\n".join(["%s %s" % setting for setting in graphsettings.items()])
+		graphsettings=dict(list(graphdefaults.items())+list(graphsettings.items()))
+		print ("multigraph %s" % (gr_simple))
+		print ("\n".join(["%s %s" % setting for setting in graphsettings.items()]))
 		for osd in sortlist(data.keys()):
-			print "osd%s_%s.label osd %s" % (osd,gr_simple,osd)
+			print ("osd%s_%s.label osd %s" % (osd,gr_simple,osd))
 		if subgraphs:
 			for osd in sortlist(data.keys()):
-				print "multigraph %s.osd%s" % (gr_simple,osd)
-				thisrecord=dict(graphsettings.items()+[("graph_title","%s - OSD %s" % (graphsettings["graph_title"],osd),)])
+				print ("multigraph %s.osd%s" % (gr_simple,osd))
+				thisrecord=dict(list(graphsettings.items())+[("graph_title","%s - OSD %s" % (graphsettings["graph_title"],osd),)])
 				#print thisrecord
 				if ("%s.osd*" % (graph) in settings_graph):
 					thisrecord=dict(thisrecord.items()+settings_graph["%s.osd%s" % (graph,osd)].items())
 				if ("%s.osd%s" % (graph,osd) in settings_graph):
 					thisrecord=dict(thisrecord.items()+settings_graph["%s.osd%s" % (graph,osd)].items())
-				print "\n".join(["%s %s" % setting for setting in thisrecord.items()])
-				print "osd%s_%s.label osd %s" % (osd,gr_simple,osd)
+				print ("\n".join(["%s %s" % setting for setting in thisrecord.items()]))
+				print ("osd%s_%s.label osd %s" % (osd,gr_simple,osd))
 else:
 	for graph in graphlist:
 		gr=graph.replace("-","_").replace(":","_")
-		print "multigraph %s" % gr
+		print ("multigraph %s" % gr)
 		for osd in osds:
 			if type(data[osd][graph])==dict:
 				if data[osd][graph]["avgcount"]==0:
@@ -177,8 +178,8 @@ else:
 					data[osd][graph]=float(data[osd][graph]["sum"])/float(data[osd][graph]["avgcount"])
 		for osd in osds:
 			value=data[osd][graph]
-			print "osd%s_%s.value %s" % (osd,gr,data[osd][graph])
+			print ("osd%s_%s.value %s" % (osd,gr,data[osd][graph]))
 		if subgraphs:
 			for osd in osds:
-				print "multigraph %s.osd%s" % (gr,osd)
-				print "osd%s_%s.value %s" % (osd,gr,data[osd][graph])
+				print ("multigraph %s.osd%s" % (gr,osd))
+				print ("osd%s_%s.value %s" % (osd,gr,data[osd][graph]))

--- a/plugins/ceph/ceph_capacity
+++ b/plugins/ceph/ceph_capacity
@@ -35,6 +35,8 @@ fi
 WARNING_LEVEL=${warning_level:-"80"}
 CRITICAL_LEVEL=${critical_level:-"90"}
 
+CEPH_STATUS=$(ceph -s --format=json)
+
 if [ "$1" = "config" ]; then
 
 	echo 'graph_title CEPH capacity'
@@ -43,7 +45,7 @@ if [ "$1" = "config" ]; then
 	echo 'graph_info CEPH cluster capacity'
 	echo 'graph_args --base 1000 -l 0'
 
-	CAPACITY=$(ceph -s | grep pgmap | cut -d ';' -f 2 | cut -d ',' -f 3 | cut -d '/' -f 2 | awk '{ print $1 }')
+	CAPACITY=$(echo "$CEPH_STATUS" | jq '.pgmap.bytes_total')
 	WARNING=$(echo "scale=2;$CAPACITY * ($WARNING_LEVEL/100)" | bc -l | cut -d '.' -f 1)
 	CRITICAL=$(echo "scale=2;$CAPACITY * ($CRITICAL_LEVEL/100)" | bc -l | cut -d '.' -f 1)
 	echo "capacity.label Capacity"
@@ -57,6 +59,6 @@ if [ "$1" = "config" ]; then
 	exit 0
 fi
 
-echo "capacity.value $(ceph -s | grep pgmap | cut -d ';' -f 2 | cut -d ',' -f 3 | cut -d '/' -f 2 | awk '{ print $1 }')"
-echo "used.value $(ceph -s | grep pgmap | cut -d ';' -f 2 | cut -d ',' -f 2 | awk '{ print $1 }')"
-echo "data.value $(ceph -s | grep pgmap | cut -d ';' -f 2 | cut -d ',' -f 1 | awk '{ print $1 }')"
+echo "capacity.value $(echo "$CEPH_STATUS" | jq '.pgmap.bytes_total')"
+echo "used.value     $(echo "$CEPH_STATUS" | jq '.pgmap.bytes_used')"
+echo "data.value     $(echo "$CEPH_STATUS" | jq '.pgmap.data_bytes')"  # no idea of the intention of this metric; could be bytes_avail

--- a/plugins/ceph/ceph_osd
+++ b/plugins/ceph/ceph_osd
@@ -50,6 +50,6 @@ fi
 
 CEPH_STATUS=$(ceph -s --format=json)
 
-echo "osds.value $(echo "$CEPH_STATUS" | jq '.osdmap.osdmap.num_osds')"
-echo "up.value $(echo "$CEPH_STATUS" | jq '.osdmap.osdmap.num_up_osds')"
-echo "in.value $(echo "$CEPH_STATUS" | jq '.osdmap.osdmap.num_in_osds')"
+echo "osds.value $(echo "$CEPH_STATUS" | jq '.osdmap.num_osds')"
+echo "up.value $(echo "$CEPH_STATUS" | jq '.osdmap.num_up_osds')"
+echo "in.value $(echo "$CEPH_STATUS" | jq '.osdmap.num_in_osds')"


### PR DESCRIPTION
system default python is now usually python3 - better make our code compliant with it

`ceph` CLI itself has some slightly different usage and outputs

jq used instead of cut in a few places, because was easier to work out what the original commands were intending to grab, now that those outputs have moved location.  Yes, jq is a new dependency for some of the plugins, but it was already implicitly depended upon in ceph_osd plugin