### PR TITLE
[wireguard_] Prevent never-connected peers to be shown as "(none)"

### DIFF
--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -80,7 +80,7 @@ function wg_peers {
     # Subsequent lines are printed for each peer and contain in order separated
     # by tab: public-key, preshared-key, endpoint, allowed-ips, latest-handshake,
     # transfer-rx, transfer-tx, persistent-keepalive
-    for line in $(wg show "$iface" dump | tr '\t' ';'); do
+    for line in $(wg show "$iface" dump | grep -v none | tr '\t' ';'); do
         column_count=$(awk -F';' '{print NF}' <<< "$line")
         if [ "$column_count" -ne 8 ]; then
             # First line of dump contains interface info, ignore this line


### PR DESCRIPTION
In case of peers that have never been connected, the output of `wg show {iface} dump` is something like this

    aAbBcCdD=   eEfFgGhH=   (none)   10.0.0.15/32   0   0   0   off
    aAbBcCdD=   eEfFgGhH=   (none)   10.0.0.16/32   0   0   0   off
    aAbBcCdD=   eEfFgGhH=   (none)   10.0.0.17/32   0   0   0   off

The repeated `(none)` in many lines break the charts image to be created.

This PR excludes `(none)` from the list of peers.