### PR TITLE
Fix pdns_rel to always have correct output

### DIFF
--- a/plugins/pdns/pdns_rel
+++ b/plugins/pdns/pdns_rel
@@ -49,6 +49,8 @@ if [ -f "$state_file" ] && [ "$(stat --format=%Y "$state_file")" -gt "$(date --d
         d_queries=$((queries - old_queries))
         if [ $d_queries -gt 0 ] ; then
            echo packetcache_hitrate.value $(( d_hits * 100 / d_queries ))
+        else
+           echo packetcache_hitrate.value 0
         fi
 fi
 


### PR DESCRIPTION
Fix the condition to not return any values when there were no queries to the server since the last call. Return a 0 as cache hit rate in that case.