### PR TITLE
process_group: fix bug caused by auto-indent

### DIFF
--- a/plugins/cpu/process_group
+++ b/plugins/cpu/process_group
@@ -191,7 +191,7 @@ def fetch():
     for group, values in data.items():
         print(f'{safename(group)}.value {values["cpu"]}')
 
-        print('multigraph process_group_count')
+    print('multigraph process_group_count')
     for group, values in data.items():
         print(f'{safename(group)}.value {values["count"]}')
 


### PR DESCRIPTION
Plugin printed wrong values if multiple groups were defined.