### PR TITLE
documentation fix for critical threshold for nutups2_ plugin

### DIFF
--- a/plugins/power/nutups2_
+++ b/plugins/power/nutups2_
@@ -25,8 +25,8 @@ used to set the defaults for all fields:
 
 You can also control individual fields like:
 
-    env.input_L1.warning
-    env.output.critical
+    env.input_L1_warning
+    env.output_critical
 
 =head1 MAGIC MARKERS
 


### PR DESCRIPTION
Wrong format for setting the environment for critical and warning thresholds.  Adjusted and tested via making sure limits are updated in config run of `nutups2_powershield-commander_voltage config`

```ini
[nutups2_powershield-commander*]
env.battery_critical 20.8:27.5
```