### PR TITLE
fix(turbostat_): always check turbostat exists and is executable

### DIFF
--- a/plugins/sensors/turbostat_
+++ b/plugins/sensors/turbostat_
@@ -195,6 +195,10 @@ case $1 in
 		fi
 		;;
 	*)
+		if ! turbostat_exists; then
+			exit 1
+		fi
+
 		GRAPH_TYPE=${0##*turbostat_}
 
 		for TYPE in "${SUPPORTED_GRAPH_TYPES[@]}"; do

--- a/plugins/sensors/turbostat_
+++ b/plugins/sensors/turbostat_
@@ -24,8 +24,8 @@ anything about what happened between two measurements.
 
 =head1 INSTALLATION
 
-On debian systems turbostat is provided by the linux-tools-generic package. If you are running a custom
-kernel, you can also build turbostat as follows:
+On debian systems turbostat is provided by either the linux-tools-generic or linux-cpupower package.
+If you are running a custom kernel, you can also build turbostat as follows:
 
 $ apt-get install build-essential git libcap-dev 
 $ cd /usr/local/src


### PR DESCRIPTION
The `turbostat_exists` function should always be called as it 1) sets the default executable path  and 2) ensures that turbostat is really executable and returns meaningfull data