### PR TITLE
[nextcloud_]: Allow to disable check for app updates

### DIFF
--- a/plugins/nextcloud/nextcloud_
+++ b/plugins/nextcloud/nextcloud_
@@ -34,6 +34,7 @@ Set username and password in your munin-node configuration
 	env.scheme <default: https>
 	env.timeout <default: 2s>
 	env.updates_warning <default: 1>
+	env.check_app_updates <default: true>
 
 It's advised to use a serverinfo token, or at least to set an app password (for
 this plugin) in your nextcloud instance and not to use the "real" password of
@@ -71,12 +72,17 @@ if [ "${MUNIN_DEBUG:-0}" = 1 ]; then
     set -x
 fi
 
-API_PATH="${api_path:-/ocs/v2.php/apps/serverinfo/api/v1/info}?format=json&skipApps=false"
+CHECK_APP_UPDATES="${check_app_updates:-true}"
+API_PATH="${api_path:-/ocs/v2.php/apps/serverinfo/api/v1/info}?format=json&skipApps=$check_app_updates"
 DOMAIN="${0##*nextcloud_}"
 SCHEME="${scheme:-https}://"
 TIMEOUT="${timeout:-2}"
 UPDATES_WARNING="${updates_warning:-1}"
 CLEANDOMAIN="$(clean_fieldname "${DOMAIN}")"
+
+if [ "$CHECK_APP_UPDATES" = "false" ]; then
+	UPDATES_WARNING="-1"
+fi
 
 SERVERINFO_TOKEN="${serverinfo_token}"
 if [ -z "${SERVERINFO_TOKEN}" ]; then


### PR DESCRIPTION
When running the `nextcloud_` plugins for multiple nextcloud instances, you can easily hit the rate limit for the app updater check. This fix allows to disable checking for app updates on certain instances.