### PR TITLE
Docker volumesize bugfix

### DIFF
--- a/plugins/docker/docker_volumesize
+++ b/plugins/docker/docker_volumesize
@@ -38,7 +38,7 @@ if [ "$1" = "autoconf" ]; then
   exit 0
 fi
 
-volume_info=$(docker system df -v --format '{{json .Volumes}}' | jq -r '.[] | "\(.Name):\(.Size):\(.Labels)"')
+volume_info=$(docker system df -v --format '{{json .Volumes}}' | jq -r '.[] | select(.Size != "0B" ) | "\(.Name):\(.Size):\(.Labels)"')
 
 
 

--- a/plugins/docker/docker_volumesize
+++ b/plugins/docker/docker_volumesize
@@ -12,6 +12,7 @@ Michael Grote (michael.grote@posteo.de)
 =head1 MAGIC MARKERS
 
 #%# family=auto
+#%# capabilities=autoconf
 
 =head1 LICENSE
 

--- a/plugins/docker/docker_volumesize
+++ b/plugins/docker/docker_volumesize
@@ -50,6 +50,8 @@ if [ "$1" = "config" ]; then
   echo "graph_args -l 0 --base 1024"
   echo "graph_info This graph shows the size per volume."
   while IFS= read -r line; do
+    # ignore empty lines
+    [ -n "$line" ] || continue
     echo "$line" | awk 'BEGIN { FS = ":" } { label = substr($1, 1, 30); print $1 ".label " label }'
     # display info only when labels are set
     if [ -n "$(echo "$line" | awk 'BEGIN { FS = ":" } { print $3 }')" ]; then
@@ -62,6 +64,8 @@ fi
 
 echo "multigraph volumesize"
 while IFS= read -r line; do
+  # ignore empty lines
+  [ -n "$line" ] || continue
   name=$(echo "$line" | awk 'BEGIN { FS = ":" } { print $1 }')
   value=$(echo "$line" | awk 'BEGIN { FS = ":" } { print $2 }')
 


### PR DESCRIPTION
I found some small bugs and added a small improvement.

Added compatibilities "autoconf" to remove the warning.
Ignore empty lines in the loop to prevent broken output.
Removed volumes with size 0B from output.

Hope this helps and thanks for taking the time to think about it.
