### PR TITLE
Fix for checking installed and updateable apps

### DIFF
--- a/plugins/nextcloud/nextcloud_
+++ b/plugins/nextcloud/nextcloud_
@@ -60,7 +60,7 @@ if [ "${MUNIN_DEBUG:-0}" = 1 ]; then
     set -x
 fi
 
-API_PATH="${api_path:-/ocs/v2.php/apps/serverinfo/api/v1/info}?format=json"
+API_PATH="${api_path:-/ocs/v2.php/apps/serverinfo/api/v1/info}?format=json&skipApps=false"
 DOMAIN="${0##*nextcloud_}"
 SCHEME="${scheme:-https}://"
 TIMEOUT="${timeout:-2}"


### PR DESCRIPTION
After nextcloud version 28 the installed and updateable apps aren't listed anymore by default in serverinfo, see https://docs.nextcloud.com/server/stable/admin_manual/release_notes/upgrade_to_28.html#monitoring

The documentation says _However, please do not check this endpoint too often._. Presuming that every five minutes is _not too often_, appending `&skipApps=false` to the `API_PATH` is including the apps information again.