### PR TITLE
nginx_vhost_traffic: Fix typo aggregate

### DIFF
--- a/plugins/nginx/nginx_vhost_traffic
+++ b/plugins/nginx/nginx_vhost_traffic
@@ -35,7 +35,7 @@ ACCESS_LOG=$LOGDIR/${logfile:-access.log}
 LOGTAIL=${logtail:-`which logtail`}
 STATEFILE=$MUNIN_PLUGSTATE/nginx_vhost_traffic.state
 VHOSTS=${vhosts:-`hostname`}
-AGGREGATE=${aggregate:true}
+AGGREGATE=${aggregate:-true}
 
 BPARAM=${bparam:-11}
 


### PR DESCRIPTION
Otherwise:

```console
$ ./nginx_vhost_traffic
./nginx_vhost_traffic: 38: Bad substitution
```