### PR TITLE
kea: fix autoconf, it always returned "yes"

### DIFF
--- a/plugins/dhcp/kea
+++ b/plugins/dhcp/kea
@@ -186,7 +186,7 @@ def fetch(data):
 
 if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1] == 'autoconf':
-        print('yes' if read_data() else 'no (no Kea statistics)')
+        print('yes' if read_data()[0] else 'no (no Kea statistics)')
     elif len(sys.argv) > 1 and sys.argv[1] == 'config':
         config(read_data())
     else:


### PR DESCRIPTION
I changed read_data's return value after testing autoconf. Oops...