### PR TITLE
[crowdsec]: Increase decisions to 1000 (more than default 100)

### DIFF
--- a/plugins/security/crowdsec
+++ b/plugins/security/crowdsec
@@ -100,7 +100,7 @@ class Decisions():
     def __init__(self):
         _state = state.read_section('scenarios')
         self.state = _state if _state is not None else {}
-        self.data = call_cli('decisions', 'list')
+        self.data = call_cli('decisions', 'list', '--limit', '1000')
         if self.data is not None:
             self.decisions = len(self.data)
             self.banned_ips = len(set([d['source']['ip'] for d in self.data if d['source']['scope'] == 'Ip']))  # noqa: E501


### PR DESCRIPTION
By default, the command `cscli decisions list` on a crowdsec instance only shows 100 decisions, but normally, there are more decisions, so increase the list of decisions with `cscli decisions list --limit 1000`.