### PR TITLE
nvme: fix handling namespaces prefixed with 0x

### DIFF
--- a/plugins/disk/nvme
+++ b/plugins/disk/nvme
@@ -160,6 +160,10 @@ sub nvme_list {
     # --------------------- --------------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
     # /dev/nvme1n1          /dev/ng1n1            23103F009522         Micron_3400_MTFDKBA1T0TFH                1           1.02  TB /   1.02  TB    512   B +  0 B   P7MU002
     # /dev/nvme0n1          /dev/ng0n1            23103F00956D         Micron_3400_MTFDKBA1T0TFH                1           1.02  TB /   1.02  TB    512   B +  0 B   P7MU002
+    # version 2.5 (Namespace prefixed with 0x)
+    # Node                  Generic               SN                   Model                                    Namespace  Usage                      Format           FW Rev
+    # --------------------- --------------------- -------------------- ---------------------------------------- ---------- -------------------------- ---------------- --------
+    # /dev/nvme0n1          /dev/ng0n1            50026B7684E7EA69     KINGSTON SKC2500M82000G                  0x1          1,36  TB /   2,00  TB    512   B +  0 B   S7781101
     my %devices;
 
     my $recognised_output;
@@ -172,7 +176,7 @@ sub nvme_list {
         } elsif (m:^Node\s+Generic\s+SN\s+Model\s+Namespace\s+Usage\s+:) {
             # version 2 header
             ++$recognised_output;
-        } elsif (m:^(/\S+)\s+(/\S+)\s+(\S+)\s+(\S.*\S)\s{3,}(\d+)\s+(\S+\s+.B)\s+/\s+(\S+\s+.B):) {
+        } elsif (m:^(/\S+)\s+(/\S+)\s+(\S+)\s+(\S.*\S)\s{3,}((0x)?\d+)\s+(\S+\s+.B)\s+/\s+(\S+\s+.B):) {
             # version 2 data (first 2 columns start with /)
             $devices{'SN_'.$3} = {
                 device    => $1,


### PR DESCRIPTION
On my Ubuntu 23.10 the Namespace in `nvme list` is now prefixed with 0x.

`nvme --version`: nvme version 2.5 (git 2.5)

Info @wt-io-it