### PR TITLE
nutups2_: silently exit when called as base symlink during data fetch

### DIFF
--- a/plugins/power/nutups2_
+++ b/plugins/power/nutups2_
@@ -340,6 +340,9 @@ croak("Unknown command line arguments") if $ARGV[0] and $ARGV[0] ne 'config';
 # The UPS name may contain underscores
 my $fn_re = join('|', keys %config);
 my ($ups, $func) = $0 =~ m/nutups2_(.*)_($fn_re)$/;
+# Called via base symlink without UPS/metric – nothing to do
+exit 0 unless defined $ups and defined $func;
+
 $ups =~ s/\./@/;  # ups.host.name => ups@host.name
 
 if ($ARGV[0] and $ARGV[0] eq 'config') {


### PR DESCRIPTION
The base 'nutups2_' symlink is invoked by munin-node without arguments to collect data, but it cannot extract a UPS name or metric.  Instead of dying with an error (and spamming the logs), simply exit 0.  'autoconf' and 'suggest' continue to work as their blocks are executed before this check.