### PR TITLE
rtorrent: make plugins compatible with TinyXML2-generated responses

### DIFF
--- a/plugins/rtorrent/rtom_allsessions_mem
+++ b/plugins/rtorrent/rtom_allsessions_mem
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's memory usage
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -111,7 +111,7 @@ sub rtorrent_version_lower_than {
 # init rtorrent_version
 rtorrent_version_lower_than();
 
-my $pattern     = qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $pattern     = qr/<value><(?:int|i4|i8|ex\.i8)>(\d+)<\/(?:int|i4|i8|ex\.i8)><\/value>/;
 my $mem         = 0;
 sub construct_line {
 	my $function	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
@@ -123,34 +123,28 @@ sub construct_line {
 	return $line;
 }
 
-if ( ( defined $src ) && ( $src eq "socket" ) ) {
-  for $socket (@sockets)
-  {
-    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-    print SOCK construct_line($socket);
-    flush SOCK;
-    while ( $line = <SOCK> ) {
-      if ( $line =~ /$pattern/ ) {
-        $mem = $mem + $2;
-      }
-    }
-    close (SOCK);
-  }
-} else {
-  for $port (@ports)
-  {
-    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-    print SOCK construct_line($port);
-    flush SOCK;
-    while ( $line = <SOCK> ) {
-      if ( $line =~ /$pattern/ ) {
-        $mem = $mem + $2;
-      }
-    }
-    close (SOCK);
-  }
+my $is_socket = ( defined $src ) && ( $src eq "socket" );
+
+foreach my $instance ( $is_socket ? @sockets : @ports ) {
+	socket( SOCK, $is_socket ? PF_UNIX : PF_INET, SOCK_STREAM, $is_socket ? 0 : getprotobyname( "tcp" ) ) or die $!;
+	connect( SOCK, $is_socket ? sockaddr_un( $instance ) : sockaddr_in( $instance, inet_aton( $ip ) ) ) or die $!;
+
+	print SOCK construct_line($instance);
+	flush SOCK;
+
+	my $resp = "";
+	while ( $line = <SOCK> ) {
+		$resp .= $line;
+	}
+
+	close (SOCK);
+
+	# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+	$resp =~ s/\s+//g;
+
+	if ( $resp =~ /$pattern/ ) {
+		$mem += $1;
+	}
 }
 
 print "mem.value ${mem}\n";

--- a/plugins/rtorrent/rtom_allsessions_peers
+++ b/plugins/rtorrent/rtom_allsessions_peers
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's peer count
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -121,7 +121,7 @@ sub rtorrent_version_lower_than {
 # init rtorrent_version
 rtorrent_version_lower_than();
 
-my $pattern  = qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $pattern  = qr/<value><(?:int|i4|i8|ex\.i8)>(\d+)<\/(?:int|i4|i8|ex\.i8)><\/value>/;
 my $tpattern  = qr/[0-9A-F]{20}/;
 sub construct_line {
 	my $function_multicall	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'd.multicall' : 'd.multicall2';
@@ -139,61 +139,50 @@ my $tor = 0;
 my $tot = 0;
 my $enc = 0;
 my $inc = 0;
-my $pline = "";
-my $ppline = "";
 my $out = 0;
 my $pla = 0;
 
-if ( ( defined $src ) && ( $src eq "socket" ) ) {
-  for $socket (@sockets)
-  {
-    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-    print SOCK construct_line($socket);
-    flush SOCK;
-    while ( $line = <SOCK> ) {
-      if ( $line =~ /$tpattern/ ) {
-        $tor += 1;
-      } elsif ( $line =~ /$pattern/ ) {
-        $tot += 1;
-        $enc += $2;
-        $line = <SOCK>;
-        $line =~ /$pattern/;
-        $inc += $2;
-      }
-      $ppline = $pline;
-      $pline = $line;
-    }
-    close (SOCK);
-    $out = $out + $tot - $inc;
-    $pla = $pla + $tot - $enc;
-  }
-} else {
-  for $port (@ports)
-  {
-    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-    print SOCK construct_line($port);
-    flush SOCK;
-    while ( $line = <SOCK> ) {
-      if ( $line =~ /$tpattern/ ) {
-        $tor += 1;
-      } elsif ( $line =~ /$pattern/ ) {
-        $tot += 1;
-        $enc += $2;
-        $line = <SOCK>;
-        $line =~ /$pattern/;
-        $inc += $2;
-      }
-      $ppline = $pline;
-      $pline = $line;
-    }
-    close (SOCK);
-    $out = $out + $tot - $inc;
-    $pla = $pla + $tot - $enc;
-  }
-}
+my $is_socket = ( defined $src ) && ( $src eq "socket" );
 
+foreach my $instance ( $is_socket ? @sockets : @ports ) {
+	socket( SOCK, $is_socket ? PF_UNIX : PF_INET, SOCK_STREAM, $is_socket ? 0 : getprotobyname( "tcp" ) ) or die $!;
+	connect( SOCK, $is_socket ? sockaddr_un( $instance ) : sockaddr_in( $instance, inet_aton( $ip ) ) ) or die $!;
+
+	print SOCK construct_line($instance);
+	flush SOCK;
+
+	my $resp = "";
+	while ( $line = <SOCK> ) {
+		$resp .= $line;
+	}
+
+	close (SOCK);
+
+	# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+	$resp =~ s/\s+//g;
+
+	# split into chunks per the info hash
+	foreach my $segment ( split(/>(?=$tpattern)/, $resp) ) {
+		$tor++;
+
+		my @c;
+		while ($segment =~ /$pattern/g) {
+			push(@c, $1);
+
+			# a bit fragile; we do explicitly request both, however
+			if ( scalar(@c) == 2 ) {
+				$tot++;
+				$enc += shift(@c);
+				$inc += shift(@c);
+			}
+		}
+	}
+
+	$tor-- if ($tor); # discard xml header segment
+
+	$out = $out + $tot - $inc;
+	$pla = $pla + $tot - $enc;
+}
 
 print "torrents.value ${tor}\ntotal.value ${tot}\nencrypted.value ${enc}\nplain.value ${pla}\nincoming.value ${inc}\noutgoing.value ${out}\n";
 

--- a/plugins/rtorrent/rtom_allsessions_spdd
+++ b/plugins/rtorrent/rtom_allsessions_spdd
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's upload/download speed
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -135,13 +135,11 @@ sub rtorrent_version_lower_than {
 # init rtorrent_version
 rtorrent_version_lower_than();
 
-my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $pattern	= qr/<value><(?:int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(?:int|i4|i8|ex\.i8)><\/value>/;
 sub construct_line {
 	my $function_totalup	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_up_total' : 'throttle.global_up.total';
 	my $function_totaldown	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_down_total' : 'throttle.global_down.total';
-	my $function_rateup	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_upload_rate' : 'throttle.global_up.max_rate';
-	my $function_ratedown	= rtorrent_version_lower_than($_[0], '0.9.0') ? 'get_download_rate' : 'throttle.global_down.max_rate';
-	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_rateup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_ratedown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
+	my $line		= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>system.multicall</methodName><params><param><value><array><data><value><struct><member><name>methodName</name><value><string>$function_totalup</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value><value><struct><member><name>methodName</name><value><string>$function_totaldown</string></value></member><member><name>params</name><value><array><data/></array></value></member></struct></value></data></array></value></param></params></methodCall>";
 
 	my $llen        = length $line;
 	my $header      = "CONTENT_LENGTH\000${llen}\000SCGI\0001\000";
@@ -150,58 +148,37 @@ sub construct_line {
 	return $line;
 }
 
-my $up = -1;
-my $down = -1;
+my $up = 0;
+my $down = 0;
 
-if ( ( defined $src ) && ( $src eq "socket" ) ) {
-  for $socket (@sockets)
-  {
-    socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-    connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-    print SOCK construct_line($socket);
-    flush SOCK;
-    my $up_tmp = -1;
-    my $down_tmp = -1;
-    while (( $up_tmp == -1 ) && ( $line = <SOCK> ) ) {
-      if ( $line =~ /$pattern/ ) {
-        $up_tmp = $2;
-      }
-    }
-    while (( $down_tmp == -1 ) && ( $line = <SOCK> ) ) {
-      if ( $line =~ /$pattern/ ) {
-        $down_tmp = $2;
-      }
-    }
-    close (SOCK);
-    $up = $up + $up_tmp;
-    $down = $down + $down_tmp;
-  }
-} else {
-  for $port (@ports)
-  {
-    socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-    connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-    print SOCK construct_line($port);
-    flush SOCK;
-    my $up_tmp = -1;
-    my $down_tmp = -1;
-    while (( $up_tmp == -1 ) && ( $line = <SOCK> ) ) {
-      if ( $line =~ /$pattern/ ) {
-        $up_tmp = $2;
-      }
-    }
-    while (( $down_tmp == -1 ) && ( $line = <SOCK> ) ) {
-      if ( $line =~ /$pattern/ ) {
-        $down_tmp = $2;
-      }
-    }
-    close (SOCK);
-    $up = $up + $up_tmp;
-    $down = $down + $down_tmp;
-  }
+my $is_socket = ( defined $src ) && ( $src eq "socket" );
+
+foreach my $instance ( $is_socket ? @sockets : @ports ) {
+	socket( SOCK, $is_socket ? PF_UNIX : PF_INET, SOCK_STREAM, $is_socket ? 0 : getprotobyname( "tcp" ) ) or die $!;
+	connect( SOCK, $is_socket ? sockaddr_un( $instance ) : sockaddr_in( $instance, inet_aton( $ip ) ) ) or die $!;
+
+	print SOCK construct_line($instance);
+	flush SOCK;
+
+	my $resp = "";
+	while ( $line = <SOCK> ) {
+		$resp .= $line;
+	}
+
+	close (SOCK);
+
+	# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+	$resp =~ s/\s+//g;
+
+	my @speeds = ($resp =~ /$pattern/g);
+
+	if ( scalar(@speeds) == 2 ) { # sanity check
+		my $up_tmp = shift(@speeds);
+		my $down_tmp = shift(@speeds);
+		$up = $up + $up_tmp;
+		$down = $down + $down_tmp;
+	}
 }
-
-
 
 print "up.value ${up}\ndown.value ${down}\n";
 

--- a/plugins/rtorrent/rtom_allsessions_vol
+++ b/plugins/rtorrent/rtom_allsessions_vol
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's torrent count
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -136,39 +136,32 @@ sub construct_line {
 	return $line;
 }
 
-foreach ( @views ) {
-  my $num = 0;
+my $is_socket = ( defined $src ) && ( $src eq "socket" );
 
-  if ( ( defined $src ) && ( $src eq "socket" ) ) {
-    for $socket (@sockets)
-    {
-      socket( SOCK, PF_UNIX, SOCK_STREAM, 0 ) or die;
-      connect( SOCK, sockaddr_un( $socket ) ) or die $!;
-      print SOCK construct_line($socket);
-      flush SOCK;
-      while ( $line = <SOCK> ) {
-        if ( $line =~ /$pattern/ ) {
-          $num++;
-        }
-      }
-      close (SOCK);
-    }
-  } else {
-    for $port (@ports)
-    {
-      socket( SOCK, PF_INET, SOCK_STREAM, getprotobyname( "tcp" ) );
-      connect( SOCK, sockaddr_in( $port, inet_aton( $ip ) ) );
-      print SOCK construct_line($port);
-      flush SOCK;
-      while ( $line = <SOCK> ) {
-        if ( $line =~ /$pattern/ ) {
-          $num++;
-        }
-      }
-      close (SOCK);
-    }
-  }
-  print "${_}.value ${num}\n";
+foreach ( @views ) {
+	my $num = 0;
+
+	foreach my $instance ( $is_socket ? @sockets : @ports ) {
+		socket( SOCK, $is_socket ? PF_UNIX : PF_INET, SOCK_STREAM, $is_socket ? 0 : getprotobyname( "tcp" ) ) or die $!;
+		connect( SOCK, $is_socket ? sockaddr_un( $instance ) : sockaddr_in( $instance, inet_aton( $ip ) ) ) or die $!;
+
+		print SOCK construct_line($instance);
+		flush SOCK;
+
+		my $resp = "";
+		while ( $line = <SOCK> ) {
+			$resp .= $line;
+		}
+
+		close (SOCK);
+
+		# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+		$resp =~ s/\s+//g;
+
+		$num += () = $resp =~ /$pattern/g;
+	}
+
+	print "${_}.value ${num}\n";
 }
 
 exit;

--- a/plugins/rtorrent/rtom_mem
+++ b/plugins/rtorrent/rtom_mem
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's memory usage
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -94,7 +94,7 @@ sub rtorrent_version_lower_than {
 	return version->parse($rtorrent_version) < version->parse($_[0]);
 }
 
-my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $pattern	= qr/<value><(?:int|i4|i8|ex\.i8)>(\d+)<\/(?:int|i4|i8|ex\.i8)><\/value>/;
 my $function	= rtorrent_version_lower_than('0.9.0') ? 'get_memory_usage' : 'pieces.memory.current';
 my $line	= "<?xml version=\"1.0\" encoding=\"utf-8\"?><methodCall><methodName>$function</methodName></methodCall>";
 my $llen	= length $line;
@@ -113,13 +113,20 @@ if ( ( defined $src ) && ( $src eq "socket" ) ) {
 print SOCK $line;
 flush SOCK;
 
-my $mem = 0;
+my $resp = "";
 while ( $line = <SOCK> ) {
-	if ( $line =~ /$pattern/ ) {
-		$mem = $2;
-	}
+	$resp .= $line;
 }
+
 close (SOCK);
+
+# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+$resp =~ s/\s+//g;
+
+my $mem = 'U';
+if ( $resp =~ /$pattern/ ) {
+	$mem = $1;
+}
 
 print "mem.value ${mem}\n";
 

--- a/plugins/rtorrent/rtom_peers
+++ b/plugins/rtorrent/rtom_peers
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's peer count
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -105,7 +105,7 @@ sub rtorrent_version_lower_than {
 	return version->parse($rtorrent_version) < version->parse($_[0]);
 }
 
-my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>(\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $pattern	= qr/<value><(?:int|i4|i8|ex\.i8)>(\d+)<\/(?:int|i4|i8|ex\.i8)><\/value>/;
 my $tpattern	= qr/[0-9A-F]{20}/;
 
 my $function_multicall	= rtorrent_version_lower_than('0.9.0') ? 'd.multicall' : 'd.multicall2';
@@ -132,22 +132,35 @@ my $tor = 0;
 my $tot = 0;
 my $enc = 0;
 my $inc = 0;
-my $pline = "";
-my $ppline = "";
+my $resp = "";
+
 while ( $line = <SOCK> ) {
-	if ( $line =~ /$tpattern/ ) {
-		$tor += 1;
-	} elsif ( $line =~ /$pattern/ ) {
-		$tot += 1;
-		$enc += $2;
-		$line = <SOCK>;
-		$line =~ /$pattern/;
-		$inc += $2;
-	}
-	$ppline = $pline;
-	$pline = $line;
+	$resp .= $line;
 }
+
 close (SOCK);
+
+# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+$resp =~ s/\s+//g;
+
+# split into chunks per the info hash
+foreach my $segment ( split(/>(?=$tpattern)/, $resp) ) {
+	$tor++;
+
+	my @c;
+	while ($segment =~ /$pattern/g) {
+		push(@c, $1);
+
+		# a bit fragile; we do explicitly request both, however
+		if ( scalar(@c) == 2 ) {
+			$tot++;
+			$enc += shift(@c);
+			$inc += shift(@c);
+		}
+	}
+}
+
+$tor-- if ($tor); # discard xml header segment
 
 my $out = $tot - $inc;
 my $pla = $tot - $enc;

--- a/plugins/rtorrent/rtom_spdd
+++ b/plugins/rtorrent/rtom_spdd
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's upload/download speed
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -132,7 +132,7 @@ sub rtorrent_version_lower_than {
 	}
 	return version->parse($rtorrent_version) < version->parse($_[0]);
 }
-my $pattern	= qr/<value><(int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(int|i4|i8|ex\.i8)><\/value>/;
+my $pattern	= qr/<value><(?:int|i4|i8|ex\.i8)>([-]{0,1}\d+)<\/(?:int|i4|i8|ex\.i8)><\/value>/;
 
 my $function_totalup	= rtorrent_version_lower_than('0.9.0') ? 'get_up_total' : 'throttle.global_up.total';
 my $function_totaldown	= rtorrent_version_lower_than('0.9.0') ? 'get_down_total' : 'throttle.global_down.total';
@@ -156,31 +156,26 @@ if ( ( defined $src ) && ( $src eq "socket" ) ) {
 print SOCK $line;
 flush SOCK;
 
-my $up = -1;
-my $down = -1;
-my $uprate = -1;
-my $downrate = -1;
-while ( ( $up == -1 ) && ( $line = <SOCK> ) ) {
-	if ( $line =~ /$pattern/ ) {
-		$up = $2;
-	}
+my $resp = "";
+while ($line = <SOCK>) {
+	$resp .= $line;
 }
-while ( ( $down == -1 ) && ( $line = <SOCK> ) ) {
-	if ( $line =~ /$pattern/ ) {
-		$down = $2;
-	}
-}
-while ( ( $uprate == -1 ) && ( $line = <SOCK> ) ) {
-	if ( $line =~ /$pattern/ ) {
-		$uprate = $2;
-	}
-}
-while ( ( $downrate == -1 ) && ( $line = <SOCK> ) ) {
-	if ( $line =~ /$pattern/ ) {
-		$downrate = $2;
-	}
-}
+
 close (SOCK);
+
+# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+$resp =~ s/\s+//g;
+
+my @speeds = ($resp =~ /$pattern/g);
+
+my ($up, $down, $uprate, $downrate) = ('U' x 4);
+
+if ( scalar(@speeds) == 4 ) { # sanity check
+	$up = shift(@speeds);
+	$down = shift(@speeds);
+	$uprate = shift(@speeds);
+	$downrate = shift(@speeds);
+}
 
 print "up.value ${up}\ndown.value ${down}\nuprate.value ${uprate}\ndownrate.value ${downrate}\n";
 

--- a/plugins/rtorrent/rtom_vol
+++ b/plugins/rtorrent/rtom_vol
@@ -2,8 +2,8 @@
 #
 # xmlrpc based munin plugin for monitoring rtorrent's torrent count
 # prerequisites:
-#  - rtorrent 0.7.5 or newer compiled with --with-xmlrpc-c
-# check http://libtorrent.rakshasa.no/wiki/RTorrentXMLRPCGuide for further information
+#  - rtorrent 0.7.5 or newer compiled with xmlrpc support
+# check https://github.com/rakshasa/rtorrent/wiki/RPC-Setup-XMLRPC for further information
 #
 # written by Gabor Hudiczius
 # web: http://projects.cyla.homeip.net/rtwi/wiki/rTorrentOMeter
@@ -113,7 +113,7 @@ rtorrent_version_lower_than();
 my $pattern	= qr/<value><string>([A-Z0-9]+)<\/string><\/value>/;
 
 my $line;
-my $llenmy;
+my $llen;
 my $header;
 my $hlen;
 
@@ -144,15 +144,19 @@ foreach ( @views ) {
 	print SOCK $line;
 	flush SOCK;
 
-	$num = 0;
+	my $resp = "";
 	while ( $line = <SOCK> ) {
-		if ( $line =~ /$pattern/ ) {
-			$num++;
-		}
+		$resp .= $line;
 	}
-	print "${_}.value ${num}\n";
 
 	close (SOCK);
+
+	# normalize to contain *no* whitespace; this is to accomodate both xmlrpc-c (newlines) and tinyxml2 (single line) responses
+	$resp =~ s/\s+//g;
+
+	$num = () = $resp =~ /$pattern/g;
+
+	print "${_}.value ${num}\n";
 }
 
 exit;


### PR DESCRIPTION
The plugins were written in a way that depended on the XML having newlines in specific places. Building rtorrent with TinyXML2 leads to responses with no newlines, breaking the plugins.

Normalize XML responses to remove whitespace and adjust the parsers accordingly.

Additionally:
- Deduplicate some of the code (UNIX vs TCP) in the 'allsession' variants
- Add basic response checking to a couple of the plugins (rtom_mem and rtom_spdd) so that they return 'U' if the expected values aren't found
- Make several of the regex groups non-capturing where the data isn't wanted
- Fix broken links to wiki
- Remove references to '--with-xmlrpc-c' build flag
- Remove unused 'max_rate' fetches in rtom_allsession_spdd
- Switch indents to tabs in a few places; this matches the majority of lines throughout the set of plugins