### PR TITLE
[systemd_units] fix missing failed units

### DIFF
--- a/plugins/systemd/systemd_units
+++ b/plugins/systemd/systemd_units
@@ -24,7 +24,7 @@ states have default levels set.)
 Value calculations for each state are made using the following algorithm (all filters performed using
 C<grep -E>):
 
-1. Global include rules are applied on the output of C<systemctl list-units --all --no-legend>;
+1. Global include rules are applied on the output of C<systemctl list-units --no-pager --no-legend --plain --all>;
 2. Global exclude rules are then applied to the result of that;
 3. Then, for each state, this global output is further filtered by include, then exclude rules for the state;
 4. Then the result is filtered for the given state and the remaining units counted and listed.
@@ -108,7 +108,7 @@ EOF
 fetch () {
 	# Get all units, filtering by global include/exclude rules
 	local state_include_var state_include state_exclude_var state_exclude global_unit_list state_unit_list
-	global_unit_list=$(systemctl --no-pager --no-legend --all | grep -E "$include" | grep -Ev "$exclude" | awk '{print $1, $3}')
+	global_unit_list=$(systemctl --no-pager --no-legend --plain --all | grep -E "$include" | grep -Ev "$exclude" | awk '{print $1, $3}')
 
 	# For each state, echo the number of units and some extra info, filtering for state-specific include/excludes
 	for state in $states ; do


### PR DESCRIPTION
## Goal

- Avoid missing failed units

## Information

`--plain` argument print unit dependencies as a list instead of a tree and avoid showing sometimes colored dot.

This dots are displayed to identify failed units but messed with the awk command, so this failed unit is never seen. With this `--plain` argument, dots are not displayed anymore.

## Example

This example use 3 services: 2 active (`dovecot` and `postfix`) and 1 failed (`fail2ban`).

### Before

```
$ sudo systemctl --no-pager --no-legend --all | grep -E "dovecot.service|fail2ban.service|postfix.service" | awk '{print $1, $3}'
dovecot.service active
● loaded
postfix.service active
```

### After

```
$ sudo systemctl --no-pager --no-legend --plain --all | grep -E "dovecot.service|fail2ban.service|postfix.service" | awk '{print $1, $3}'
dovecot.service active
fail2ban.service failed
postfix.service active
```