### PR TITLE
nvidia_gpu_: fix utilization when using 570.x driver

### DIFF
--- a/plugins/gpu/nvidia_gpu_
+++ b/plugins/gpu/nvidia_gpu_
@@ -265,7 +265,7 @@ case $name in
 		valueGpus=$(echo "$smiOutput" | grep "Power Draw" | cut -d ':' -f 2 | cut -d ' ' -f 2)
 		;;
 	utilization)
-		valueGpus=$(echo "$smiOutput" | grep "Gpu" | cut -d ':' -f 2 | cut -d ' ' -f 2)
+		valueGpus=$(echo "$smiOutput" | grep -A 1 "Utilization" | grep -i "GPU" | cut -d ':' -f 2 | cut -d ' ' -f 2)
 		;;
 	rx)
 		rxGpus=$(echo "$smiOutput" | grep "Rx Throughput" | cut -d ':' -f 2 | cut -d ' ' -f 2)


### PR DESCRIPTION
The utilization used to be on a line beginning with "Gpu", but has since been capitalized to "GPU". There's already several other instances of that in the nvidia-smi output, so narrow down the search by returning only the line after "Utilization".