### PR TITLE
fix(docker_): set empty extinfo value to '-' when no volumes exists

### DIFF
--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -236,7 +236,7 @@ def print_containers_status(client):
         elif container.status == 'dead':
             dead.append(container)
     print('running.value', len(running))
-    print('running.extinfo', ', '.join(container_summary(c) for c in running))
+    print('running.extinfo', (', '.join(container_summary(c) for c in running)) or '-')
     print('unhealthy.value', len(unhealthy))
     print('unhealthy.extinfo', (', '.join(container_summary(c) for c in unhealthy)) or '-')
     print('paused.value', len(paused))
@@ -266,11 +266,11 @@ def print_images_count(client):
     dangling = client.dangling_images
 
     print('intermediate_quantity.value', len(intermediate))
-    print('intermediate_quantity.extinfo', ', '.join(image_summary(i) for i in intermediate))
+    print('intermediate_quantity.extinfo', (', '.join(image_summary(i) for i in intermediate)) or '-')
     print('images_quantity.value', len(images))
-    print('images_quantity.extinfo', ', '.join(image_summary(i) for i in images))
+    print('images_quantity.extinfo', (', '.join(image_summary(i) for i in images)) or '-')
     print('dangling_quantity.value', len(dangling))
-    print('dangling_quantity.extinfo', ', '.join(image_summary(i) for i in dangling))
+    print('dangling_quantity.extinfo', (', '.join(image_summary(i) for i in dangling)) or '-')
 
 
 def get_container_stats(container, q):

--- a/plugins/docker/docker_
+++ b/plugins/docker/docker_
@@ -453,9 +453,9 @@ def volumes(client, mode):
         )
 
         print('volumes_quantity.value', len(volumes))
-        print('volumes_quantity.extinfo', ', '.join(volume_summary(v) for v in volumes))
+        print('volumes_quantity.extinfo', (', '.join(volume_summary(v) for v in volumes)) or '-')
         print('dangling_quantity.value', len(dangling))
-        print('dangling_quantity.extinfo', ', '.join(volume_summary(i) for i in dangling))
+        print('dangling_quantity.extinfo', (', '.join(volume_summary(i) for i in dangling)) or '-')
 
 
 def size(client, mode):


### PR DESCRIPTION
When there aren't any volumes then extinfo wont have any content, which causes a line error to be logged in munin-update.log. This fix ensures that extinfo will be set to a dash when no volumes exists