### PR TITLE
Add switch and dimmer state capability for tasmota plugin

### DIFF
--- a/plugins/power/tasmota_
+++ b/plugins/power/tasmota_
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 : << =cut
 
@@ -54,7 +54,7 @@ get_status() {
             cached_curl='{}'
         fi
     fi
-    res=$( echo "$cached_curl" | jq -c "$2" )
+    res=$( echo "$cached_curl" | jq -c -r "$2" )
     if [ "$res" = null ] ; then
         res=U
     fi
@@ -101,6 +101,16 @@ if [ "$1" = "suggest" ]; then
     done
     nodeattr -n '(tasmota || beken) && millivolts' | while read -r device ; do
         for i in millivolts ; do
+            echo "${device}_${i}"
+        done
+    done
+    nodeattr -n '(tasmota || beken) && switch' | while read -r device ; do
+        for i in switch ; do
+            echo "${device}_${i}"
+        done
+    done
+    nodeattr -n '(tasmota || beken) && dimmer' | while read -r device ; do
+        for i in dimmer ; do
             echo "${device}_${i}"
         done
     done
@@ -269,8 +279,101 @@ millivolts() {
     fi
 }
 
+switch() {
+    if [ "$1" = "config" ]; then
+        echo "graph_title Tasmota Switch: $DEVICE"
+        echo "graph_args --base 1000 -l 0"
+
+        for v in POWER POWER{1,2,3,4,5,6,7,8,9} ; do
+            axis=$( echo "$v" | cut -d= -f 1 )
+            lab=$( echo "$v" | cut -d= -f 2 )
+            get_status 11 ".StatusSTS.$v"
+            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
+                # if we've ever seen an axis, then we want to keep
+                # telling munin we are capable of reading that axis,
+                # even if the device is currently unpowered
+                mkdir -p $MUNIN_PLUGSTATE/tasmota
+                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+
+                echo "$axis.label $lab"
+                echo "$axis.type GAUGE"
+                echo "$axis.min 0"
+            fi
+        done
+    else
+        for v in POWER POWER{1,2,3,4,5,6,7,8,9} ; do
+            axis=$( echo "$v" | cut -d= -f 1 )
+            lab=$( echo "$v" | cut -d= -f 2 )
+            get_status 11 ".StatusSTS.$v"
+            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
+                # if we've ever seen an axis, then we want to keep
+                # telling munin we are capable of reading that axis,
+                # even if the device is currently unpowered
+                mkdir -p $MUNIN_PLUGSTATE/tasmota
+                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+
+                case "$res" in
+                    ON)
+                        res=1
+                        ;;
+                    OFF)
+                        res=0
+                        ;;
+                    U) # assume off, since if it doesn't have power to get wifi, then it's not going to have power output
+                        res=0
+                        ;;
+                esac
+
+                echo "$axis.value $res"
+            fi
+        done
+    fi
+}
+
+dimmer() {
+    if [ "$1" = "config" ]; then
+        echo "graph_title Tasmota Dimmer: $DEVICE"
+        echo "graph_args --base 1000 -l 0"
+
+        for v in Channel{1,2,3,4} ; do
+            axis=$( echo "$v" | cut -d= -f 1 )
+            lab=$( echo "$v" | cut -d= -f 2 )
+            get_status 11 ".StatusSTS.$v"
+            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
+                # if we've ever seen an axis, then we want to keep
+                # telling munin we are capable of reading that axis,
+                # even if the device is currently unpowered
+                mkdir -p $MUNIN_PLUGSTATE/tasmota
+                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+
+                echo "$axis.label $lab"
+                echo "$axis.type GAUGE"
+                echo "$axis.min 0"
+            fi
+        done
+    else
+        for v in Channel{1,2,3,4} ; do
+            axis=$( echo "$v" | cut -d= -f 1 )
+            lab=$( echo "$v" | cut -d= -f 2 )
+            get_status 11 ".StatusSTS.$v"
+            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
+                # if we've ever seen an axis, then we want to keep
+                # telling munin we are capable of reading that axis,
+                # even if the device is currently unpowered
+                mkdir -p $MUNIN_PLUGSTATE/tasmota
+                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+
+                if [ "$res" = U ] ; then
+                    res=0 # assume 0 power, since if it doesn't have power to get wifi, then it's not going to have power output
+                fi
+                echo "$axis.value $res"
+            fi
+        done
+    fi
+}
+
 case "$FUNCTION" in
-    voltage|power|powerfactor|current|energy|DS18B20|SCD40|PMS5003|millivolts)
+    voltage|power|powerfactor|current|energy|DS18B20|SCD40|PMS5003|millivolts|switch|dimmer)
         $FUNCTION "$1"
         ;;
     *)

