### PR TITLE
rtorrent: fix SCGI headers

### DIFF
--- a/plugins/rtorrent/rtom_allsessions_mem
+++ b/plugins/rtorrent/rtom_allsessions_mem
@@ -70,7 +70,7 @@ sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
-	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen	= length $header;
 	$line_version= "${hlen}:${header},${line_version}";
 	print SOCK $line_version;
@@ -117,7 +117,7 @@ sub construct_line {
 	my $function	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
 	my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function</methodName></methodCall>";
 	my $llen        = length $line;
-	my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen        = length $header;
 	$line = "${hlen}:${header},${line}";
 	return $line;

--- a/plugins/rtorrent/rtom_allsessions_peers
+++ b/plugins/rtorrent/rtom_allsessions_peers
@@ -80,7 +80,7 @@ sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
-	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen	= length $header;
 	$line_version= "${hlen}:${header},${line_version}";
 	print SOCK $line_version;
@@ -129,7 +129,7 @@ sub construct_line {
 	my $function_hash	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.get_hash=' : 'd.hash=';
 	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
 	my $llen  = length $line;
-	my $header  = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header  = "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen  = length $header;
 	$line = "${hlen}:${header},${line}";
 	return $line;

--- a/plugins/rtorrent/rtom_allsessions_spdd
+++ b/plugins/rtorrent/rtom_allsessions_spdd
@@ -94,7 +94,7 @@ sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
-	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen	= length $header;
 	$line_version= "${hlen}:${header},${line_version}";
 	print SOCK $line_version;
@@ -144,7 +144,7 @@ sub construct_line {
 	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_rateup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_ratedown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
 
 	my $llen        = length $line;
-	my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen        = length $header;
 	$line = "${hlen}:${header},${line}";
 	return $line;

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -81,7 +81,7 @@ sub get_rtorrent_version {
 	my $version;
 	my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 	my $llen	= length $line_version;
-	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen	= length $header;
 	$line_version= "${hlen}:${header},${line_version}";
 	print SOCK $line_version;
@@ -130,7 +130,7 @@ sub construct_line {
 	my $function_hash	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.get_hash=' : 'd.hash=';
 	my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
 	my $llen = length $line;
-	my $header = "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	my $header = "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	my $hlen = length $header;
 	$line = "${hlen}:${header},${line}";
 	return $line;

--- a/plugins/rtorrent/rtom_mem
+++ b/plugins/rtorrent/rtom_mem
@@ -78,7 +78,7 @@ sub rtorrent_version_lower_than {
 		}
 		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 		my $hlen	= length $header;
 		$line_version= "${hlen}:${header},${line_version}";
 		print SOCK $line_version;
@@ -98,7 +98,7 @@ my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>
 my $function	= rtorrent_version_lower_than('0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
 my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function</methodName></methodCall>";
 my $llen	= length $line;
-my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 my $hlen	= length $header;
 $line		= "${hlen}:${header},${line}";
 

--- a/plugins/rtorrent/rtom_peers
+++ b/plugins/rtorrent/rtom_peers
@@ -89,7 +89,7 @@ sub rtorrent_version_lower_than {
 		}
 		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 		my $hlen	= length $header;
 		$line_version= "${hlen}:${header},${line_version}";
 		print SOCK $line_version;
@@ -113,7 +113,7 @@ my $function_multicall_arg      = rtorrent_version_lower_than('0.9.0') ? '' : '<
 my $function_hash	= rtorrent_version_lower_than('0.9.0') ? 'd.get_hash=' : 'd.hash=';
 my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>main</string></value></param><param><value><string>$function_hash</string></value></param><param><value><string>p.multicall=,p.is_encrypted=,p.is_incoming=</string></value></param></params></methodCall>";
 my $llen	= length $line;
-my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 my $hlen	= length $header;
 $line		= "${hlen}:${header},${line}";
 

--- a/plugins/rtorrent/rtom_spdd
+++ b/plugins/rtorrent/rtom_spdd
@@ -117,7 +117,7 @@ sub rtorrent_version_lower_than {
 		}
 		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 		my $hlen	= length $header;
 		$line_version= "${hlen}:${header},${line_version}";
 		print SOCK $line_version;
@@ -141,7 +141,7 @@ my $function_ratedown	= rtorrent_version_lower_than('0.9.0') ? 'get_download_rat
 my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_rateup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_ratedown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
 
 my $llen	= length $line;
-my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 my $hlen	= length $header;
 $line		= "${hlen}:${header},${line}";
 

--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -90,7 +90,7 @@ sub rtorrent_version_lower_than {
 		}
 		my $line_version= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.client_version</methodName></methodCall>";
 		my $llen	= length $line_version;
-		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+		my $header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 		my $hlen	= length $header;
 		$line_version= "${hlen}:${header},${line_version}";
 		print SOCK $line_version;
@@ -137,7 +137,7 @@ foreach ( @views ) {
 	$line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function_multicall</methodName><params>$function_multicall_arg<param><value><string>${_}</string></value></param><param><value><string>$function_hash</string></value></param></params></methodCall>";
 
 	$llen	= length $line;
-	$header	= "CONTENT_LENGTH\000${llen}\000SCGI\001\000";
+	$header	= "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
 	$hlen	= length $header;
 	$line	= "${hlen}:${header},${line}";
 


### PR DESCRIPTION
Newer versions of rtorrent stopped responding to these plugins, and comparing it to another (working) XML-RPC client, the difference was the 1 after the SCGI in the header (\000 1 vs \001).

This matches up with the example on Wikipedia's "Simple Common Gateway Interface" page.