### PR TITLE
postfix_mail_stats1: Fix date grepping

### DIFF
--- a/plugins/postfix/postfix_mail_stats1
+++ b/plugins/postfix/postfix_mail_stats1
@@ -21,7 +21,7 @@
 
 
 LOGFILE=${logfile:-/var/log/maillog}	# Allow user to specify logfile through env.logfile
-DATE=`date '+%b %e %H'`
+DATE=`LC_ALL=C date '+%b %d %H'`
 MAXLABEL=20
 
 if [ "$1" = "autoconf" ]; then
@@ -66,4 +66,3 @@ echo -en "spamhaus.value "
 echo $(grep "blocked using sbl-xbl.spamhaus.org" $LOGFILE | grep "$DATE" -c)
 echo -en "spamcop.value "
 echo $(grep "blocked using bl.spamcop.net" $LOGFILE | grep "$DATE" -c)
-


### PR DESCRIPTION
- use english month names, so that German ones "Mär" do not collide with english ones in the log file "Mar"
- use a two-digit day name as the logs contain.

This is with Debian 13 and postfix 3.10.5-1~deb13u1

Resolves: https://github.com/munin-monitoring/contrib/issues/1520