### PR TITLE
fix(wireguard_): use public key as graph id's as those are required and unique

### DIFF
--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -99,20 +99,6 @@ function wg_peers {
     local -n _wg_peers=$1
     local iface=$2
 
-<<<<<<< Updated upstream
-    # From wg 8 manpage:
-    # If dump is specified, then several lines are printed; the first contains
-    # in order separated by tab: private-key, public-key, listen-port, fwmark.
-    # Subsequent lines are printed for each peer and contain in order separated
-    # by tab: public-key, preshared-key, endpoint, allowed-ips, latest-handshake,
-    # transfer-rx, transfer-tx, persistent-keepalive
-    for line in $(wg show "$iface" dump | grep -v none | tr '\t' ';'); do
-        column_count=$(awk -F';' '{print NF}' <<< "$line")
-        if [ "$column_count" -ne 8 ]; then
-            # First line of dump contains interface info, ignore this line
-            continue
-        fi
-=======
     if [ -z "${_CACHE_PEERS[$iface]}" ]; then
         # From wg 8 manpage:
         # If dump is specified, then several lines are printed; the first contains
@@ -123,7 +109,6 @@ function wg_peers {
         # Pipe to tail to skip first line
         _CACHE_PEERS["$iface"]="$(wg show "$iface" dump | tail -n +2)"
     fi
->>>>>>> Stashed changes
 
     readarray -t peers <<< "${_CACHE_PEERS[$iface]}"
     _wg_peers=("${peers[@]}")

--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -57,23 +57,49 @@ function wg_exists {
     return $?
 }
 
+_MAIN_ARG_FIRST=$1
+function should_emit_config {
+    if [ "$_MAIN_ARG_FIRST" = "config" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+function should_emit_values {
+    if ! should_emit_config || [ "$MUNIN_CAP_DIRTYCONFIG" = "1" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+declare -a _CACHE_INTERFACES
 function wg_interfaces {
-    show_all=$1
-    for iface in $(wg show interfaces | tr " " "\n"); do
+    local -n _wg_ifaces=$1
+    local show_all=$2
+
+    if [ "${#_CACHE_INTERFACES[@]}" -eq 0 ]; then
+        IFS=' ' read -ra _CACHE_INTERFACES <<< "$(wg show interfaces)"
+    fi
+
+    local iface
+    for iface in "${_CACHE_INTERFACES[@]}"; do
         # Filter interfaces if needed
         if [ -z "$show_all" ] \
             && [ -n "$INTERFACE" ] \
             && [ "$INTERFACE" != "$iface" ]; then
             continue
         fi
-
-        echo "$iface"
+        _wg_ifaces+=("$iface")
     done
 }
-
+declare -A _CACHE_PEERS
 function wg_peers {
-    iface=$1
+    local -n _wg_peers=$1
+    local iface=$2
 
+<<<<<<< Updated upstream
     # From wg 8 manpage:
     # If dump is specified, then several lines are printed; the first contains
     # in order separated by tab: private-key, public-key, listen-port, fwmark.
@@ -86,15 +112,119 @@ function wg_peers {
             # First line of dump contains interface info, ignore this line
             continue
         fi
+=======
+    if [ -z "${_CACHE_PEERS[$iface]}" ]; then
+        # From wg 8 manpage:
+        # If dump is specified, then several lines are printed; the first contains
+        # in order separated by tab: private-key, public-key, listen-port, fwmark.
+        # Subsequent lines are printed for each peer and contain in order separated
+        # by tab: public-key, preshared-key, endpoint, allowed-ips, latest-handshake,
+        # transfer-rx, transfer-tx, persistent-keepalive
+        # Pipe to tail to skip first line
+        _CACHE_PEERS["$iface"]="$(wg show "$iface" dump | tail -n +2)"
+    fi
+>>>>>>> Stashed changes
 
-        echo "$line"
-    done
+    readarray -t peers <<< "${_CACHE_PEERS[$iface]}"
+    _wg_peers=("${peers[@]}")
 }
 
 function safe_peer_id {
     unsafe_peer_id=$1
 
-    echo "${unsafe_peer_id//[.:]/_}"
+    echo "${unsafe_peer_id//[^a-zA-Z0-9-_]/_}"
+}
+
+function peer_count {
+    declare -a ifaces
+    wg_interfaces ifaces
+
+    echo "multigraph wireguard_peercount"
+
+    if should_emit_config; then
+        # Config for peer count per interface graph
+        cat << EOF
+graph_title interface peer count
+graph_vlabel Number of peers
+graph_category wireguard
+graph_info This graph shows the number of peers per wireguard interface
+EOF
+    fi
+
+    for iface in "${ifaces[@]}"; do
+        if should_emit_config; then
+            # List config for all interfaces
+            cat <<EOF
+pc_on_$iface.label $iface
+pc_on_$iface.info Configured peers on interface $iface
+pc_on_$iface.min 0
+apc_on_$iface.label Active on $iface
+apc_on_$iface.info Active peers on interface $iface
+apc_on_$iface.min 0
+EOF
+        fi
+
+        if should_emit_values; then
+            active_threshold="${active_threshold:-$(date --date="${active_threshold_m:-3} min ago" +%s)}"
+
+            declare -a peers
+            wg_peers peers "$iface"
+
+            peer_count="${#peers[@]}"
+            active_peer_count=$(awk -F"\t" -v threshold="$active_threshold" '$5 > threshold' <<< "$(IFS=$'\n'; echo "${peers[*]}")" | wc -l)
+
+            echo "pc_on_$iface.value $peer_count"
+            echo "apc_on_$iface.value $active_peer_count"
+        fi
+    done
+}
+
+function peer_traffic {
+    iface="$1"
+
+
+    echo "multigraph wireguard_peertraffic_$iface"
+
+    if should_emit_config; then
+        cat <<EOF
+graph_title $iface peer traffic
+graph_args --base 1000
+graph_vlabel bits in (-) / out (+) per \${graph_period}
+graph_category wireguard
+graph_info This graph shows the traffic per peer on the $iface wireguard interface. Traffic is shown in bits per second.
+EOF
+    fi
+
+    declare -a _peers
+    wg_peers peers "$iface"
+
+    for line in "${peers[@]}"; do
+        IFS=$'\t' read -ra peer <<< "$line"
+        peer_id="$(safe_peer_id "${peer[0]}")"
+
+        if should_emit_config; then
+            # List config for up/down values for each peer
+            cat <<EOF
+down_${peer_id}.label received
+down_${peer_id}.type DERIVE
+down_${peer_id}.graph no
+down_${peer_id}.cdef down_${peer_id},8,*
+down_${peer_id}.min 0
+up_${peer_id}.label ${peer[2]}
+up_${peer_id}.type DERIVE
+up_${peer_id}.negative down_${peer_id}
+up_${peer_id}.cdef up_${peer_id},8,*
+up_${peer_id}.min 0
+EOF
+        fi
+
+        if should_emit_values; then
+            cat <<EOF
+down_${peer_id}.value ${peer[5]}
+up_${peer_id}.value ${peer[6]}
+EOF
+        fi
+    done
 }
 
 case $1 in
@@ -107,94 +237,19 @@ case $1 in
         ;;
     suggest)
         if wg_exists; then
-            wg_interfaces 1
+            declare -a ifaces
+            wg_interfaces ifaces 1
+            IFS=$'\n'
+            echo "${ifaces[*]}"
         fi
         ;;
-    config)
-        # Config for peer count per interface graph
-        cat << EOF
-multigraph wireguard_peercount
-graph_title interface peer count
-graph_vlabel Number of peers
-graph_category wireguard
-graph_info This graph shows the number of peers per wireguard interface
-EOF
-
-        for iface in $(wg_interfaces); do
-            # List config for all interfaces
-            cat <<EOF
-pc_on_$iface.label $iface
-pc_on_$iface.info Interface $iface
-pc_on_$iface.min 0
-apc_on_$iface.label Active on $iface
-apc_on_$iface.info Active on $iface
-apc_on_$iface.min 0
-EOF
-        done
-        echo ""
-
-        for iface in $(wg_interfaces); do
-            # Config for peer traffic
-            cat <<EOF
-multigraph wireguard_peertraffic_$iface
-graph_title $iface peer traffic
-graph_args --base 1000
-graph_vlabel bits in (-) / out (+) per ${graph_period}
-graph_category wireguard
-graph_info This graph shows the traffic per peer on the $iface wireguard interface. Traffic is shown in bits per second.
-
-EOF
-
-            for line in $(wg_peers "$iface"); do
-                read -r -a peer <<< "$(echo "$line" | tr ';' ' ')"
-		        peer_id=$(safe_peer_id "${peer[2]}")
-
-                # List config for up/down values for each peer
-                cat <<EOF
-down_${peer_id}.label received
-down_${peer_id}.type DERIVE
-down_${peer_id}.graph no
-down_${peer_id}.cdef down_${peer_id},8,*
-down_${peer_id}.min 0
-up_${peer_id}.label ${peer[2]}
-up_${peer_id}.type DERIVE
-up_${peer_id}.negative down_${peer_id}
-up_${peer_id}.cdef up_${peer_id},8,*
-up_${peer_id}.min 0
-
-EOF
-            done
-        done
-        ;;
     *)
-        # Collect & print current monitoring values
-        echo "multigraph wireguard_peercount"
-	active_threshold=$(date --date="${active_threshold_m:-3} min ago" +%s)
+        peer_count
 
-        for iface in $(wg_interfaces); do
-            iface_peers=$(wg_peers "$iface")
-
-            peer_count=$(wc -l <<< "$iface_peers")
-            active_peer_count=$(awk -F";" -v threshold=$active_threshold '$5 > threshold' <<< "$iface_peers" | wc -l)
-
-            echo "pc_on_$iface.value $peer_count"
-            echo "apc_on_$iface.value $active_peer_count"
-        done
-        echo ""
-
-        for iface in $(wg_interfaces); do
-            echo "multigraph wireguard_peertraffic_$iface"
-
-            for line in $(wg_peers "$iface"); do
-                read -r -a peer <<< "$(echo "$line" | tr ';' ' ')"
-
-                peer_id=$(safe_peer_id "${peer[2]}")
-
-                echo "down_${peer_id}.value ${peer[5]}"
-                echo "up_${peer_id}.value ${peer[6]}"
-            done
-
-            echo ""
+        declare -a ifaces
+        wg_interfaces ifaces
+        for iface in "${ifaces[@]}"; do
+            peer_traffic "$iface"
         done
         ;;
 esac

--- a/plugins/wireguard/wireguard_
+++ b/plugins/wireguard/wireguard_
@@ -94,6 +94,7 @@ function wg_interfaces {
         _wg_ifaces+=("$iface")
     done
 }
+
 declare -A _CACHE_PEERS
 function wg_peers {
     local -n _wg_peers=$1
@@ -165,8 +166,7 @@ EOF
 }
 
 function peer_traffic {
-    iface="$1"
-
+    local iface="$1"
 
     echo "multigraph wireguard_peertraffic_$iface"
 


### PR DESCRIPTION
> ⚠️ This PR contains a breaking change, installing it will recreate/reset all existing wireguard graphs

Basically a rewrite of the wireguard plugin.

The wireguard plugin is currently using the endpoint as a unique identifier for peers. Not sure why I ever thought that was a good idea, because besides that that field returns `(none)` for not connected peers (as found by @droscy in #1487) it will also change every time a warrior client changes its location.

The only field  that is guaranteed to be unique & present is the public key, so this PR changes that graph ids are using the public key. This also fixes the problem from #1487.  The endpoint is still used as label for graphs, not sure if that is the best option? Let me know if anyone has suggestions.

Also add dirtyconfig support & some caching so each unique wg call is only called once

