### PR TITLE
network: Fix sscanf format warnings

### DIFF
--- a/plugins/network/if1sec-c.c
+++ b/plugins/network/if1sec-c.c
@@ -184,8 +184,8 @@ int acquire() {
 			if (nif ++ < 0) { continue; }
 
 			char if_id[64];
-			uint_fast64_t r_bytes, r_packets, r_errs, r_drop, r_fifo, r_frame, r_compressed, r_multicast;
-			uint_fast64_t t_bytes, t_packets, t_errs, t_drop, t_fifo, t_frame, t_compressed, t_multicast;
+			unsigned long long r_bytes, r_packets, r_errs, r_drop, r_fifo, r_frame, r_compressed, r_multicast;
+			unsigned long long t_bytes, t_packets, t_errs, t_drop, t_fifo, t_frame, t_compressed, t_multicast;
 			sscanf(line, "%s"
 				" "
 				"%llu %llu %llu %llu %llu %llu %llu %llu"


### PR DESCRIPTION
Compilers warn that "`%llu`" doesn't match the `uint_fast64_t` type for all machines.

These are just being `sscanf()`'ed to be `sprintf()`'ed a few lines later, there's no need for performance.  These can just be vanilla "`unsigned long long`"'s to match the existing format specifiers.

Example of compiler warning:
```
if1sec-c.c: In function 'acquire':
if1sec-c.c:189:38: warning: format '%llu' expects argument of type 'long long unsigned int *', but argument 4 has type 'uint_fast64_t *' {aka 'long unsigned int *'} [-Wformat=]
  189 |                         sscanf(line, "%s"
      |                                      ^~~~
......
  195 |                                 , &r_bytes, &r_packets, &r_errs, &r_drop, &r_fifo, &r_frame, &r_compressed, &r_multicast
      |                                   ~~~~~~~~
      |                                   |
      |                                   uint_fast64_t * {aka long unsigned int *}
```