### PR TITLE
ping: Use better default values in case of failure

### DIFF
--- a/plugins/ping/ping
+++ b/plugins/ping/ping
@@ -179,8 +179,8 @@ for (my $host_i = 0; $host_i < @host_addrs; ++$host_i) {
 				my @ping = `$h_ping $ping_args $h_addr $ping_args2`;
 				chomp @ping;
 				my $ping = join(" ", @ping);
-				my $ping_time = "U";
-				my $packet_loss = "U";
+				my $ping_time = "NaN";
+				my $packet_loss = "100";
 				$ping_time = ($1 / 1000) if ($ping =~ m@min/avg/max.*\s\d+(?:\.\d+)?/(\d+(?:\.\d+)?)/\d+(?:\.\d+)?@);
 				$packet_loss = $1 if ($ping =~ /(\d+)% packet loss/);
 				print "$h_norm_name.value ". ($packetloss_mode ? $packet_loss : $ping_time) . "\n";


### PR DESCRIPTION
When the ping fails (e.g. unresolvable name, complete probe loss, or any other system error), the default value for ping time and packet loss is currently "U".  This is not very numeric-friendly.

Instead, let's use "NaN" by default for ping times, and "100%" by default for packet loss.