### PR TITLE
syslog_ng_stats: mark total counter stats as DERIVE / min 0

### DIFF
--- a/plugins/syslog/syslog_ng_stats
+++ b/plugins/syslog/syslog_ng_stats
@@ -117,6 +117,7 @@ if( exists $ARGV[0] and $ARGV[0] eq "config" ) {
         printf "%s.label %s: %s, %s\n", $id,
             $graph->{source_name},$graph->{source_id}, $graph->{type};
         printf "%s.min 0\n", $id;
+        printf "%s.type DERIVE\n", $id;
     }
 }
 


### PR DESCRIPTION
the data produced by the underlying `syslog-ng-ctl stats` gives the stats values in absolute numbers since the start of the syslog-ng daemon. In order to visualize in a more user friendly way those values are now marked in the config as type DERIVE.

here a comparison.

before the change with absolute values:
![syslog-ng-abs](https://github.com/user-attachments/assets/efa7b40e-3c11-4522-8707-2c85c3ff4e6c)

here with derive:
![grafik](https://github.com/user-attachments/assets/ae8dea69-4ccb-4cfc-aef6-deb511e0862d)
