### PR TITLE
chrony_status: fix reboot-workaround, value is str not int

### DIFF
--- a/plugins/chrony/chrony_status
+++ b/plugins/chrony/chrony_status
@@ -177,7 +177,7 @@ def fetch():
     values = get_values()
     for graph in GRAPHS:
         print('multigraph chrony_{}'.format(graph))
-        if graph == 'stratum' and values[graph] == 0:
+        if graph == 'stratum' and values[graph] == '0':
             print('{}.value U'.format(graph))
         elif graph == 'serverstats':
             for stat in SERVERSTATS:


### PR DESCRIPTION
After reboot stratum is 0 for a very short period of time. Convert it to U. Include unknown_limit to config to not send warning email.

I finally found a server where this workaround was needed.