### PR TITLE
Fix nvme always reporting 0 usage.

### DIFF
--- a/plugins/disk/nvme
+++ b/plugins/disk/nvme
@@ -89,7 +89,7 @@ None known.
 
 =head1 VERSION
 
-  1.1
+  1.2
 
 =head1 AUTHOR
 
@@ -176,7 +176,7 @@ sub nvme_list {
         } elsif (m:^Node\s+Generic\s+SN\s+Model\s+Namespace\s+Usage\s+:) {
             # version 2 header
             ++$recognised_output;
-        } elsif (m:^(/\S+)\s+(/\S+)\s+(\S+)\s+(\S.*\S)\s{3,}((0x)?\d+)\s+(\S+\s+.B)\s+/\s+(\S+\s+.B):) {
+        } elsif (m|^(/\S+)\s+(/\S+)\s+(\S+)\s+(\S.*\S)\s{3,}((?:0x)?\d+)\s+(\S+\s+.B)\s+/\s+(\S+\s+.B)|) {
             # version 2 data (first 2 columns start with /)
             $devices{'SN_'.$3} = {
                 device    => $1,


### PR DESCRIPTION
the previous commit 2eab6784c052335efa1a58c97ce2827970dbf2fc introduced an issue because it used a capturing group for 0x. All groups after this were off by one then and the usage always reported as 0.

Unfortunately i only noticed this today because a few servers i have a warning when nvme reported usage is 0.

Info @wt-io-it