--- a/plugins/power/tasmota_
+++ b/plugins/power/tasmota_
@@ -283,35 +283,25 @@ switch() {
     if [ "$1" = "config" ]; then
         echo "graph_title Tasmota Switch: $DEVICE"
         echo "graph_args --base 1000 -l 0"
+    fi
 
-        for v in POWER POWER{1,2,3,4,5,6,7,8,9} ; do
-            axis=$( echo "$v" | cut -d= -f 1 )
-            lab=$( echo "$v" | cut -d= -f 2 )
-            get_status 11 ".StatusSTS.$v"
-            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
-                # if we've ever seen an axis, then we want to keep
-                # telling munin we are capable of reading that axis,
-                # even if the device is currently unpowered
-                mkdir -p $MUNIN_PLUGSTATE/tasmota
-                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+    for v in POWER POWER{1,2,3,4,5,6,7,8,9} ; do
+        axis=$( echo "$v" | cut -d= -f 1 )
+        lab=$(  echo "$v" | cut -d= -f 2 )
+        get_status 11 ".StatusSTS.$v"
 
+        if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
+            # if we've ever seen an axis, then we want to keep
+            # telling munin we are capable of reading that axis,
+            # even if the device is currently unpowered
+            mkdir -p $MUNIN_PLUGSTATE/tasmota
+            touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+
+            if [ "$1" = "config" ]; then
                 echo "$axis.label $lab"
                 echo "$axis.type GAUGE"
                 echo "$axis.min 0"
-            fi
-        done
-    else
-        for v in POWER POWER{1,2,3,4,5,6,7,8,9} ; do
-            axis=$( echo "$v" | cut -d= -f 1 )
-            lab=$( echo "$v" | cut -d= -f 2 )
-            get_status 11 ".StatusSTS.$v"
-            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
-                # if we've ever seen an axis, then we want to keep
-                # telling munin we are capable of reading that axis,
-                # even if the device is currently unpowered
-                mkdir -p $MUNIN_PLUGSTATE/tasmota
-                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
-
+            else
                 case "$res" in
                     ON)
                         res=1
@@ -326,50 +316,41 @@ switch() {
 
                 echo "$axis.value $res"
             fi
-        done
-    fi
+        fi
+    done
 }
 
 dimmer() {
     if [ "$1" = "config" ]; then
         echo "graph_title Tasmota Dimmer: $DEVICE"
         echo "graph_args --base 1000 -l 0"
+    fi
 
-        for v in Channel{1,2,3,4} ; do
-            axis=$( echo "$v" | cut -d= -f 1 )
-            lab=$( echo "$v" | cut -d= -f 2 )
-            get_status 11 ".StatusSTS.$v"
-            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
-                # if we've ever seen an axis, then we want to keep
-                # telling munin we are capable of reading that axis,
-                # even if the device is currently unpowered
-                mkdir -p $MUNIN_PLUGSTATE/tasmota
-                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+    for v in Channel{1,2,3,4} ; do
+        axis=$( echo "$v" | cut -d= -f 1 )
+        lab=$(  echo "$v" | cut -d= -f 2 )
+        get_status 11 ".StatusSTS.$v"
 
+        if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
+            # if we've ever seen an axis, then we want to keep
+            # telling munin we are capable of reading that axis,
+            # even if the device is currently unpowered
+            mkdir -p $MUNIN_PLUGSTATE/tasmota
+            touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
+
+            if [ "$1" = "config" ]; then
                 echo "$axis.label $lab"
                 echo "$axis.type GAUGE"
                 echo "$axis.min 0"
-            fi
-        done
-    else
-        for v in Channel{1,2,3,4} ; do
-            axis=$( echo "$v" | cut -d= -f 1 )
-            lab=$( echo "$v" | cut -d= -f 2 )
-            get_status 11 ".StatusSTS.$v"
-            if [ "$res" != U ] || [ -e $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen ] ; then
-                # if we've ever seen an axis, then we want to keep
-                # telling munin we are capable of reading that axis,
-                # even if the device is currently unpowered
-                mkdir -p $MUNIN_PLUGSTATE/tasmota
-                touch $MUNIN_PLUGSTATE/tasmota/$DEVICE.$FUNCTION.$v.seen
-
+            else
                 if [ "$res" = U ] ; then
                     res=0 # assume 0 power, since if it doesn't have power to get wifi, then it's not going to have power output
                 fi
+
                 echo "$axis.value $res"
             fi
-        done
-    fi
+        fi
+    done
 }
 
 case "$FUNCTION" in

--- a/plugins/power/tasmota_
+++ b/plugins/power/tasmota_
@@ -79,27 +79,27 @@ if [ "$1" = "autoconf" ]; then
 fi
 
 if [ "$1" = "suggest" ]; then
-    nodeattr -n 'tasmota&&powermon' | while read -r device ; do
+    nodeattr -n '(tasmota || beken) && powermon' | while read -r device ; do
         for i in voltage power powerfactor current energy ; do
             echo "${device}_${i}"
         done
     done
-    nodeattr -n 'tasmota&&DS18B20' | while read -r device ; do
+    nodeattr -n '(tasmota || beken) && DS18B20' | while read -r device ; do
         for i in DS18B20 ; do
             echo "${device}_${i}"
         done
     done
-    nodeattr -n 'tasmota&&SCD40' | while read -r device ; do
+    nodeattr -n '(tasmota || beken) && SCD40' | while read -r device ; do
         for i in SCD40 ; do
             echo "${device}_${i}"
         done
     done
-    nodeattr -n 'tasmota&&PMS5003' | while read -r device ; do
+    nodeattr -n '(tasmota || beken) && PMS5003' | while read -r device ; do
         for i in PMS5003 ; do
             echo "${device}_${i}"
         done
     done
-    nodeattr -n 'tasmota&&millivolts' | while read -r device ; do
+    nodeattr -n '(tasmota || beken) && millivolts' | while read -r device ; do
         for i in millivolts ; do
             echo "${device}_${i}"
         done


### PR DESCRIPTION
Outputs current switch state for tasmota switches (including multi switches if present) and tasmota dimmers (including multiple channels if present)