### PR TITLE
php_apc: fix DivisionByZeroError when hits + misses = 0

### DIFF
--- a/plugins/php/php_apc.php
+++ b/plugins/php/php_apc.php
@@ -29,8 +29,14 @@ if(!empty($apc_fn_name))
       $tmp =  call_user_func($apc_fn_name . "_sma_info");
       $ret["memory"] = 100-(($tmp["avail_mem"] / $tmp["seg_size"])*100);
       $tmp = apcu_cache_info();
-      $ret["hits"] = ($tmp["num_hits"] / ( $tmp["num_hits"]+$tmp["num_misses"]) ) * 100;
-      $ret["misses"] = ($tmp["num_misses"] / ( $tmp["num_hits"]+$tmp["num_misses"]) ) * 100;
+      if (($tmp["num_hits"]+$tmp["num_misses"]) > 0)
+      {
+          $ret["hits"] = ($tmp["num_hits"] / ( $tmp["num_hits"]+$tmp["num_misses"]) ) * 100;
+          $ret["misses"] = ($tmp["num_misses"] / ( $tmp["num_hits"]+$tmp["num_misses"]) ) * 100;
+      } else {
+          $ret["hits"] = 0;
+          $ret["misses"] = 0;
+      }
       break;
   }
 


### PR DESCRIPTION
The `php_apc` plugin accesses `http://localhost/php_apc.php?act=percents` .

When APC has no statistics for hits and misses (e.g., right after the server starts up), a `DivisionByZeroError` is raised:

```
PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /var/www/html/php_apc.php:32
```

This pull request fixes the `DivisionByZeroError` by ensuring the denominator is validated when APC has no statistics.