### PR TITLE
Adding active peer information into wireguard_ plugin

### DIFF
--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -124,6 +124,9 @@ EOF
 pc_on_$iface.label $iface
 pc_on_$iface.info Interface $iface
 pc_on_$iface.min 0
+pc_on_active_$iface.label Active on $iface
+pc_on_active_$iface.info Active on $iface
+pc_on_active_$iface.min 0
 EOF
         done
         echo ""
@@ -165,7 +168,17 @@ EOF
         # Collect & print current monitoring values
         echo "multigraph wireguard_peercount"
         for iface in $(wg_interfaces); do
+	    threshold=$(date --date="10 min ago" +%s)
+	    isactive=0
+	    for line in $(wg_peers "$iface"); do
+	        handshake=$(echo "$line" | tr ';' ' ' | awk '{print $5}')
+		if [[ "handshake" -gt "threshold" ]]; then
+		    isactive=$((isactive + 1))
+		fi
+	    done
+
             echo "pc_on_$iface.value $(wg show "$iface" peers | wc -l)"
+            echo "pc_on_active_$iface.value $isactive"
         done
         echo ""
 

--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -169,16 +169,13 @@ EOF
         echo "multigraph wireguard_peercount"
         for iface in $(wg_interfaces); do
 	    threshold=$(date --date="10 min ago" +%s)
-	    isactive=0
-	    for line in $(wg_peers "$iface"); do
-	        handshake=$(echo "$line" | tr ';' ' ' | awk '{print $5}')
-		if [[ "handshake" -gt "threshold" ]]; then
-		    isactive=$((isactive + 1))
-		fi
-	    done
+            iface_peers=$(wg_peers "$iface")
 
-            echo "pc_on_$iface.value $(wg show "$iface" peers | wc -l)"
-            echo "pc_on_active_$iface.value $isactive"
+            peer_count=$(wc -l <<< "$iface_peers")
+            active_peer_count=$(awk -F";" -v threshold=$active_threshold '$5 > threshold' <<< "$iface_peers" | wc -l)
+
+            echo "pc_on_$iface.value $peer_count"
+            echo "pc_active_on_$iface.value $active_peer_count"
         done
         echo ""
 

--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -11,7 +11,9 @@ wireguard_ - Wildcard-plugin to monitor wireguard peer count and traffic
 
 =head1 CONFIGURATION
 
-This plugin does not normally require configuration.
+The following environment variables are used by this plugin
+
+ active_threshold_m       - threshold to count the connection as inactive (default 3 minutes)
 
 The plugin needs to run as root to be able to call the wg show
 command.  This is configured like this:
@@ -124,9 +126,9 @@ EOF
 pc_on_$iface.label $iface
 pc_on_$iface.info Interface $iface
 pc_on_$iface.min 0
-pc_on_active_$iface.label Active on $iface
-pc_on_active_$iface.info Active on $iface
-pc_on_active_$iface.min 0
+apc_on_$iface.label Active on $iface
+apc_on_$iface.info Active on $iface
+apc_on_$iface.min 0
 EOF
         done
         echo ""
@@ -167,15 +169,16 @@ EOF
     *)
         # Collect & print current monitoring values
         echo "multigraph wireguard_peercount"
+	active_threshold=$(date --date="${active_threshold_m:-3} min ago" +%s)
+
         for iface in $(wg_interfaces); do
-	    threshold=$(date --date="10 min ago" +%s)
             iface_peers=$(wg_peers "$iface")
 
             peer_count=$(wc -l <<< "$iface_peers")
             active_peer_count=$(awk -F";" -v threshold=$active_threshold '$5 > threshold' <<< "$iface_peers" | wc -l)
 
             echo "pc_on_$iface.value $peer_count"
-            echo "pc_active_on_$iface.value $active_peer_count"
+            echo "apc_on_$iface.value $active_peer_count"
         done
         echo ""
 


### PR DESCRIPTION
Enhancing the wireguard_ plugin in Munin by adding active peer information based on the latest handshake timestamp. This addition provides insights into ongoing connections. The decision to use a 10-minute interval balances the need for accuracy with minimizing data fluctuations. This enhancement improves monitoring capabilities and contributes to a more comprehensive overview of WireGuard activity.