### PR TITLE
Fix capabilities: Separate them with space not comma

### DIFF
--- a/plugins/dhcp/dhcpd-pools
+++ b/plugins/dhcp/dhcpd-pools
@@ -18,7 +18,7 @@
 #
 ####
 #%# family=manual
-#%# capabilities=autoconf,multigraph
+#%# capabilities=autoconf multigraph
 
 export WARN=85
 export CRIT=98

--- a/plugins/network/dns/dnsresponse_
+++ b/plugins/network/dns/dnsresponse_
@@ -35,7 +35,7 @@ The plugin shows the average and median times taken to resolve a site.
 =head1 MAGIC MARKERS
 
   #%# family=auto
-  #%# capabilities=autoconf,suggest
+  #%# capabilities=autoconf suggest
 
 =head1 BUGS
 

--- a/plugins/sensors/turbostat_
+++ b/plugins/sensors/turbostat_
@@ -61,7 +61,7 @@ MIT
 =head1 MAGIC MARKERS
 
  #%# family=auto
- #%# capabilities=autoconf,suggest
+ #%# capabilities=autoconf suggest
 
 =cut
 


### PR DESCRIPTION
https://guide.munin-monitoring.org/en/latest/architecture/syntax.html#magic-markers

The commas are one of the problems that we need to fix to get the plugin gallery build working again in https://github.com/munin-monitoring/munin-plugin-gallery/issues/13