### PR TITLE
tasmota: introduced incorrect escaping in f1e354eb

### DIFF
--- a/plugins/power/tasmota_
+++ b/plugins/power/tasmota_
@@ -101,7 +101,7 @@ voltage() {
 
         echo "$axis.label Voltage"
     else
-        get_status 8 '.StatusSNS["ENERGY"].Voltage'
+        get_status 8 '.StatusSNS["ENERGY"]'.Voltage
         echo "$axis.value $res"
     fi
 }
@@ -115,7 +115,7 @@ current() {
 
         echo "$axis.label Current"
     else
-        get_status 8 '.StatusSNS["ENERGY"].Current'
+        get_status 8 '.StatusSNS["ENERGY"]'.Current
         echo "$axis.value $res"
     fi
 }
@@ -135,7 +135,7 @@ power() {
         done
     else
         for axis in ApparentPower ReactivePower Power ; do
-            get_status 8 '.StatusSNS["ENERGY"].$axis'
+            get_status 8 '.StatusSNS["ENERGY"]'.$axis
             echo "$axis.value $res"
         done
     fi
@@ -152,7 +152,7 @@ powerfactor() {
         echo "$axis.max 1"
         echo "$axis.label Power Factor"
     else
-        get_status 8 '.StatusSNS["ENERGY"].Factor'
+        get_status 8 '.StatusSNS["ENERGY"]'.Factor
         echo "$axis.value $res"
     fi
 }
@@ -167,7 +167,7 @@ energy() {
         echo "$axis.label Energy"
         echo "$axis.draw AREA"
     else
-        get_status 8 '.StatusSNS["ENERGY"].Total'
+        get_status 8 '.StatusSNS["ENERGY"]'.Total
         echo "$axis.value $res"
     fi
 }
@@ -183,7 +183,7 @@ temperature() {
         echo "$axis.type GAUGE"
         #echo "$axis.min 0"
     else
-        get_status 10 '.StatusSNS["ANALOG"].Temperature1'
+        get_status 10 '.StatusSNS["ANALOG"]'.Temperature1
         echo "$axis.value $res"
     fi
 }
@@ -199,14 +199,14 @@ DS18B20() {
     for i in '' `seq 1 9` ; do
         axis=Temperature$i
         if [ "$1" = "config" ]; then
-            get_status 10 ".StatusSNS[\"DS18B20${i:+-$i}\"].Temperature"
+            get_status 10 ".StatusSNS[\"DS18B20${i:+-$i}\"]".Temperature
             if [ "$res" != U ] ; then
                 echo "$axis.label Temperature${i:+ $i}"
                 echo "$axis.type GAUGE"
                 #echo "$axis.min 0"
             fi
         else
-            get_status 10 ".StatusSNS[\"DS18B20${i:+-$i}\"].Temperature"
+            get_status 10 ".StatusSNS[\"DS18B20${i:+-$i}\"]".Temperature
             if [ "$res" != U ] ; then # should only echo U if there's
                                       # not a valid temperature where
                                       # there once was, but we don't
@@ -228,7 +228,7 @@ SCD40() {
         echo "$axis.label Carbon Dioxide"
         echo "$axis.type GAUGE"
     else
-        get_status 8 '.StatusSNS["SCD40"].CarbonDioxide'
+        get_status 8 '.StatusSNS["SCD40"]'.CarbonDioxide
         echo "$axis.value $res"
     fi
 }
@@ -250,7 +250,7 @@ PMS5003() {
         for v in 'PB1="PB1"' 'PB2_5="PB2.5"' 'PB10="PB10"' ; do
             axis=$( echo "$v" | cut -d= -f 1 )
             field=$( echo "$v" | cut -d= -f 2 )
-            get_status 8 '.StatusSNS["PMS5003"].$field'
+            get_status 8 '.StatusSNS["PMS5003"]'.$field
             echo "$axis.value $res"
         done
     fi
@@ -276,7 +276,7 @@ millivolts() {
         echo "$axis.label V"
         echo "$axis.type GAUGE"
     else
-        get_status 8 '.StatusSNS["ANALOG"].Range'
+        get_status 8 '.StatusSNS["ANALOG"]'.Range
         if [ "$res" != U ] ; then
             res=$( echo "$res" | awk '{printf "%0.3f", $1/1000}' )
         fi


### PR DESCRIPTION
I introduced a quoting error in f1e354eb, particularly '$axis'.  Formatting of all similar lines changed so I don't do it again.