### PR TITLE
Revert "Merge pull request #1487 from droscy/fix/wireguard/none"

### DIFF
--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -80,7 +80,7 @@ function wg_peers {
     # Subsequent lines are printed for each peer and contain in order separated
     # by tab: public-key, preshared-key, endpoint, allowed-ips, latest-handshake,
     # transfer-rx, transfer-tx, persistent-keepalive
-    for line in $(wg show "$iface" dump | grep -v none | tr '\t' ';'); do
+    for line in $(wg show "$iface" dump | tr '\t' ';'); do
         column_count=$(awk -F';' '{print NF}' <<< "$line")
         if [ "$column_count" -ne 8 ]; then
             # First line of dump contains interface info, ignore this line


### PR DESCRIPTION
This reverts commit 0016cfdfa62a5f2a8c3a5f0f3d1c9893845973cb, reversing changes made to 8184ce0871bffc3d94b6a3a71c5254fe55ec7faa.

The change in #1487 is not correct and should be reverted as the grep is too greedy as the preshared-key could also be listed as `(none)`.

Will create a new PR with a proper 'fix' later
