### PR TITLE
bind9_*: update stat_file only if it's older than 4 minutes

### DIFF
--- a/plugins/bind/bind9_resolver_stats
+++ b/plugins/bind/bind9_resolver_stats
@@ -26,11 +26,20 @@ if [ "$rndc" = "" ]; then
 	rndc="/usr/sbin/rndc"
 fi
 
-# Blank the stats file (else stats are appended not replaced)
-rm ${stat_file}
+# only renew stats if older than 4 minutes
+if [ "$refresh_minutes" = "" ]; then
+	refresh_minutes=4
+fi
 
-# Ask to bind to build new one
-${rndc} stats
+if [ "$(find "$(dirname "$stat_file")" -mindepth 1 -maxdepth 1 -cmin -"$refresh_minutes" -name "$(basename "$stat_file")" )" == "" ] ; then
+	if [ -e "${stat_file}" ] ; then
+		# Blank the stats file (else stats are appended not replaced)
+		rm "${stat_file}"
+	fi
+
+	# Ask to bind to build new one
+	${rndc} stats
+fi
 
 # The section we are looking for in the stats.
 section="Resolver Statistics"

--- a/plugins/bind/bind9_server_stats
+++ b/plugins/bind/bind9_server_stats
@@ -26,11 +26,20 @@ if [ "$rndc" = "" ]; then
 	rndc="/usr/sbin/rndc"
 fi
 
-# Blank the stats file (else stats are appended not replaced)
-rm ${stat_file}
+# only renew stats if older than 4 minutes
+if [ "$refresh_minutes" = "" ]; then
+	refresh_minutes=4
+fi
 
-# Ask to bind to build new one
-${rndc} stats
+if [ "$(find "$(dirname "$stat_file")" -mindepth 1 -maxdepth 1 -cmin -"$refresh_minutes" -name "$(basename "$stat_file")" )" == "" ] ; then
+	if [ -e "${stat_file}" ] ; then
+		# Blank the stats file (else stats are appended not replaced)
+		rm "${stat_file}"
+	fi
+
+	# Ask to bind to build new one
+	${rndc} stats
+fi
 
 # The section we are looking for in the stats.
 section="Name Server Statistics"

--- a/plugins/bind/bind9_socket_stats
+++ b/plugins/bind/bind9_socket_stats
@@ -26,11 +26,20 @@ if [ "$rndc" = "" ]; then
 	rndc="/usr/sbin/rndc"
 fi
 
-# Blank the stats file (else stats are appended not replaced)
-rm ${stat_file}
+# only renew stats if older than 4 minutes
+if [ "$refresh_minutes" = "" ]; then
+	refresh_minutes=4
+fi
 
-# Ask to bind to build new one
-${rndc} stats
+if [ "$(find "$(dirname "$stat_file")" -mindepth 1 -maxdepth 1 -cmin -"$refresh_minutes" -name "$(basename "$stat_file")" )" == "" ] ; then
+	if [ -e "${stat_file}" ] ; then
+		# Blank the stats file (else stats are appended not replaced)
+		rm "${stat_file}"
+	fi
+
+	# Ask to bind to build new one
+	${rndc} stats
+fi
 
 # The section we are looking for in the stats.
 section="Socket I/O Statistics"


### PR DESCRIPTION
when having all 3 plugins enabled this cuts down the number of rndc stats dumps from 6 to 1 per munin node update

info @wt-io-it